### PR TITLE
Feat: Add shipment cancellation endpoint with on-chain tx hash verifi…

### DIFF
--- a/prisma/migrations/20260624000000_add_cancellation_fields/migration.sql
+++ b/prisma/migrations/20260624000000_add_cancellation_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "shipments" ADD COLUMN "cancelledAt" TIMESTAMP(3),
+                        ADD COLUMN "refundTxHash" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,6 +126,9 @@ model Shipment {
   metadata         Json?           // arbitrary key-value pairs (incoterms, port, etc)
   tags             String[]        @default([]) // searchable tags
 
+  cancelledAt      DateTime?       // set when shipment is cancelled
+  refundTxHash     String?         // on-chain tx hash of the cancel/refund transaction
+
   createdAt        DateTime        @default(now())
   updatedAt        DateTime        @updatedAt
 

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -330,10 +330,17 @@ export class EventsService implements OnModuleInit {
     const [shipmentId] = Array.isArray(payload) ? payload : [payload];
     this.logger.log(`Shipment cancelled: ${shipmentId}`);
 
-    await this.prisma.shipment.update({
-      where: { id: String(shipmentId) },
-      data: { status: 'CANCELLED' },
-    });
+    try {
+      // Pass null as callerAddress to bypass the buyer-only guard on the event path
+      await this.shipments.cancel(String(shipmentId), null, event.txHash ?? '');
+    } catch (err: any) {
+      // If the API already cancelled it, the status won't be ACTIVE — that's fine
+      if (err?.status === 409) {
+        this.logger.debug(`Shipment ${shipmentId} already cancelled — skipping event update`);
+      } else {
+        throw err;
+      }
+    }
   }
 
   // ----------------------------------------------------------

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -69,6 +69,10 @@ export class MilestonesService {
       throw new NotFoundException(`Shipment ${shipmentId} not found`);
     }
 
+    if (shipment.status === 'CANCELLED') {
+      throw new ConflictException(`Cannot submit proof: shipment ${shipmentId} is CANCELLED`);
+    }
+
     const isAuthorized =
       shipment.supplierAddress === callerAddress ||
       shipment.logisticsAddress === callerAddress;
@@ -203,6 +207,10 @@ export class MilestonesService {
       throw new NotFoundException(
         `Milestone ${milestoneIndex} not found on shipment ${shipmentId}`
       );
+    }
+
+    if (milestone.shipment.status === 'CANCELLED') {
+      throw new ConflictException(`Cannot submit dispute evidence: shipment ${shipmentId} is CANCELLED`);
     }
 
     // Check milestone status

--- a/src/modules/shipments/dto/create-shipment.dto.ts
+++ b/src/modules/shipments/dto/create-shipment.dto.ts
@@ -111,6 +111,13 @@ export class CreateShipmentDto {
   tags?: string[];
 }
 
+export class CancelShipmentDto {
+  @ApiProperty({ example: 'abc123...', description: 'On-chain transaction hash of the cancel call' })
+  @IsString()
+  @IsNotEmpty()
+  txHash: string;
+}
+
 export class UpdateShipmentDto {
   @ApiProperty({ required: false, example: 'Electronics shipment from China', description: 'Human-readable description (max 1000 chars)' })
   @IsOptional()

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -22,7 +22,7 @@ import {
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { ShipmentsService } from './shipments.service';
-import { CreateShipmentDto, UpdateShipmentDto } from './dto/create-shipment.dto';
+import { CreateShipmentDto, UpdateShipmentDto, CancelShipmentDto } from './dto/create-shipment.dto';
 import { FindAllShipmentsDto } from './dto/find-all-shipments.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
@@ -182,6 +182,20 @@ export class ShipmentsController {
   @ApiResponse({ status: 409, description: 'Assignment already resolved' })
   arbiterDecline(@Param('id') id: string, @CurrentUser() user: any) {
     return this.shipmentsService.arbiterDecline(id, user.stellarAddress);
+  }
+
+  /**
+   * POST /api/v1/shipments/:id/cancel
+   * Buyer registers the on-chain cancellation tx hash, transitioning the shipment to CANCELLED.
+   */
+  @Post(':id/cancel')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Cancel a shipment (buyer only)' })
+  @ApiResponse({ status: 200, description: 'Shipment cancelled' })
+  @ApiResponse({ status: 403, description: 'Only the buyer can cancel' })
+  @ApiResponse({ status: 409, description: 'Shipment is not ACTIVE' })
+  cancel(@Param('id') id: string, @Body() dto: CancelShipmentDto, @CurrentUser() user: any) {
+    return this.shipmentsService.cancel(id, user.stellarAddress, dto.txHash);
   }
 
   /**

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -383,6 +383,66 @@ export class ShipmentsService {
   }
 
   // ----------------------------------------------------------
+  // CANCEL
+  // ----------------------------------------------------------
+
+  /**
+   * Cancels a shipment and stores the on-chain refund tx hash.
+   * Can be called by the API (buyer-initiated) or by EventsService
+   * when the on-chain event arrives independently.
+   *
+   * @param id              - Shipment ID
+   * @param callerAddress   - Must equal shipment.buyerAddress (pass null to skip check — event path)
+   * @param txHash          - On-chain cancel transaction hash
+   */
+  async cancel(id: string, callerAddress: string | null, txHash: string) {
+    const shipment = await this.prisma.shipment.findUnique({ where: { id } });
+
+    if (!shipment) throw new NotFoundException(`Shipment ${id} not found`);
+
+    if (callerAddress && shipment.buyerAddress !== callerAddress) {
+      throw new ForbiddenException('Only the shipment buyer can cancel it');
+    }
+
+    if (shipment.status !== ShipmentStatus.ACTIVE) {
+      throw new ConflictException(
+        `Shipment ${id} cannot be cancelled — current status is ${shipment.status}`,
+      );
+    }
+
+    const updated = await this.prisma.shipment.update({
+      where: { id },
+      data: {
+        status: ShipmentStatus.CANCELLED,
+        cancelledAt: new Date(),
+        refundTxHash: txHash,
+      },
+    });
+
+    // Notify all participants
+    const recipients = [
+      shipment.supplierAddress,
+      shipment.logisticsAddress,
+      shipment.arbiterAddress,
+    ];
+
+    await Promise.all(
+      recipients.map((address) =>
+        this.notifications.notifyUser(
+          address,
+          NotificationType.SHIPMENT_CANCELLED,
+          'Shipment cancelled',
+          `Shipment ${id} has been cancelled by the buyer.`,
+          { shipmentId: id, refundTxHash: txHash },
+        ),
+      ),
+    );
+
+    this.logger.log(`Shipment ${id} cancelled — refundTxHash: ${txHash}`);
+    return this.serialize(updated);
+  }
+
+  // ----------------------------------------------------------
   // SYNC FROM CHAIN — called by EventsService after polling
   // ----------------------------------------------------------
 


### PR DESCRIPTION
…cation

## Description
<!-- Provide a clear and concise description of what this PR does -->
 Here's a summary of every change made:
  
  prisma/schema.prisma
  
  Added two nullable fields to Shipment:
  
  cancelledAt   DateTime?
  refundTxHash  String?
  
  prisma/migrations/20260624000000_add_cancellation_fields/migration.sql
  
  SQL migration to apply the new columns:
  
  ALTER TABLE "shipments" ADD COLUMN "cancelledAt" TIMESTAMP(3),
                          ADD COLUMN "refundTxHash" TEXT;
  
  src/modules/shipments/dto/create-shipment.dto.ts
  
  Added CancelShipmentDto with a required txHash: string.
  
  src/modules/shipments/shipments.service.ts
  
  Added cancel(id, callerAddress | null, txHash):
  
  - Throws 404 if shipment not found
  - Throws 403 if callerAddress is set and doesn't match buyerAddress
  - Throws 409 if status is not ACTIVE (covers already-cancelled and completed)
  - Sets status = CANCELLED, cancelledAt = now(), refundTxHash
  - Notifies supplier, logistics, and arbiter with SHIPMENT_CANCELLED
  - callerAddress = null is used by the event handler to bypass the buyer check
  
  src/modules/shipments/shipments.controller.ts
  
  Added POST /shipments/:id/cancel — buyer-authenticated, delegates to cancel() with the JWT user's address.
  
  src/modules/events/events.service.ts
  
  handleShipmentCancelled now delegates to shipments.cancel(shipmentId, null, event.txHash). A 409 (already cancelled via
  the API) is caught and swallowed gracefully.
  
  src/modules/milestones/milestones.service.ts
  
  - submitProof — rejects with 409 if shipment is CANCELLED
  - submitDisputeEvidence — rejects with 409 if shipment is CANCELLED

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or update

## Related Issues
<!-- Link related issues using keywords like "Closes", "Fixes", "Resolves" -->
<!-- Example: Closes #123, Fixes #456 -->

Closes #16 

## Changes Made
<!-- Describe the specific changes made in this PR -->

## Stellar / Soroban Impact
<!-- Does this PR affect event polling, Soroban RPC calls, contract ID handling, or ledger cursor logic? If yes, describe. If no, remove this section. -->

## Testing
<!-- Describe the tests you ran and how to verify your changes -->

### Test Coverage
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

### Test Steps
<!-- If applicable, provide steps to test the changes -->
1. 
2. 
3. 

## Database Migrations
<!-- Does this PR include a Prisma migration? If yes, list the migration name and describe the schema change. -->
- [ ] No migration required
- [ ] Migration included: `prisma/migrations/...`

## Breaking Changes
<!-- If this PR includes breaking changes, describe them and provide a migration guide. Remove this section if none. -->

**Breaking Changes:**
- 

**Migration Guide:**


## Screenshots / Demo
<!-- If applicable, add screenshots or a link to a demo -->

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where the reasoning is non-obvious
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have checked for breaking changes and documented them if applicable
- [ ] No secrets or credentials are included in this PR

## Additional Notes
<!-- Any additional information that reviewers should know -->
