### PR TITLE
feat : Add dispute resolution escalation cron and and Add POST /shipm…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6544,6 +6544,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -159,6 +159,7 @@ model Milestone {
   confirmedAt        DateTime?
   dueAt              DateTime?       // optional deadline for milestone completion
   overdueNotifiedAt  DateTime?       // timestamp when overdue notification was sent (prevents re-notification)
+  disputeEscalatedAt DateTime?       // set when the dispute has been escalated to admins (prevents re-escalation)
   createdAt          DateTime        @default(now())
   updatedAt          DateTime        @updatedAt
 

--- a/src/common/prisma/prisma.service.ts
+++ b/src/common/prisma/prisma.service.ts
@@ -5,6 +5,20 @@ import { PrismaClient } from '@prisma/client';
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(PrismaService.name);
 
+  constructor() {
+    const isDev = process.env.NODE_ENV !== 'production';
+    super(isDev ? { log: [{ emit: 'event', level: 'query' }] } : {});
+
+    if (isDev) {
+      const threshold = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS ?? '100', 10);
+      (this as any).$on('query', (e: { duration: number; query: string }) => {
+        if (e.duration > threshold) {
+          this.logger.warn(`Slow query (${e.duration}ms): ${e.query}`);
+        }
+      });
+    }
+  }
+
   async onModuleInit() {
     await this.$connect();
     this.logger.log('Database connected');

--- a/src/modules/milestones/dispute-escalation.job.ts
+++ b/src/modules/milestones/dispute-escalation.job.ts
@@ -1,0 +1,108 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { MilestoneStatus, NotificationType, UserRole } from '@prisma/client';
+
+/**
+ * DisputeEscalationJob
+ *
+ * Runs hourly. For every milestone that has been in DISPUTED status for longer
+ * than DISPUTE_ESCALATION_DAYS (default 7) without being resolved, sends a
+ * SYSTEM_ALERT notification to every ADMIN user and sets disputeEscalatedAt to
+ * prevent repeated alerts.
+ */
+@Injectable()
+export class DisputeEscalationJob {
+  private readonly logger = new Logger(DisputeEscalationJob.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notifications: NotificationsService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async checkAndEscalateDisputes() {
+    try {
+      this.logger.log('Starting dispute escalation check...');
+
+      const days = parseInt(process.env.DISPUTE_ESCALATION_DAYS ?? '7', 10);
+      const threshold = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+      const overdue = await this.prisma.milestone.findMany({
+        where: {
+          status: MilestoneStatus.DISPUTED,
+          updatedAt: { lt: threshold },
+          disputeEscalatedAt: null,
+        },
+        include: {
+          shipment: {
+            select: { id: true, arbiterAddress: true },
+          },
+        },
+      });
+
+      if (overdue.length === 0) {
+        this.logger.log('No disputes require escalation');
+        return;
+      }
+
+      this.logger.log(`Found ${overdue.length} dispute(s) requiring escalation`);
+
+      const admins = await this.prisma.user.findMany({
+        where: { role: UserRole.ADMIN },
+        select: { stellarAddress: true },
+      });
+
+      if (admins.length === 0) {
+        this.logger.warn('No admin users found — disputes cannot be escalated');
+      }
+
+      for (const milestone of overdue) {
+        await this.escalate(milestone, admins, days);
+      }
+    } catch (error) {
+      this.logger.error('Dispute escalation check failed', error.message);
+    }
+  }
+
+  private async escalate(
+    milestone: any,
+    admins: { stellarAddress: string }[],
+    days: number,
+  ) {
+    try {
+      const { shipment, milestoneIndex, id } = milestone;
+
+      const title = `Unresolved dispute — shipment ${shipment.id} milestone ${milestoneIndex}`;
+      const message =
+        `Dispute on shipment ${shipment.id} milestone ${milestoneIndex} has been unresolved for over ${days} days. Arbiter: ${shipment.arbiterAddress}.`;
+
+      for (const admin of admins) {
+        await this.notifications.notifyUser(
+          admin.stellarAddress,
+          NotificationType.SYSTEM_ALERT,
+          title,
+          message,
+          {
+            shipmentId: shipment.id,
+            milestoneIndex,
+            arbiterAddress: shipment.arbiterAddress,
+          },
+        );
+      }
+
+      await this.prisma.milestone.update({
+        where: { id },
+        data: { disputeEscalatedAt: new Date() },
+      });
+
+      this.logger.log(`Escalated dispute: shipment ${shipment.id}[${milestoneIndex}]`);
+    } catch (error) {
+      this.logger.error(
+        `Failed to escalate dispute for milestone ${milestone.id}`,
+        error.message,
+      );
+    }
+  }
+}

--- a/src/modules/milestones/milestones.module.ts
+++ b/src/modules/milestones/milestones.module.ts
@@ -3,12 +3,13 @@ import { Module } from '@nestjs/common';
 import { MilestonesController } from './milestones.controller';
 import { MilestonesService } from './milestones.service';
 import { MilestoneDeadlineJob } from './milestone-deadline.job';
+import { DisputeEscalationJob } from './dispute-escalation.job';
 import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [NotificationsModule],
   controllers: [MilestonesController],
-  providers: [MilestonesService, MilestoneDeadlineJob],
+  providers: [MilestonesService, MilestoneDeadlineJob, DisputeEscalationJob],
   exports: [MilestonesService],
 })
 export class MilestonesModule {}

--- a/src/modules/shipments/dto/create-shipment.dto.ts
+++ b/src/modules/shipments/dto/create-shipment.dto.ts
@@ -2,6 +2,8 @@ import {
   IsString,
   IsNotEmpty,
   IsArray,
+  ArrayMinSize,
+  ArrayMaxSize,
   ValidateNested,
   IsInt,
   Min,
@@ -140,4 +142,26 @@ export class UpdateShipmentDto {
   @IsArray()
   @IsString({ each: true })
   tags?: string[];
+}
+
+export class BulkStatusDto {
+  @ApiProperty({ type: [String], example: ['SHIP-001', 'SHIP-002'], description: 'Shipment IDs to look up (1–50 items)' })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(50)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  ids: string[];
+}
+
+export class CloneShipmentDto {
+  @ApiProperty({ example: 'abc123...txhash', description: 'On-chain transaction hash for the new cloned shipment' })
+  @IsString()
+  @IsNotEmpty()
+  txHash: string;
+
+  @ApiProperty({ example: '1000000000', description: 'Total amount in stroops for the new shipment (7 decimal places)' })
+  @IsString()
+  @IsNotEmpty()
+  totalAmount: string;
 }

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -22,7 +22,7 @@ import {
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { ShipmentsService } from './shipments.service';
-import { CreateShipmentDto, UpdateShipmentDto } from './dto/create-shipment.dto';
+import { CreateShipmentDto, UpdateShipmentDto, CancelShipmentDto, CloneShipmentDto, BulkStatusDto } from './dto/create-shipment.dto';
 import { CreateTrackingDto } from './dto/tracking.dto';
 import { FindAllShipmentsDto } from './dto/find-all-shipments.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
@@ -133,6 +133,20 @@ export class ShipmentsController {
 
 
   /**
+   * POST /api/v1/shipments/bulk-status
+   * Returns a map of id → status for up to 50 shipment IDs in a single round trip.
+   * IDs the caller is not a participant of are silently omitted.
+   */
+  @Post('bulk-status')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get status for multiple shipments by ID (max 50)' })
+  @ApiResponse({ status: 200, description: 'Map of shipment id to status' })
+  bulkStatus(@Body() dto: BulkStatusDto, @CurrentUser() user: any) {
+    const isAdmin = user?.role === UserRole.ADMIN;
+    return this.shipmentsService.bulkStatus(dto.ids, user.stellarAddress, isAdmin);
+  }
+
+  /**
    * GET /api/v1/shipments/:id
    * Full shipment detail including milestones and recent on-chain events.
    */
@@ -183,6 +197,21 @@ export class ShipmentsController {
   @ApiResponse({ status: 409, description: 'Assignment already resolved' })
   arbiterDecline(@Param('id') id: string, @CurrentUser() user: any) {
     return this.shipmentsService.arbiterDecline(id, user.stellarAddress);
+  }
+
+  /**
+   * POST /api/v1/shipments/:id/clone
+   * Copies a shipment's structure into a new ACTIVE shipment with a fresh ID and reset milestones.
+   * Restricted to the original shipment's buyerAddress.
+   */
+  @Post(':id/clone')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Clone a shipment into a new active shipment (buyer only)' })
+  @ApiResponse({ status: 201, description: 'Cloned shipment created' })
+  @ApiResponse({ status: 403, description: 'Only the original buyer can clone' })
+  @ApiResponse({ status: 404, description: 'Source shipment not found' })
+  clone(@Param('id') id: string, @Body() dto: CloneShipmentDto, @CurrentUser() user: any) {
+    return this.shipmentsService.clone(id, user.stellarAddress, dto);
   }
 
   /**

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -10,10 +10,11 @@ import { PrismaService } from '../../common/prisma/prisma.service';
 import { StellarService } from '../../common/stellar/stellar.service';
 import { TokenRegistryService } from '../../common/token-registry/token-registry.service';
 import { NotificationsService } from '../notifications/notifications.service';
-import { CreateShipmentDto } from './dto/create-shipment.dto';
+import { CreateShipmentDto, CloneShipmentDto } from './dto/create-shipment.dto';
 import { CreateTrackingDto } from './dto/tracking.dto';
 import { ShipmentStatus, NotificationType, ArbiterStatus } from '@prisma/client';
 import { nativeToScVal } from '@stellar/stellar-sdk';
+import { randomUUID } from 'crypto';
 
 @Injectable()
 export class ShipmentsService {
@@ -251,6 +252,34 @@ export class ShipmentsService {
     return this.serialize(shipment);
   }
 
+  async bulkStatus(
+    ids: string[],
+    callerAddress: string,
+    isAdmin: boolean,
+  ): Promise<{ results: Record<string, ShipmentStatus> }> {
+    const where: any = { id: { in: ids } };
+
+    if (!isAdmin) {
+      where.OR = [
+        { buyerAddress: callerAddress },
+        { supplierAddress: callerAddress },
+        { logisticsAddress: callerAddress },
+        { arbiterAddress: callerAddress },
+      ];
+    }
+
+    const shipments = await this.prisma.shipment.findMany({
+      where,
+      select: { id: true, status: true },
+    });
+
+    const results: Record<string, ShipmentStatus> = {};
+    for (const s of shipments) {
+      results[s.id] = s.status;
+    }
+    return { results };
+  }
+
   /**
    * Update shipment metadata (description, referenceNumber, metadata, tags).
    * Only the buyer can update a shipment.
@@ -382,6 +411,65 @@ export class ShipmentsService {
 
     this.logger.log(`Arbiter ${callerAddress} declined assignment for shipment ${id}`);
     return this.serialize(updated);
+  }
+
+  // ----------------------------------------------------------
+  // CLONE — copy structure into a new ACTIVE shipment
+  // ----------------------------------------------------------
+
+  async clone(id: string, buyerAddress: string, dto: CloneShipmentDto) {
+    const source = await this.prisma.shipment.findUnique({
+      where: { id },
+      include: { milestones: { orderBy: { milestoneIndex: 'asc' } } },
+    });
+
+    if (!source) throw new NotFoundException(`Shipment ${id} not found`);
+
+    if (source.buyerAddress !== buyerAddress) {
+      throw new ForbiddenException('Only the original shipment buyer can clone it');
+    }
+
+    const token = this.tokenRegistry.getToken(source.tokenAddress);
+    const newId = randomUUID();
+
+    const cloned = await this.prisma.shipment.create({
+      data: {
+        id: newId,
+        buyerAddress: source.buyerAddress,
+        supplierAddress: source.supplierAddress,
+        logisticsAddress: source.logisticsAddress,
+        arbiterAddress: source.arbiterAddress,
+        tokenAddress: source.tokenAddress,
+        tokenDecimals: token.decimals,
+        tokenSymbol: token.symbol,
+        totalAmount: BigInt(dto.totalAmount),
+        txHash: dto.txHash,
+        description: source.description,
+        metadata: source.metadata ?? undefined,
+        tags: source.tags,
+        status: ShipmentStatus.ACTIVE,
+        arbiterStatus: ArbiterStatus.PENDING_ACCEPTANCE,
+        milestones: {
+          create: source.milestones.map((m, index) => ({
+            milestoneIndex: index,
+            name: m.name,
+            paymentPercent: m.paymentPercent,
+          })),
+        },
+      },
+      include: { milestones: true },
+    });
+
+    await this.notifications.notifyUser(
+      source.arbiterAddress,
+      NotificationType.ARBITER_INVITED,
+      'Arbiter assignment invitation',
+      `You have been assigned as arbiter for shipment ${cloned.id}. Please accept or decline this assignment.`,
+      { shipmentId: cloned.id, buyerAddress: source.buyerAddress, supplierAddress: source.supplierAddress },
+    );
+
+    this.logger.log(`Shipment ${id} cloned to ${cloned.id} by buyer ${buyerAddress}`);
+    return this.serialize(cloned);
   }
 
   // ----------------------------------------------------------


### PR DESCRIPTION
Add POST /shipments/:id/clone — duplicate a shipment structure for recurring trade relationships 
 closes #96

Add POST /shipments/bulk-status — query statuses for up to 50 shipment IDs in one request
  closes #97

Add Prisma query logging in development mode with configurable slow-query threshold
 closes #98

Add dispute resolution escalation cron — alert admins when arbiter is inactive for 7 days
 closes #99