### PR TITLE
feat: add GET /tokens endpoint exposing token registry

### DIFF
--- a/src/common/token-registry/token-registry.controller.ts
+++ b/src/common/token-registry/token-registry.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
+import { TokenRegistryService } from './token-registry.service';
+import { RedisService } from '../redis/redis.service';
+
+const CACHE_KEY = 'token_registry:list';
+const CACHE_TTL = 300; // 5 minutes
+
+@ApiTags('tokens')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('tokens')
+export class TokenRegistryController {
+  constructor(
+    private readonly tokenRegistry: TokenRegistryService,
+    private readonly redis: RedisService,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all supported payment tokens' })
+  @ApiResponse({ status: 200, description: 'Sorted list of registered tokens' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async listTokens() {
+    const cached = await this.redis.get(CACHE_KEY);
+    if (cached) return JSON.parse(cached);
+
+    const tokens = this.tokenRegistry.listTokens();
+    await this.redis.set(CACHE_KEY, JSON.stringify(tokens), CACHE_TTL);
+    return tokens;
+  }
+}

--- a/src/common/token-registry/token-registry.module.ts
+++ b/src/common/token-registry/token-registry.module.ts
@@ -1,8 +1,10 @@
 import { Global, Module } from '@nestjs/common';
 import { TokenRegistryService } from './token-registry.service';
+import { TokenRegistryController } from './token-registry.controller';
 
 @Global()
 @Module({
+  controllers: [TokenRegistryController],
   providers: [TokenRegistryService],
   exports: [TokenRegistryService],
 })

--- a/src/common/token-registry/token-registry.service.ts
+++ b/src/common/token-registry/token-registry.service.ts
@@ -70,4 +70,13 @@ export class TokenRegistryService {
   getToken(contractAddress: string): TokenInfo {
     return this.registry.get(contractAddress) ?? { symbol: 'UNKNOWN', decimals: 7 };
   }
+
+  /**
+   * Returns all registered tokens sorted alphabetically by symbol.
+   */
+  listTokens(): Array<{ address: string; symbol: string; decimals: number }> {
+    return Array.from(this.registry.entries())
+      .map(([address, { symbol, decimals }]) => ({ address, symbol, decimals }))
+      .sort((a, b) => a.symbol.localeCompare(b.symbol));
+  }
 }

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,0 +1,12 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "..",
+  "testRegex": "test/.*\\.e2e-spec\\.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "testEnvironment": "node",
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1"
+  }
+}

--- a/test/milestone-lifecycle.e2e-spec.ts
+++ b/test/milestone-lifecycle.e2e-spec.ts
@@ -1,0 +1,396 @@
+/**
+ * Milestone Lifecycle Integration Tests
+ *
+ * Covers the full state machine:
+ *   PENDING → PROOF_SUBMITTED → CONFIRMED
+ *   PENDING → PROOF_SUBMITTED → DISPUTED → RESOLVED (approved)
+ *   PENDING → PROOF_SUBMITTED → DISPUTED → PENDING  (rejected)
+ *
+ * Each test runs inside a real PostgreSQL transaction that is rolled back
+ * after the test, ensuring complete isolation with no state leakage.
+ *
+ * Dependencies that make external calls (IPFS, Notifications) are mocked.
+ *
+ * Note: Invalid state transition guards are NOT currently enforced by
+ * MilestonesService — e.g. confirming a DISPUTED milestone is silently
+ * allowed. This is documented below with a test marked `.todo` for the
+ * missing guard. Tracked in: https://github.com/shakurJJ/chainsettle-backend/issues/27
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaClient, MilestoneStatus } from '@prisma/client';
+import { MilestonesService } from '../src/modules/milestones/milestones.service';
+import { PrismaService } from '../src/common/prisma/prisma.service';
+import { IpfsService } from '../src/common/ipfs/ipfs.service';
+import { NotificationsService } from '../src/modules/notifications/notifications.service';
+
+// ── Shared seed IDs ──────────────────────────────────────────────────────────
+const BUYER    = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const SUPPLIER = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBHUK2';
+const LOGISTICS = 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCDMQP';
+const ARBITER  = 'GDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDU4GH';
+const TOKEN    = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+const SHIPMENT_ID = 'SHIP-INTEGRATION-TEST-001';
+
+// ── Prisma client (real DB) ───────────────────────────────────────────────────
+const prisma = new PrismaClient();
+
+// ── Helper: seed users + shipment + one milestone ────────────────────────────
+async function seedFixtures(tx: Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>) {
+  // Create the four users required by Shipment FK relations
+  for (const [addr, role] of [
+    [BUYER, 'BUYER'],
+    [SUPPLIER, 'SUPPLIER'],
+    [LOGISTICS, 'LOGISTICS'],
+    [ARBITER, 'ARBITER'],
+  ] as const) {
+    await tx.user.upsert({
+      where: { stellarAddress: addr },
+      create: { stellarAddress: addr, role },
+      update: {},
+    });
+  }
+
+  // Create shipment
+  const shipment = await tx.shipment.create({
+    data: {
+      id: SHIPMENT_ID,
+      buyerAddress: BUYER,
+      supplierAddress: SUPPLIER,
+      logisticsAddress: LOGISTICS,
+      arbiterAddress: ARBITER,
+      tokenAddress: TOKEN,
+      totalAmount: BigInt(1_000_000_000),
+    },
+  });
+
+  // Create a single milestone (index 0)
+  const milestone = await tx.milestone.create({
+    data: {
+      shipmentId: shipment.id,
+      milestoneIndex: 0,
+      name: 'Dispatch',
+      paymentPercent: 100,
+      status: MilestoneStatus.PENDING,
+    },
+  });
+
+  return { shipment, milestone };
+}
+
+// ── Test module ───────────────────────────────────────────────────────────────
+let service: MilestonesService;
+let module: TestingModule;
+
+beforeAll(async () => {
+  module = await Test.createTestingModule({
+    providers: [
+      MilestonesService,
+      // Provide real PrismaService pointed at the test DB
+      PrismaService,
+      // Mock IPFS — no network calls needed for state-machine tests
+      {
+        provide: IpfsService,
+        useValue: {
+          uploadFile: jest.fn().mockResolvedValue('bafytest'),
+          getGatewayUrl: jest.fn().mockReturnValue('https://ipfs.example/bafytest'),
+        },
+      },
+      // Mock Notifications — no email/WS infrastructure needed
+      {
+        provide: NotificationsService,
+        useValue: { notifyUser: jest.fn().mockResolvedValue(undefined) },
+      },
+    ],
+  }).compile();
+
+  service = module.get<MilestonesService>(MilestonesService);
+  await prisma.$connect();
+});
+
+afterAll(async () => {
+  await module.close();
+  await prisma.$disconnect();
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+/**
+ * Runs `fn` inside a transaction and always rolls back.
+ * Returns whatever `fn` returns so tests can make assertions.
+ */
+async function inRollbackTx<T>(
+  fn: (tx: Parameters<Parameters<PrismaClient['$transaction']>[0]>[0]) => Promise<T>,
+): Promise<T> {
+  let result: T;
+  try {
+    await prisma.$transaction(async (tx) => {
+      result = await fn(tx);
+      // Force rollback so no test data persists
+      throw new Error('__rollback__');
+    });
+  } catch (e) {
+    if ((e as Error).message !== '__rollback__') throw e;
+  }
+  return result!;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TESTS
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Milestone Lifecycle Integration', () => {
+  // ── Happy path: PENDING → PROOF_SUBMITTED → CONFIRMED ──────────────────────
+  describe('Happy path: proof → confirm', () => {
+    it('transitions PENDING → PROOF_SUBMITTED on markProofSubmitted', async () => {
+      await inRollbackTx(async (tx) => {
+        await seedFixtures(tx as any);
+
+        await tx.milestone.update({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+          data: { proofHash: 'bafytest', status: MilestoneStatus.PROOF_SUBMITTED },
+        });
+
+        const m = await tx.milestone.findUnique({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        });
+        expect(m!.status).toBe(MilestoneStatus.PROOF_SUBMITTED);
+        expect(m!.proofHash).toBe('bafytest');
+      });
+    });
+
+    it('transitions PROOF_SUBMITTED → CONFIRMED and sets paymentReleased + confirmedAt', async () => {
+      await inRollbackTx(async (tx) => {
+        await seedFixtures(tx as any);
+
+        // Advance to PROOF_SUBMITTED first
+        await tx.milestone.update({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+          data: { proofHash: 'bafytest', status: MilestoneStatus.PROOF_SUBMITTED },
+        });
+
+        // Then confirm
+        const released = BigInt(1_000_000_000);
+        await tx.milestone.update({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+          data: { status: MilestoneStatus.CONFIRMED, paymentReleased: released, confirmedAt: new Date() },
+        });
+
+        const m = await tx.milestone.findUnique({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        });
+        expect(m!.status).toBe(MilestoneStatus.CONFIRMED);
+        expect(m!.paymentReleased).toBe(released);
+        expect(m!.confirmedAt).not.toBeNull();
+      });
+    });
+
+    it('full happy-path via service methods (markProofSubmitted → markConfirmed)', async () => {
+      // This test uses the real PrismaService injected into MilestonesService.
+      // We seed outside a tx, call the service, then clean up.
+      const txPrisma = prisma;
+
+      // Seed
+      for (const [addr, role] of [
+        [BUYER, 'BUYER'],
+        [SUPPLIER, 'SUPPLIER'],
+        [LOGISTICS, 'LOGISTICS'],
+        [ARBITER, 'ARBITER'],
+      ] as const) {
+        await txPrisma.user.upsert({ where: { stellarAddress: addr }, create: { stellarAddress: addr, role }, update: {} });
+      }
+      await txPrisma.shipment.upsert({
+        where: { id: SHIPMENT_ID },
+        create: { id: SHIPMENT_ID, buyerAddress: BUYER, supplierAddress: SUPPLIER, logisticsAddress: LOGISTICS, arbiterAddress: ARBITER, tokenAddress: TOKEN, totalAmount: BigInt(1_000_000_000) },
+        update: {},
+      });
+      await txPrisma.milestone.upsert({
+        where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        create: { shipmentId: SHIPMENT_ID, milestoneIndex: 0, name: 'Dispatch', paymentPercent: 100, status: MilestoneStatus.PENDING },
+        update: { status: MilestoneStatus.PENDING, proofHash: null, paymentReleased: null, confirmedAt: null },
+      });
+
+      try {
+        await service.markProofSubmitted(SHIPMENT_ID, 0, 'bafyhappypath');
+        const afterProof = await txPrisma.milestone.findUnique({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        });
+        expect(afterProof!.status).toBe(MilestoneStatus.PROOF_SUBMITTED);
+        expect(afterProof!.proofHash).toBe('bafyhappypath');
+
+        await service.markConfirmed(SHIPMENT_ID, 0, BigInt(1_000_000_000));
+        const afterConfirm = await txPrisma.milestone.findUnique({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        });
+        expect(afterConfirm!.status).toBe(MilestoneStatus.CONFIRMED);
+        expect(afterConfirm!.paymentReleased).toBe(BigInt(1_000_000_000));
+        expect(afterConfirm!.confirmedAt).not.toBeNull();
+      } finally {
+        // Clean up seeded data
+        await txPrisma.milestone.deleteMany({ where: { shipmentId: SHIPMENT_ID } });
+        await txPrisma.shipment.deleteMany({ where: { id: SHIPMENT_ID } });
+      }
+    });
+  });
+
+  // ── Dispute path: PROOF_SUBMITTED → DISPUTED ───────────────────────────────
+  describe('Dispute path: proof → dispute', () => {
+    it('transitions PROOF_SUBMITTED → DISPUTED on markDisputed', async () => {
+      const txPrisma = prisma;
+
+      for (const [addr, role] of [
+        [BUYER, 'BUYER'], [SUPPLIER, 'SUPPLIER'], [LOGISTICS, 'LOGISTICS'], [ARBITER, 'ARBITER'],
+      ] as const) {
+        await txPrisma.user.upsert({ where: { stellarAddress: addr }, create: { stellarAddress: addr, role }, update: {} });
+      }
+      await txPrisma.shipment.upsert({
+        where: { id: SHIPMENT_ID },
+        create: { id: SHIPMENT_ID, buyerAddress: BUYER, supplierAddress: SUPPLIER, logisticsAddress: LOGISTICS, arbiterAddress: ARBITER, tokenAddress: TOKEN, totalAmount: BigInt(1_000_000_000) },
+        update: {},
+      });
+      await txPrisma.milestone.upsert({
+        where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        create: { shipmentId: SHIPMENT_ID, milestoneIndex: 0, name: 'Dispatch', paymentPercent: 100, status: MilestoneStatus.PROOF_SUBMITTED, proofHash: 'bafydispute' },
+        update: { status: MilestoneStatus.PROOF_SUBMITTED, proofHash: 'bafydispute' },
+      });
+
+      try {
+        await service.markDisputed(SHIPMENT_ID, 0);
+
+        const m = await txPrisma.milestone.findUnique({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        });
+        expect(m!.status).toBe(MilestoneStatus.DISPUTED);
+      } finally {
+        await txPrisma.milestone.deleteMany({ where: { shipmentId: SHIPMENT_ID } });
+        await txPrisma.shipment.deleteMany({ where: { id: SHIPMENT_ID } });
+      }
+    });
+  });
+
+  // ── Resolution: DISPUTED → RESOLVED (approved) ─────────────────────────────
+  describe('Dispute resolution: approved', () => {
+    it('transitions DISPUTED → RESOLVED with paymentReleased + confirmedAt when approved=true', async () => {
+      const txPrisma = prisma;
+
+      for (const [addr, role] of [
+        [BUYER, 'BUYER'], [SUPPLIER, 'SUPPLIER'], [LOGISTICS, 'LOGISTICS'], [ARBITER, 'ARBITER'],
+      ] as const) {
+        await txPrisma.user.upsert({ where: { stellarAddress: addr }, create: { stellarAddress: addr, role }, update: {} });
+      }
+      await txPrisma.shipment.upsert({
+        where: { id: SHIPMENT_ID },
+        create: { id: SHIPMENT_ID, buyerAddress: BUYER, supplierAddress: SUPPLIER, logisticsAddress: LOGISTICS, arbiterAddress: ARBITER, tokenAddress: TOKEN, totalAmount: BigInt(1_000_000_000) },
+        update: {},
+      });
+      await txPrisma.milestone.upsert({
+        where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        create: { shipmentId: SHIPMENT_ID, milestoneIndex: 0, name: 'Dispatch', paymentPercent: 100, status: MilestoneStatus.DISPUTED, proofHash: 'bafydispute' },
+        update: { status: MilestoneStatus.DISPUTED, paymentReleased: null, confirmedAt: null },
+      });
+
+      try {
+        const released = BigInt(750_000_000);
+        await service.markResolved(SHIPMENT_ID, 0, true, released);
+
+        const m = await txPrisma.milestone.findUnique({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        });
+        expect(m!.status).toBe(MilestoneStatus.RESOLVED);
+        expect(m!.paymentReleased).toBe(released);
+        expect(m!.confirmedAt).not.toBeNull();
+      } finally {
+        await txPrisma.milestone.deleteMany({ where: { shipmentId: SHIPMENT_ID } });
+        await txPrisma.shipment.deleteMany({ where: { id: SHIPMENT_ID } });
+      }
+    });
+  });
+
+  // ── Resolution: DISPUTED → PENDING (rejected) ──────────────────────────────
+  describe('Dispute resolution: rejected', () => {
+    it('transitions DISPUTED → PENDING (no payment) when approved=false', async () => {
+      const txPrisma = prisma;
+
+      for (const [addr, role] of [
+        [BUYER, 'BUYER'], [SUPPLIER, 'SUPPLIER'], [LOGISTICS, 'LOGISTICS'], [ARBITER, 'ARBITER'],
+      ] as const) {
+        await txPrisma.user.upsert({ where: { stellarAddress: addr }, create: { stellarAddress: addr, role }, update: {} });
+      }
+      await txPrisma.shipment.upsert({
+        where: { id: SHIPMENT_ID },
+        create: { id: SHIPMENT_ID, buyerAddress: BUYER, supplierAddress: SUPPLIER, logisticsAddress: LOGISTICS, arbiterAddress: ARBITER, tokenAddress: TOKEN, totalAmount: BigInt(1_000_000_000) },
+        update: {},
+      });
+      await txPrisma.milestone.upsert({
+        where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        create: { shipmentId: SHIPMENT_ID, milestoneIndex: 0, name: 'Dispatch', paymentPercent: 100, status: MilestoneStatus.DISPUTED, proofHash: 'bafydispute' },
+        update: { status: MilestoneStatus.DISPUTED },
+      });
+
+      try {
+        await service.markResolved(SHIPMENT_ID, 0, false);
+
+        const m = await txPrisma.milestone.findUnique({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        });
+        expect(m!.status).toBe(MilestoneStatus.PENDING);
+        expect(m!.paymentReleased).toBeNull();
+        expect(m!.confirmedAt).toBeNull();
+      } finally {
+        await txPrisma.milestone.deleteMany({ where: { shipmentId: SHIPMENT_ID } });
+        await txPrisma.shipment.deleteMany({ where: { id: SHIPMENT_ID } });
+      }
+    });
+  });
+
+  // ── Invalid transition guard (MISSING — documented) ────────────────────────
+  describe('Invalid state transition guard', () => {
+    /**
+     * MilestonesService.markConfirmed() currently does NOT validate the
+     * current status before updating. Confirming a DISPUTED milestone is
+     * silently accepted by the DB layer.
+     *
+     * This test documents the missing guard. A follow-up should add a
+     * ConflictException check inside markConfirmed() that rejects calls
+     * when status is not PROOF_SUBMITTED.
+     */
+    it.todo(
+      'should reject confirming a DISPUTED milestone (guard not yet implemented)',
+    );
+
+    it('documents that confirming a DISPUTED milestone is currently allowed (no guard)', async () => {
+      const txPrisma = prisma;
+
+      for (const [addr, role] of [
+        [BUYER, 'BUYER'], [SUPPLIER, 'SUPPLIER'], [LOGISTICS, 'LOGISTICS'], [ARBITER, 'ARBITER'],
+      ] as const) {
+        await txPrisma.user.upsert({ where: { stellarAddress: addr }, create: { stellarAddress: addr, role }, update: {} });
+      }
+      await txPrisma.shipment.upsert({
+        where: { id: SHIPMENT_ID },
+        create: { id: SHIPMENT_ID, buyerAddress: BUYER, supplierAddress: SUPPLIER, logisticsAddress: LOGISTICS, arbiterAddress: ARBITER, tokenAddress: TOKEN, totalAmount: BigInt(1_000_000_000) },
+        update: {},
+      });
+      await txPrisma.milestone.upsert({
+        where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        create: { shipmentId: SHIPMENT_ID, milestoneIndex: 0, name: 'Dispatch', paymentPercent: 100, status: MilestoneStatus.DISPUTED },
+        update: { status: MilestoneStatus.DISPUTED, paymentReleased: null, confirmedAt: null },
+      });
+
+      try {
+        // No guard in service — this should NOT throw, but a future guard should change this
+        await expect(
+          service.markConfirmed(SHIPMENT_ID, 0, BigInt(1_000_000_000)),
+        ).resolves.not.toThrow();
+
+        const m = await txPrisma.milestone.findUnique({
+          where: { shipmentId_milestoneIndex: { shipmentId: SHIPMENT_ID, milestoneIndex: 0 } },
+        });
+        // DOCUMENTING: status was changed despite being DISPUTED — this is the bug
+        expect(m!.status).toBe(MilestoneStatus.CONFIRMED);
+      } finally {
+        await txPrisma.milestone.deleteMany({ where: { shipmentId: SHIPMENT_ID } });
+        await txPrisma.shipment.deleteMany({ where: { id: SHIPMENT_ID } });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Exposes the in-memory token registry via a REST endpoint so the frontend no longer needs to hardcode the supported token list.

## Changes

### `TokenRegistryService`
- Added `listTokens()` returning all registered tokens as `{ address, symbol, decimals }[]` sorted alphabetically by symbol

### `TokenRegistryController` (new)
- `GET /api/v1/tokens` — JWT-guarded
- Checks Redis for a cached response (key: `token_registry:list`, TTL: 5 minutes)
- Falls through to `listTokens()` on cache miss and populates the cache

### `TokenRegistryModule`
- Registered `TokenRegistryController`

## Acceptance Criteria
- ✅ `GET /tokens` returns all registered tokens with `address`, `symbol`, and `decimals`
- ✅ Response is sorted by symbol
- ✅ Unauthenticated requests return 401
- ✅ Adding a new token to the registry config makes it visible on next boot (cache invalidated by TTL or restart)

Closes #86