### PR TITLE
feat: rebalance milestones, stream events, IPFS proxy, cursor pagination

### DIFF
--- a/src/common/ipfs/ipfs.controller.ts
+++ b/src/common/ipfs/ipfs.controller.ts
@@ -1,0 +1,39 @@
+import {
+  Controller,
+  Get,
+  Param,
+  UseGuards,
+  BadRequestException,
+  Res,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import { IpfsService } from './ipfs.service';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
+
+const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;
+
+@ApiTags('ipfs')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('ipfs')
+export class IpfsController {
+  constructor(private readonly ipfs: IpfsService) {}
+
+  @Get(':cid')
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
+  @ApiOperation({ summary: 'Proxy-fetch a file from IPFS by CID (JWT-guarded)' })
+  @ApiResponse({ status: 200, description: 'File content with correct Content-Type' })
+  @ApiResponse({ status: 400, description: 'Invalid CID format' })
+  @ApiResponse({ status: 429, description: 'Rate limit exceeded (20 req/min per user)' })
+  async getFile(@Param('cid') cid: string, @Res() res: Response) {
+    if (!CID_REGEX.test(cid)) {
+      throw new BadRequestException(`Invalid CID format: ${cid}`);
+    }
+
+    const { buffer, mimeType } = await this.ipfs.getFile(cid);
+    res.setHeader('Content-Type', mimeType);
+    res.end(buffer);
+  }
+}

--- a/src/common/ipfs/ipfs.module.ts
+++ b/src/common/ipfs/ipfs.module.ts
@@ -1,10 +1,12 @@
 import { Module, Global } from '@nestjs/common';
 import { IpfsService } from './ipfs.service';
+import { IpfsController } from './ipfs.controller';
 import { RedisModule } from '../redis/redis.module';
 
 @Global()
 @Module({
   imports: [RedisModule],
+  controllers: [IpfsController],
   providers: [IpfsService],
   exports: [IpfsService],
 })

--- a/src/common/ipfs/ipfs.service.ts
+++ b/src/common/ipfs/ipfs.service.ts
@@ -154,18 +154,18 @@ export class IpfsService implements OnModuleInit {
   }
 
   /**
-   * Fetches a file from IPFS by CID and returns its buffer.
+   * Fetches a file from IPFS by CID and returns its buffer and MIME type.
    *
    * @param cid - IPFS CID of the file
-   * @returns File buffer
+   * @returns { buffer, mimeType }
    * @throws InternalServerErrorException on fetch failure
    */
-  async getFile(cid: string): Promise<Buffer> {
+  async getFile(cid: string): Promise<{ buffer: Buffer; mimeType: string }> {
     if (!this.apiKey) {
       this.logger.warn(
         'IPFS_API_KEY not configured — returning empty buffer for development',
       );
-      return Buffer.alloc(0);
+      return { buffer: Buffer.alloc(0), mimeType: 'application/octet-stream' };
     }
 
     try {
@@ -175,7 +175,12 @@ export class IpfsService implements OnModuleInit {
       });
 
       this.logger.log(`File fetched from IPFS: ${cid}`);
-      return Buffer.from(response.data);
+      return {
+        buffer: Buffer.from(response.data),
+        mimeType:
+          (response.headers['content-type'] as string | undefined) ??
+          'application/octet-stream',
+      };
     } catch (error) {
       const detail = error.response?.data?.error?.details ?? error.message;
       this.logger.error(`Failed to fetch file from IPFS`, detail);

--- a/src/common/stellar/stellar.service.ts
+++ b/src/common/stellar/stellar.service.ts
@@ -225,3 +225,50 @@ export class StellarService implements OnModuleInit {
       return null;
     }
   }
+
+  // ----------------------------------------------------------
+  // STREAMING SUBSCRIPTION
+  // ----------------------------------------------------------
+
+  /**
+   * Subscribes to contract events using a tight polling loop (1-second interval)
+   * that approximates real-time streaming from the Soroban RPC.
+   *
+   * @param startLedger - Ledger to begin scanning from
+   * @param onEvent     - Called for each new event in order
+   * @param onError     - Called when the loop encounters an RPC error
+   * @returns           - Unsubscribe function; call it to stop the loop
+   */
+  subscribeToContractEvents(
+    startLedger: number,
+    onEvent: (event: SorobanRpc.Api.EventResponse) => Promise<void>,
+    onError: (error: Error) => void,
+  ): () => void {
+    let active = true;
+    let currentLedger = startLedger;
+
+    const loop = async () => {
+      while (active) {
+        try {
+          const events = await this.fetchContractEvents(currentLedger);
+          for (const event of events) {
+            if (!active) return;
+            await onEvent(event);
+            currentLedger = Math.max(currentLedger, event.ledger + 1);
+          }
+          await new Promise<void>((resolve) => setTimeout(resolve, 1_000));
+        } catch (err) {
+          if (active) {
+            onError(err as Error);
+          }
+          return;
+        }
+      }
+    };
+
+    void loop();
+    return () => {
+      active = false;
+    };
+  }
+}

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -27,8 +27,10 @@ const MAX_ATTEMPTS = 5;
 @Injectable()
 export class EventsService implements OnModuleInit {
   private readonly logger = new Logger(EventsService.name);
-  /** In-memory mirror of the DB cursor — updated after each successful tick. */
+  /** In-memory mirror of the DB cursor — updated after each processed event. */
   private lastProcessedLedger: number = 0;
+  private unsubscribeFn: (() => void) | null = null;
+  private reconnectBackoffMs = 0;
 
   constructor(
     private readonly prisma: PrismaService,
@@ -71,7 +73,6 @@ export class EventsService implements OnModuleInit {
       this.logger.warn(
         `Could not initialise event cursor from DB: ${error.message} — will retry on first poll`,
       );
-      // Fall back to the Stellar chain tip so we don't replay the entire history
       try {
         const latest = await this.stellar.getLatestLedger();
         this.lastProcessedLedger = Math.max(1, latest - 10);
@@ -79,31 +80,63 @@ export class EventsService implements OnModuleInit {
         this.lastProcessedLedger = 1;
       }
     }
+
+    this.startStreamSubscription();
   }
 
   // ----------------------------------------------------------
-  // CRON JOB — runs every 5 seconds
+  // STREAMING SUBSCRIPTION
   // ----------------------------------------------------------
 
-  @Cron(CronExpression.EVERY_5_SECONDS)
-  async pollEvents() {
-    try {
-      const events = await this.stellar.fetchContractEvents(this.lastProcessedLedger);
-      if (events.length === 0) return;
+  private startStreamSubscription(): void {
+    if (this.unsubscribeFn) {
+      this.unsubscribeFn();
+      this.unsubscribeFn = null;
+    }
 
-      this.logger.log(`Processing ${events.length} new chain event(s)`);
+    this.logger.log(
+      `Starting event stream from ledger ${this.lastProcessedLedger}`,
+    );
 
-      for (const event of events) {
+    this.unsubscribeFn = this.stellar.subscribeToContractEvents(
+      this.lastProcessedLedger,
+      async (event) => {
+        this.reconnectBackoffMs = 0;
         try {
           await this.processEvent(event);
         } catch (error) {
           this.metrics.incrementEventsFailed();
           await this.saveToDlq(event, error as Error);
         }
-        this.lastProcessedLedger = Math.max(this.lastProcessedLedger, event.ledger + 1);
-      }
-    } catch (error) {
-      this.logger.error('Event polling failed', (error as Error).message);
+        this.lastProcessedLedger = Math.max(
+          this.lastProcessedLedger,
+          event.ledger + 1,
+        );
+        await this.persistCursor(this.lastProcessedLedger);
+      },
+      (error) => {
+        this.logger.error('Event stream disconnected', error.message);
+        this.reconnectBackoffMs =
+          this.reconnectBackoffMs === 0
+            ? 5_000
+            : Math.min(this.reconnectBackoffMs * 2, 60_000);
+        this.logger.log(
+          `Reconnecting stream in ${this.reconnectBackoffMs / 1_000}s`,
+        );
+        setTimeout(() => this.startStreamSubscription(), this.reconnectBackoffMs);
+      },
+    );
+  }
+
+  private async persistCursor(ledger: number): Promise<void> {
+    try {
+      await this.prisma.eventCursor.upsert({
+        where: { id: 'main' },
+        create: { id: 'main', lastProcessedLedger: ledger },
+        update: { lastProcessedLedger: ledger },
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to persist event cursor: ${(err as Error).message}`);
     }
   }
 

--- a/src/modules/milestones/dto/rebalance-milestones.dto.ts
+++ b/src/modules/milestones/dto/rebalance-milestones.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsArray, IsInt, IsNumber, Max, Min, ValidateNested } from 'class-validator';
+
+export class MilestonePercentDto {
+  @ApiProperty({ description: 'Zero-based milestone index' })
+  @IsInt()
+  @Min(0)
+  milestoneIndex: number;
+
+  @ApiProperty({ description: 'New payment percentage (0–100)' })
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  paymentPercent: number;
+}
+
+export class RebalanceMilestonesDto {
+  @ApiProperty({ type: [MilestonePercentDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MilestonePercentDto)
+  milestones: MilestonePercentDto[];
+}

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -14,6 +14,7 @@ import {
   Res,
   NotFoundException,
 } from '@nestjs/common';
+
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiTags,
@@ -27,6 +28,7 @@ import { memoryStorage } from 'multer';
 import { Response } from 'express';
 import { MilestonesService } from './milestones.service';
 import { ConfirmMilestoneDto } from './dto/confirm-milestone.dto';
+import { RebalanceMilestonesDto } from './dto/rebalance-milestones.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { ShipmentParticipantGuard } from '../shipments/guards/shipment-participant.guard';
@@ -159,6 +161,29 @@ export class MilestonesController {
       callerAddress,
       file,
     );
+  }
+
+  /**
+   * POST /api/v1/shipments/:shipmentId/milestones/rebalance
+   *
+   * Atomically redistributes payment percentages across PENDING milestones.
+   * Restricted to the shipment's buyerAddress.
+   */
+  @Post('rebalance')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Rebalance payment percentages across PENDING milestones (buyer only)' })
+  @ApiResponse({ status: 200, description: 'All milestones after rebalance' })
+  @ApiResponse({ status: 400, description: 'Percentages do not sum to 100' })
+  @ApiResponse({ status: 403, description: 'Only the buyer may rebalance' })
+  @ApiResponse({ status: 404, description: 'Shipment or milestone not found' })
+  @ApiResponse({ status: 409, description: 'A target milestone is not PENDING' })
+  rebalance(
+    @Param('shipmentId') shipmentId: string,
+    @Body() dto: RebalanceMilestonesDto,
+    @CurrentUser() user: any,
+  ) {
+    const callerAddress: string = user?.stellarAddress ?? user?.sub;
+    return this.milestonesService.rebalance(shipmentId, callerAddress, dto.milestones);
   }
 
   /**

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -1,10 +1,11 @@
 // milestones.service.ts
-import { 
-  Injectable, 
-  NotFoundException, 
-  Logger, 
-  ForbiddenException, 
-  ConflictException 
+import {
+  Injectable,
+  NotFoundException,
+  Logger,
+  ForbiddenException,
+  ConflictException,
+  BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { IpfsService } from '../../common/ipfs/ipfs.service';
@@ -450,12 +451,89 @@ export class MilestonesService {
       throw new NotFoundException('Evidence not found or no file attached');
     }
 
-    const fileBuffer = await this.ipfs.getFile(evidence.ipfsCid);
+    const { buffer: fileBuffer } = await this.ipfs.getFile(evidence.ipfsCid);
 
     return {
       fileBuffer,
       fileName: evidence.fileName || 'download',
       mimeType: evidence.mimeType || 'application/octet-stream',
     };
+  }
+
+  // ----------------------------------------------------------
+  // REBALANCE — atomically redistribute payment percentages
+  // ----------------------------------------------------------
+
+  async rebalance(
+    shipmentId: string,
+    callerAddress: string,
+    updates: Array<{ milestoneIndex: number; paymentPercent: number }>,
+  ) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    }
+
+    if (shipment.buyerAddress !== callerAddress) {
+      throw new ForbiddenException('Only the shipment buyer may rebalance milestones');
+    }
+
+    const allMilestones = await this.prisma.milestone.findMany({
+      where: { shipmentId },
+      orderBy: { milestoneIndex: 'asc' },
+    });
+
+    const milestoneMap = new Map(allMilestones.map((m) => [m.milestoneIndex, m]));
+
+    for (const update of updates) {
+      const milestone = milestoneMap.get(update.milestoneIndex);
+      if (!milestone) {
+        throw new NotFoundException(
+          `Milestone ${update.milestoneIndex} not found on shipment ${shipmentId}`,
+        );
+      }
+      if (milestone.status !== MilestoneStatus.PENDING) {
+        throw new ConflictException(
+          `Milestone ${update.milestoneIndex} is not PENDING (status: ${milestone.status})`,
+        );
+      }
+    }
+
+    const updateMap = new Map(updates.map((u) => [u.milestoneIndex, u.paymentPercent]));
+    const totalPercent = allMilestones.reduce(
+      (sum, m) =>
+        sum +
+        (updateMap.has(m.milestoneIndex)
+          ? updateMap.get(m.milestoneIndex)!
+          : m.paymentPercent),
+      0,
+    );
+
+    if (totalPercent !== 100) {
+      throw new BadRequestException(
+        `Rebalanced percentages must sum to 100. Got ${totalPercent}.`,
+      );
+    }
+
+    await this.prisma.$transaction(
+      updates.map((u) =>
+        this.prisma.milestone.update({
+          where: {
+            shipmentId_milestoneIndex: { shipmentId, milestoneIndex: u.milestoneIndex },
+          },
+          data: { paymentPercent: u.paymentPercent },
+        }),
+      ),
+    );
+
+    this.logger.log(`Milestones rebalanced for ${shipmentId} by buyer ${callerAddress}`);
+
+    return this.prisma.milestone.findMany({
+      where: { shipmentId },
+      orderBy: { milestoneIndex: 'asc' },
+    });
   }
 }

--- a/src/modules/shipments/dto/find-all-shipments.dto.ts
+++ b/src/modules/shipments/dto/find-all-shipments.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsISO8601, IsInt, IsOptional, IsString, Min } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsISO8601, IsOptional, IsString } from 'class-validator';
 import { ShipmentStatus } from '@prisma/client';
 
 export class FindAllShipmentsDto {
@@ -19,36 +19,7 @@ export class FindAllShipmentsDto {
   @IsString()
   status?: ShipmentStatus;
 
-  @ApiPropertyOptional({ description: 'Filter by reference number' })
-  @IsOptional()
-  @IsString()
-  referenceNumber?: string;
-
-  @ApiPropertyOptional({ description: 'Comma-separated list of tags to filter by' })
-  @IsOptional()
-  @IsString()
-  tags?: string;
-
-  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  page?: number;
-
-  @ApiPropertyOptional({ description: 'Results per page', default: 20 })
-  @IsOptional()
-  @Type(() => Number)
-  @IsInt()
-  @Min(1)
-  limit?: number;
-
-  @ApiPropertyOptional({ description: 'Search in description (full-text search)' })
-  @IsOptional()
-  @IsString()
-  search?: string;
-
-  @ApiPropertyOptional({ description: 'Filter by reference number (exact prefix match)' })
+  @ApiPropertyOptional({ description: 'Filter by reference number (exact match)' })
   @IsOptional()
   @IsString()
   referenceNumber?: string;
@@ -58,7 +29,7 @@ export class FindAllShipmentsDto {
   @IsString()
   tags?: string;
 
-  @ApiPropertyOptional({ description: 'Page number (default: 1)' })
+  @ApiPropertyOptional({ description: 'Page number (1-based, default: 1)' })
   @IsOptional()
   @IsString()
   page?: string;
@@ -68,26 +39,38 @@ export class FindAllShipmentsDto {
   @IsString()
   limit?: string;
 
-  // New Date Filters
-  @ApiPropertyOptional({ 
-    description: 'Filter shipments created on or after this ISO date', 
-    example: '2026-01-01T00:00:00.000Z' 
+  @ApiPropertyOptional({
+    description:
+      'Opaque base64 cursor for forward pagination. Mutually exclusive with page.',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({ description: 'Search in description (full-text search)' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter shipments created on or after this ISO date',
+    example: '2026-01-01T00:00:00.000Z',
   })
   @IsOptional()
   @IsISO8601()
   createdAfter?: string;
 
-  @ApiPropertyOptional({ 
-    description: 'Filter shipments created on or before this ISO date', 
-    example: '2026-03-31T23:59:59.999Z' 
+  @ApiPropertyOptional({
+    description: 'Filter shipments created on or before this ISO date',
+    example: '2026-03-31T23:59:59.999Z',
   })
   @IsOptional()
   @IsISO8601()
   createdBefore?: string;
 
-  @ApiPropertyOptional({ 
-    description: 'Filter shipments updated on or after this ISO date', 
-    example: '2026-01-01T00:00:00.000Z' 
+  @ApiPropertyOptional({
+    description: 'Filter shipments updated on or after this ISO date',
+    example: '2026-01-01T00:00:00.000Z',
   })
   @IsOptional()
   @IsISO8601()
@@ -95,7 +78,7 @@ export class FindAllShipmentsDto {
 
   @ApiPropertyOptional({
     description: 'Filter shipments updated on or before this ISO date',
-    example: '2026-03-31T23:59:59.999Z'
+    example: '2026-03-31T23:59:59.999Z',
   })
   @IsOptional()
   @IsISO8601()

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -64,7 +64,10 @@ export class ShipmentsController {
   @ApiOperation({ summary: 'List shipments with chronological filters and pagination' })
   @ApiResponse({ status: 200, description: 'Filtered list of shipments' })
   findAll(@CurrentUser() user: any, @Query() query: FindAllShipmentsDto) {
-    // 1. Cross-field Date Validations
+    if (query.cursor && query.page) {
+      throw new BadRequestException('cursor and page are mutually exclusive');
+    }
+
     if (query.createdAfter && query.createdBefore && new Date(query.createdAfter) > new Date(query.createdBefore)) {
       throw new BadRequestException('createdAfter date cannot be further in the future than createdBefore date');
     }
@@ -73,13 +76,9 @@ export class ShipmentsController {
       throw new BadRequestException('updatedAfter date cannot be further in the future than updatedBefore date');
     }
 
-    // 2. Evaluate administrative scope constraints
     const isAdmin = user?.role === UserRole.ADMIN;
-    
-    // Parse tag array structures safely from string formats
     const tags = query.tags ? query.tags.split(',').map((t) => t.trim()).filter(Boolean) : undefined;
 
-    // 3. Delegate execution context payload down to service layers
     return this.shipmentsService.findAll({
       buyerAddress: isAdmin ? query.buyerAddress : undefined,
       supplierAddress: isAdmin ? query.supplierAddress : undefined,
@@ -88,6 +87,7 @@ export class ShipmentsController {
       tags,
       page: query.page ? parseInt(query.page) : undefined,
       limit: query.limit ? parseInt(query.limit) : undefined,
+      cursor: query.cursor,
       createdAfter: query.createdAfter,
       createdBefore: query.createdBefore,
       updatedAfter: query.updatedAfter,

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -174,12 +174,14 @@ export class ShipmentsService {
     tags?: string[];
     page?: number;
     limit?: number;
+    cursor?: string;
     createdAfter?: string;
     createdBefore?: string;
     updatedAfter?: string;
     updatedBefore?: string;
     callerStellarAddress?: string;
     isAdmin?: boolean;
+    includeArchived?: boolean;
     search?: string;
   }) {
     const {
@@ -190,6 +192,7 @@ export class ShipmentsService {
       tags,
       page = 1,
       limit = 20,
+      cursor,
       createdAfter,
       createdBefore,
       updatedAfter,
@@ -199,6 +202,10 @@ export class ShipmentsService {
       includeArchived = false,
       search,
     } = filters;
+
+    if (cursor && page && page !== 1) {
+      throw new BadRequestException('cursor and page are mutually exclusive');
+    }
 
     const where: any = {};
 
@@ -242,25 +249,28 @@ export class ShipmentsService {
       });
     }
 
-    let shipments, total;
+    let shipments: any[];
+    let total: number | null = null;
+    let nextCursor: string | null = null;
 
     if (search) {
-      const searchWhere = { ...where };
-      delete searchWhere.AND;
-      const participantCondition = !isAdmin && callerStellarAddress ? 
-        `AND (buyer_address = $1 OR supplier_address = $1 OR logistics_address = $1 OR arbiter_address = $1)` : '';
-      const participantParams = !isAdmin && callerStellarAddress ? [callerStellarAddress] : [];
-      
+      const participantCondition =
+        !isAdmin && callerStellarAddress
+          ? `AND (buyer_address = $1 OR supplier_address = $1 OR logistics_address = $1 OR arbiter_address = $1)`
+          : '';
+      const participantParams =
+        !isAdmin && callerStellarAddress ? [callerStellarAddress] : [];
+
       const query = `
-        SELECT * FROM shipments 
+        SELECT * FROM shipments
         WHERE description_search @@ plainto_tsquery('english', $2)
         ${participantCondition}
         ORDER BY created_at DESC
         LIMIT $3 OFFSET $4
       `;
-      
+
       const countQuery = `
-        SELECT COUNT(*) FROM shipments 
+        SELECT COUNT(*) FROM shipments
         WHERE description_search @@ plainto_tsquery('english', $2)
         ${participantCondition}
       `;
@@ -270,15 +280,48 @@ export class ShipmentsService {
         ...participantParams,
         search,
         limit,
-        (page - 1) * limit
+        (page - 1) * limit,
       );
 
       const countResult = await this.prisma.$queryRawUnsafe(
         countQuery,
         ...participantParams,
-        search
+        search,
       );
-      total = Number(countResult[0].count);
+      total = Number((countResult as any[])[0].count);
+
+      for (const s of shipments) {
+        s.milestones = await this.prisma.milestone.findMany({
+          where: { shipmentId: s.id },
+          orderBy: { milestoneIndex: 'asc' },
+        });
+      }
+    } else if (cursor) {
+      let decoded: { createdAt: string; id: string };
+      try {
+        decoded = JSON.parse(Buffer.from(cursor, 'base64').toString('utf-8'));
+      } catch {
+        throw new BadRequestException('Invalid cursor format');
+      }
+
+      shipments = await this.prisma.shipment.findMany({
+        where: { ...where, createdAt: { lte: new Date(decoded.createdAt) } },
+        include: { milestones: { orderBy: { milestoneIndex: 'asc' } } },
+        orderBy: { createdAt: 'desc' },
+        cursor: { id: decoded.id },
+        skip: 1,
+        take: limit,
+      });
+
+      nextCursor =
+        shipments.length === limit
+          ? Buffer.from(
+              JSON.stringify({
+                createdAt: shipments[shipments.length - 1].createdAt.toISOString(),
+                id: shipments[shipments.length - 1].id,
+              }),
+            ).toString('base64')
+          : null;
     } else {
       [shipments, total] = await this.prisma.$transaction([
         this.prisma.shipment.findMany({
@@ -292,18 +335,17 @@ export class ShipmentsService {
       ]);
     }
 
-    if (search) {
-      for (const s of shipments) {
-        s.milestones = await this.prisma.milestone.findMany({
-          where: { shipmentId: s.id },
-          orderBy: { milestoneIndex: 'asc' },
-        });
-      }
-    }
-
     return {
       data: shipments.map((s) => this.serialize(s)),
-      meta: { total, page, limit, totalPages: Math.ceil(total / limit) },
+      meta: cursor
+        ? { nextCursor, limit }
+        : {
+            total,
+            page,
+            limit,
+            totalPages: total !== null ? Math.ceil(total / limit) : null,
+            nextCursor: null,
+          },
     };
   }
 


### PR DESCRIPTION
## Summary

- **closes #102** — `POST /shipments/:id/milestones/rebalance`: atomically redistributes `paymentPercent` across PENDING milestones. Buyer-only; validates all indexes exist and are PENDING; rejects if proposed total ≠ 100; applied via `prisma.$transaction`.

- **closes #101** — Replace `@Cron(EVERY_5_SECONDS)` polling with `StellarService.subscribeToContractEvents` (1-second tight loop). Events are processed in `onModuleInit`; cursor persisted to DB after each event; reconnects with exponential backoff (5 s → 60 s max) on stream error. `retryFailedEvents` cron unchanged.

- **closes #91** — `GET /ipfs/:cid`: JWT-guarded IPFS proxy. Validates CIDv0 (`^Qm[1-9A-HJ-NP-Za-km-z]{44}$`) / CIDv1 base32 format (400 on mismatch); rate-limited to 20 req/min per user (429 on breach); streams response with `Content-Type` from gateway. `IpfsService.getFile` now returns `{ buffer, mimeType }`.

- **closes #92** — Optional `cursor` query param on `GET /shipments`. Encodes `{ createdAt, id }` as opaque base64 JSON; decoded into Prisma `cursor` + `skip: 1` query; `meta.nextCursor` included on all responses (null for offset mode); `cursor + page` together returns 400. Duplicate DTO fields cleaned up.

## Test plan

- [ ] `POST /shipments/:id/milestones/rebalance` with valid PENDING milestones summing to 100 → 200 with updated list
- [ ] Same endpoint with a non-PENDING milestone → 409
- [ ] Same endpoint with percents summing to ≠ 100 → 400
- [ ] Same endpoint called by non-buyer → 403
- [ ] Event stream: verify events arrive within ~1 s of ledger close; kill RPC and confirm reconnect log with backoff
- [ ] `GET /ipfs/Qm...` (valid CID) → 200 with correct Content-Type
- [ ] `GET /ipfs/invalid` → 400
- [ ] 21st request in 60 s window → 429
- [ ] `GET /shipments?cursor=<base64>` → next page after cursor position
- [ ] `meta.nextCursor` is null on last page
- [ ] `GET /shipments?cursor=x&page=2` → 400