### PR TITLE
Notification PATCH route, admin cursor/role endpoints, milestone confirm

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -232,6 +232,14 @@ model Notification {
   @@map("notifications")
 }
 
+model EventCursor {
+  id                  String   @id
+  lastProcessedLedger Int
+  updatedAt           DateTime @updatedAt
+
+  @@map("event_cursors")
+}
+
 model FailedEvent {
   id            String    @id @default(uuid())
   eventName     String

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
 import { UsersController } from './users.controller';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
       }),
     }),
     NotificationsModule,
+    AuditLogsModule,
   ],
   controllers: [AuthController, UsersController],
   providers: [AuthService, JwtStrategy],

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,12 +1,14 @@
-gimport { Injectable, UnauthorizedException, ConflictException, Logger } from '@nestjs/common';
+import { Injectable, UnauthorizedException, ConflictException, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { Keypair } from '@stellar/stellar-sdk';
+import { UserRole } from '@prisma/client';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { RedisService } from '../../common/redis/redis.service';
 import { LoginDto } from './dto/login.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { NotificationsService } from '../notifications/notifications.service';
+import { AuditLogService } from '../audit-logs/audit-log.service';
 
 
 
@@ -37,6 +39,7 @@ export class AuthService {
     private readonly redis: RedisService,
     private readonly config: ConfigService,
     private readonly notifications: NotificationsService,
+    private readonly auditLog: AuditLogService,
   ) { }
 
   // ----------------------------------------------------------
@@ -172,6 +175,33 @@ export class AuthService {
     }
 
     return this.getProfile(userId);
+  }
+
+  async updateUserRole(id: string, callerId: string, callerAddress: string, newRole: UserRole) {
+    const user = await this.prisma.user.findUnique({ where: { id } });
+
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    if (id === callerId && newRole !== UserRole.ADMIN) {
+      throw new ConflictException('Admins cannot demote themselves');
+    }
+
+    const oldRole = user.role;
+
+    await this.prisma.user.update({ where: { id }, data: { role: newRole } });
+
+    await this.auditLog.record({
+      actorId: callerId,
+      actorAddress: callerAddress,
+      action: 'USER_ROLE_CHANGED',
+      resourceType: 'User',
+      resourceId: id,
+      metadata: { from: oldRole, to: newRole },
+    });
+
+    return this.getProfile(id);
   }
 
   async verifyEmail(token: string) {

--- a/src/modules/auth/dto/update-user-role.dto.ts
+++ b/src/modules/auth/dto/update-user-role.dto.ts
@@ -1,0 +1,9 @@
+import { IsEnum } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { UserRole } from '@prisma/client';
+
+export class UpdateUserRoleDto {
+  @ApiProperty({ enum: UserRole, example: UserRole.ARBITER })
+  @IsEnum(UserRole)
+  role: UserRole;
+}

--- a/src/modules/auth/users.controller.ts
+++ b/src/modules/auth/users.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Patch, Body, UseGuards } from '@nestjs/common';
+import { Controller, Get, Patch, Param, Body, UseGuards, ForbiddenException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { UpdateUserRoleDto } from './dto/update-user-role.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 
@@ -27,5 +28,21 @@ export class UsersController {
   @ApiResponse({ status: 409, description: 'Email already in use' })
   updateProfile(@CurrentUser() user: any, @Body() dto: UpdateProfileDto) {
     return this.authService.updateProfile(user.id, dto);
+  }
+
+  @Patch('admin/:id/role')
+  @ApiOperation({ summary: "[Admin] Change a user's role" })
+  @ApiResponse({ status: 200, description: 'Updated user profile' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiResponse({ status: 409, description: 'Admins cannot demote themselves' })
+  updateRole(
+    @Param('id') id: string,
+    @CurrentUser() user: any,
+    @Body() dto: UpdateUserRoleDto,
+  ) {
+    if (user?.role !== 'ADMIN') {
+      throw new ForbiddenException('Admin access required');
+    }
+    return this.authService.updateUserRole(id, user.id, user.stellarAddress, dto.role);
   }
 }

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -51,6 +51,13 @@ export class EventsController {
     return this.eventsService.getAdminFailedEvents(page, limit);
   }
 
+  @Get('admin/cursor')
+  @ApiOperation({ summary: '[Admin] Inspect event poller cursor lag and health' })
+  getCursorStatus(@CurrentUser() user: any) {
+    this.requireAdmin(user);
+    return this.eventsService.getCursorStatus();
+  }
+
   @Post('admin/failed-events/:id/retry')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '[Admin] Manually retry a failed event by ID' })

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -237,6 +237,24 @@ export class EventsService implements OnModuleInit {
       ? payload
       : [payload, 0, 0];
 
+    // The buyer may have already registered this confirmation via
+    // POST /shipments/:id/milestones/:index/confirm — skip to avoid
+    // double-notifying the supplier once the on-chain event arrives.
+    const existing = await this.prisma.milestone.findUnique({
+      where: {
+        shipmentId_milestoneIndex: {
+          shipmentId: String(shipmentId),
+          milestoneIndex: Number(milestoneIndex),
+        },
+      },
+    });
+    if (existing?.status === 'CONFIRMED') {
+      this.logger.debug(
+        `Milestone ${shipmentId}[${milestoneIndex}] already confirmed — skipping duplicate event`,
+      );
+      return;
+    }
+
     this.logger.log(
       `Milestone confirmed: ${shipmentId}[${milestoneIndex}] — ${paymentAmount} released`,
     );
@@ -484,6 +502,25 @@ export class EventsService implements OnModuleInit {
         limit,
         totalPages: Math.ceil(total / limit)
       } 
+    };
+  }
+
+  /**
+   * Admin diagnostics: compares the in-memory cursor against the
+   * DB-persisted one and the live chain tip to surface poller lag.
+   */
+  async getCursorStatus() {
+    const persisted = await this.prisma.eventCursor.findUnique({ where: { id: 'main' } });
+    const chainTip = await this.stellar.getLatestLedger();
+    const lag = chainTip - this.lastProcessedLedger;
+
+    return {
+      inMemoryLedger: this.lastProcessedLedger,
+      persistedLedger: persisted?.lastProcessedLedger ?? null,
+      chainTip,
+      lag,
+      updatedAt: persisted?.updatedAt ?? null,
+      healthy: lag <= 100,
     };
   }
 

--- a/src/modules/milestones/dto/confirm-milestone.dto.ts
+++ b/src/modules/milestones/dto/confirm-milestone.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ConfirmMilestoneDto {
+  @ApiProperty({ description: 'On-chain transaction hash of the confirm_milestone call' })
+  @IsString()
+  @IsNotEmpty()
+  txHash: string;
+
+  @ApiProperty({ example: '1000000000', description: 'Amount released to the supplier, in stroops' })
+  @IsString()
+  @IsNotEmpty()
+  paymentReleased: string;
+}

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Post,
   Param,
+  Body,
   ParseIntPipe,
   UseGuards,
   UseInterceptors,
@@ -22,6 +23,7 @@ import {
 } from '@nestjs/swagger';
 import { memoryStorage } from 'multer';
 import { MilestonesService } from './milestones.service';
+import { ConfirmMilestoneDto } from './dto/confirm-milestone.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 
@@ -152,6 +154,39 @@ export class MilestonesController {
       index,
       callerAddress,
       file,
+    );
+  }
+
+  /**
+   * POST /api/v1/shipments/:shipmentId/milestones/:index/confirm
+   *
+   * Buyer registers a milestone confirmation transaction hash after
+   * signing it in Freighter. Restricted to the shipment's buyerAddress.
+   */
+  @Post(':index/confirm')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Confirm a milestone from the buyer wallet',
+    description:
+      "Registers the confirm_milestone transaction hash signed in Freighter. Only the shipment's buyerAddress may call this endpoint.",
+  })
+  @ApiResponse({ status: 200, description: 'Milestone confirmed' })
+  @ApiResponse({ status: 403, description: 'Caller is not the buyer' })
+  @ApiResponse({ status: 409, description: 'Milestone is not in PROOF_SUBMITTED status' })
+  confirmMilestone(
+    @Param('shipmentId') shipmentId: string,
+    @Param('index', ParseIntPipe) index: number,
+    @CurrentUser() user: any,
+    @Body() dto: ConfirmMilestoneDto,
+  ) {
+    const callerAddress: string = user?.stellarAddress ?? user?.sub;
+
+    return this.milestonesService.confirmFromApi(
+      shipmentId,
+      index,
+      callerAddress,
+      dto.txHash,
+      dto.paymentReleased,
     );
   }
 }

--- a/src/modules/milestones/milestones.module.ts
+++ b/src/modules/milestones/milestones.module.ts
@@ -5,9 +5,10 @@ import { MilestonesService } from './milestones.service';
 import { MilestoneDeadlineJob } from './milestone-deadline.job';
 import { DisputeEscalationJob } from './dispute-escalation.job';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { ShipmentsModule } from '../shipments/shipments.module';
 
 @Module({
-  imports: [NotificationsModule],
+  imports: [NotificationsModule, ShipmentsModule],
   controllers: [MilestonesController],
   providers: [MilestonesService, MilestoneDeadlineJob, DisputeEscalationJob],
   exports: [MilestonesService],

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -9,6 +9,7 @@ import {
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { IpfsService } from '../../common/ipfs/ipfs.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { ShipmentsService } from '../shipments/shipments.service';
 import { MilestoneStatus, NotificationType, DisputeRole, ArbiterStatus } from '@prisma/client';
 
 @Injectable()
@@ -19,6 +20,7 @@ export class MilestonesService {
     private readonly prisma: PrismaService,
     private readonly ipfs: IpfsService,
     private readonly notifications: NotificationsService,
+    private readonly shipments: ShipmentsService,
   ) {}
 
   async findByShipment(shipmentId: string) {
@@ -114,6 +116,55 @@ export class MilestonesService {
       cid,
       gatewayUrl: this.ipfs.getGatewayUrl(cid),
     };
+  }
+
+  /**
+   * Buyer registers a milestone confirmation transaction hash after signing
+   * it in Freighter. Mirrors the on-chain `handleMilestoneConfirmed` event
+   * handler so the DB reflects the confirmation immediately.
+   *
+   * Restricted to the shipment's buyerAddress.
+   */
+  async confirmFromApi(
+    shipmentId: string,
+    milestoneIndex: number,
+    callerAddress: string,
+    txHash: string,
+    paymentReleased: string,
+  ) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    }
+
+    if (shipment.buyerAddress !== callerAddress) {
+      throw new ForbiddenException('Only the shipment buyer may confirm milestones');
+    }
+
+    const milestone = await this.findOne(shipmentId, milestoneIndex);
+
+    if (milestone.status !== MilestoneStatus.PROOF_SUBMITTED) {
+      throw new ConflictException(
+        `Milestone ${milestoneIndex} must be in PROOF_SUBMITTED status to confirm (currently ${milestone.status})`,
+      );
+    }
+
+    const updated = await this.markConfirmed(shipmentId, milestoneIndex, BigInt(paymentReleased));
+
+    await this.shipments.syncStatusFromChain(shipmentId);
+
+    await this.notifications.notifyUser(
+      shipment.supplierAddress,
+      NotificationType.PAYMENT_RELEASED,
+      'Payment released',
+      `Payment has been released for milestone ${milestoneIndex} on shipment ${shipmentId}. Tx: ${txHash}`,
+      { shipmentId, milestoneIndex, paymentReleased, txHash },
+    );
+
+    return updated;
   }
 
   // ----------------------------------------------------------

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Patch, Put, Param, Query, Body, UseGuards } from '@nestjs/common';
+import { Controller, Get, Patch, Param, Query, Body, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { NotificationsService } from './notifications.service';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
@@ -44,7 +44,7 @@ export class NotificationsController {
     return this.notificationsService.getOrCreatePreferences(userId);
   }
 
-  @Put('preferences')
+  @Patch('preferences')
   @ApiOperation({ summary: 'Update notification preferences (partial merge)' })
   updatePreferences(@CurrentUser('id') userId: string, @Body() dto: UpdatePreferencesDto) {
     return this.notificationsService.updatePreferences(userId, dto);


### PR DESCRIPTION
## Summary
- Closes #131 — `PATCH /notifications/preferences` (route verb fixed from PUT to PATCH to match spec; GET/service logic already existed and matched all acceptance criteria).
- Closes #127 — `GET /admin/events/cursor` exposing `EventsService.getCursorStatus()` (in-memory ledger, DB-persisted ledger, chain tip, lag, health). Also adds the `EventCursor` Prisma model, which had a migration creating the table but was missing from `schema.prisma`.
- Closes #118 — `PATCH /admin/users/:id/role` with `AuthService.updateUserRole()`, audit log entry (`USER_ROLE_CHANGED`, before/after metadata), and a 409 guard preventing admins from demoting themselves.
- Closes #120 — `POST /shipments/:id/milestones/:index/confirm` with `MilestonesService.confirmFromApi()`. Requires `PROOF_SUBMITTED` status (409 otherwise), restricted to the shipment's buyer (403 otherwise), syncs shipment status from chain, and notifies the supplier. Added a guard in the on-chain `handleMilestoneConfirmed` handler so an already-confirmed milestone doesn't get double-notified when the on-chain event later arrives.

## Test plan
- [ ] `npm install && npx prisma generate && npx prisma migrate deploy`
- [ ] `PATCH /notifications/preferences` with partial body merges without resetting other types; `GET /notifications/preferences` returns full map
- [ ] `GET /admin/events/cursor` as non-admin returns 403; as admin returns the lag/health payload
- [ ] `PATCH /admin/users/:id/role` as non-admin returns 403; admin demoting self returns 409; valid change returns updated profile and writes an audit log row
- [ ] `POST /shipments/:id/milestones/:index/confirm` as non-buyer returns 403; on a PENDING/CONFIRMED milestone returns 409; on PROOF_SUBMITTED confirms and notifies supplier exactly once even after the on-chain event later fires