### PR TITLE
feat: add user profile update endpoint with email verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ EVENT_POLLING_INTERVAL_MS=5000
 # CORS — frontend origin
 CORS_ORIGIN=http://localhost:5173
 
+# API Base URL (used for email verification links)
+API_BASE_URL=http://localhost:3000
+
 # IPFS (Pinata — for pinning proof documents)
 # Get your JWT at https://app.pinata.cloud/keys
 IPFS_GATEWAY_URL=https://gateway.pinata.cloud/ipfs

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,8 @@ model User {
   id               String    @id @default(uuid())
   stellarAddress   String    @unique
   email            String?   @unique
+  emailVerified    Boolean   @default(false)
+  pendingEmail     String?
   name             String?
   role             UserRole  @default(BUYER)
   createdAt        DateTime  @default(now())

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,4 +1,3 @@
-// auth.controller.ts
 import { Controller, Post, Get, Body, Query, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
@@ -31,5 +30,13 @@ export class AuthController {
   @ApiResponse({ status: 429, description: 'Too many requests - rate limit exceeded' })
   login(@Body() dto: LoginDto) {
     return this.authService.login(dto);
+  }
+
+  @Get('verify-email')
+  @ApiOperation({ summary: 'Verify email address via signed token' })
+  @ApiResponse({ status: 200, description: 'Email verified successfully' })
+  @ApiResponse({ status: 401, description: 'Invalid or expired token' })
+  async verifyEmail(@Query('token') token: string) {
+    return this.authService.verifyEmail(token);
   }
 }

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -5,6 +5,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
+import { UsersController } from './users.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
@@ -17,8 +19,9 @@ import { JwtStrategy } from './jwt.strategy';
         signOptions: { expiresIn: config.get<string>('JWT_EXPIRES_IN', '7d') },
       }),
     }),
+    NotificationsModule,
   ],
-  controllers: [AuthController],
+  controllers: [AuthController, UsersController],
   providers: [AuthService, JwtStrategy],
   exports: [AuthService],
 })

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,8 +1,11 @@
-import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
+import { Injectable, UnauthorizedException, ConflictException, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { RedisService } from '../../common/redis/redis.service';
 import { LoginDto } from './dto/login.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { NotificationsService } from '../notifications/notifications.service';
 
 /**
  * AuthService
@@ -29,6 +32,8 @@ export class AuthService {
     private readonly prisma: PrismaService,
     private readonly jwt: JwtService,
     private readonly redis: RedisService,
+    private readonly config: ConfigService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   // ----------------------------------------------------------
@@ -90,5 +95,113 @@ export class AuthService {
 
     this.logger.log(`User authenticated: ${stellarAddress}`);
     return { accessToken, user };
+  }
+
+  async getProfile(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        stellarAddress: true,
+        name: true,
+        email: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    return user;
+  }
+
+  async updateProfile(userId: string, dto: UpdateProfileDto) {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    const updateData: any = {};
+
+    if (dto.name !== undefined) {
+      updateData.name = dto.name;
+    }
+
+    if (dto.email !== undefined && dto.email !== user.email) {
+      const existing = await this.prisma.user.findUnique({
+        where: { email: dto.email },
+      });
+
+      if (existing && existing.id !== userId) {
+        throw new ConflictException('Email is already in use');
+      }
+
+      const token = this.jwt.sign(
+        { sub: userId, email: dto.email },
+        { expiresIn: '24h' },
+      );
+
+      const verificationLink = `${this.config.get('API_BASE_URL', 'http://localhost:3000')}/api/v1/auth/verify-email?token=${token}`;
+
+      await this.notifications.sendEmail(
+        dto.email,
+        'Verify your email address',
+        `Click this link to verify your email: ${verificationLink}`,
+      );
+
+      updateData.pendingEmail = dto.email;
+    }
+
+    if (Object.keys(updateData).length > 0) {
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: updateData,
+      });
+    }
+
+    return this.getProfile(userId);
+  }
+
+  async verifyEmail(token: string) {
+    let payload: { sub: string; email: string };
+    try {
+      payload = this.jwt.verify<{ sub: string; email: string }>(token);
+    } catch {
+      throw new UnauthorizedException('Invalid or expired verification token');
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { id: payload.sub },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    if (user.pendingEmail !== payload.email) {
+      throw new UnauthorizedException('Verification token does not match pending email');
+    }
+
+    const existing = await this.prisma.user.findUnique({
+      where: { email: payload.email },
+    });
+
+    if (existing && existing.id !== user.id) {
+      throw new ConflictException('Email is already in use');
+    }
+
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: {
+        email: payload.email,
+        emailVerified: true,
+        pendingEmail: null,
+      },
+    });
+
+    return { message: 'Email verified successfully' };
   }
 }

--- a/src/modules/auth/dto/update-profile.dto.ts
+++ b/src/modules/auth/dto/update-profile.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsString, IsEmail, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateProfileDto {
+  @ApiPropertyOptional({ example: 'John Doe', description: 'User display name' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @ApiPropertyOptional({ example: 'john@example.com', description: 'User email address' })
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+}

--- a/src/modules/auth/users.controller.ts
+++ b/src/modules/auth/users.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Patch, Body, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { AuthService } from './auth.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+
+@ApiTags('users')
+@Controller('users')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class UsersController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get the authenticated user profile' })
+  @ApiResponse({ status: 200, description: 'Returns user profile' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  getProfile(@CurrentUser() user: any) {
+    return this.authService.getProfile(user.id);
+  }
+
+  @Patch('me')
+  @ApiOperation({ summary: 'Update user profile (name, email)' })
+  @ApiResponse({ status: 200, description: 'Profile updated successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 409, description: 'Email already in use' })
+  updateProfile(@CurrentUser() user: any, @Body() dto: UpdateProfileDto) {
+    return this.authService.updateProfile(user.id, dto);
+  }
+}

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -106,7 +106,7 @@ export class NotificationsService {
     });
   }
 
-  private async sendEmail(to: string, subject: string, text: string) {
+  async sendEmail(to: string, subject: string, text: string) {
     try {
       await this.transporter.sendMail({
         from: this.config.get('EMAIL_FROM', 'noreply@chainsetttle.com'),


### PR DESCRIPTION
Closes #17

## Summary
Adds user profile management endpoints with email verification flow.

## Changes
- **Prisma schema**: Added `emailVerified` (Boolean, default false) and `pendingEmail` (String, nullable) to `User` model
- **GET /users/me**: Returns authenticated user profile (id, stellarAddress, name, email, role, createdAt). Protected by JwtAuthGuard.
- **PATCH /users/me**: Accepts `UpdateProfileDto` with optional `name` (string, max 100) and `email` (valid email, unique). If email changes, sends verification email with signed link. `role` is not updatable. Returns HTTP 409 on duplicate email.
- **GET /auth/verify-email?token=...**: Validates signed JWT token, promotes `pendingEmail` to `email`, sets `emailVerified: true`.
- **UpdateProfileDto**: Created in `src/modules/auth/dto/update-profile.dto.ts` with optional `name` and `email` fields.
- **NotificationsService**: Made `sendEmail` public for reuse by AuthService.

## Acceptance Criteria
- [x] GET /users/me returns the authenticated user's profile
- [x] PATCH /users/me updates name and initiates email verification flow for email changes
- [x] Duplicate email values return HTTP 409
- [x] GET /auth/verify-email confirms the new email and clears pendingEmail
- [x] role is not updated by PATCH /users/me even if provided in the request body