### PR TITLE
feat: payment time series, admin users list, single evidence fetch, Handlebars email templates

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,6 +4,7 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
+    "assets": [{ "include": "**/*.hbs", "watchAssets": true }],
     "plugins": ["@nestjs/swagger"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "class-validator": "^0.14.0",
     "compression": "^1.8.1",
     "form-data": "^4.0.5",
+    "handlebars": "^4.7.9",
     "helmet": "^7.1.0",
     "ioredis": "^5.11.0",
     "ipfs-http-client": "^60.0.1",

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -213,6 +213,49 @@ export class AuthService {
     return this.getProfile(id);
   }
 
+  async findAllUsers(filters: {
+    role?: UserRole;
+    emailVerified?: boolean;
+    page?: number;
+    limit?: number;
+    orderBy?: 'createdAt' | 'name';
+  }) {
+    const { role, emailVerified, page = 1, limit = 20, orderBy = 'createdAt' } = filters;
+
+    const where: any = {};
+    if (role !== undefined) where.role = role;
+    if (emailVerified !== undefined) where.emailVerified = emailVerified;
+
+    const [users, total] = await this.prisma.$transaction([
+      this.prisma.user.findMany({
+        where,
+        select: {
+          id: true,
+          stellarAddress: true,
+          email: true,
+          emailVerified: true,
+          name: true,
+          role: true,
+          createdAt: true,
+        },
+        orderBy: orderBy === 'name' ? { name: 'asc' } : { createdAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.user.count({ where }),
+    ]);
+
+    return {
+      data: users,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
   async verifyEmail(token: string) {
     let payload: { sub: string; email: string };
     try {

--- a/src/modules/auth/users.controller.ts
+++ b/src/modules/auth/users.controller.ts
@@ -1,10 +1,22 @@
-import { Controller, Get, Patch, Param, Body, UseGuards, ForbiddenException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Patch,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { UserRole } from '@prisma/client';
 import { AuthService } from './auth.service';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { UpdateUserRoleDto } from './dto/update-user-role.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { Roles } from '../../common/decorators/roles.decorator';
 
 @ApiTags('users')
 @Controller('users')
@@ -30,6 +42,41 @@ export class UsersController {
     return this.authService.updateProfile(user.id, dto);
   }
 
+  /**
+   * GET /api/v1/admin/users
+   * Paginated user list with role and email verification filters.
+   * Restricted to ADMIN role.
+   */
+  @Get('admin/users')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: '[Admin] List platform users with role and email verification filters' })
+  @ApiResponse({ status: 200, description: 'Paginated user list' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiQuery({ name: 'role', required: false, enum: UserRole })
+  @ApiQuery({ name: 'emailVerified', required: false, type: Boolean })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'orderBy', required: false, enum: ['createdAt', 'name'] })
+  findAllUsers(
+    @CurrentUser() user: any,
+    @Query('role') role?: UserRole,
+    @Query('emailVerified') emailVerified?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('orderBy') orderBy?: 'createdAt' | 'name',
+  ) {
+    if (user?.role !== UserRole.ADMIN) {
+      throw new ForbiddenException('Admin access required');
+    }
+    return this.authService.findAllUsers({
+      role,
+      emailVerified: emailVerified !== undefined ? emailVerified === 'true' : undefined,
+      page: page ? parseInt(page, 10) : undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
+      orderBy,
+    });
+  }
+
   @Get(':stellarAddress')
   @ApiOperation({ summary: 'Get public profile by Stellar address' })
   @ApiResponse({ status: 200, description: 'Returns public profile' })
@@ -40,6 +87,8 @@ export class UsersController {
       throw new BadRequestException('Invalid Stellar address format');
     }
     return this.authService.getPublicProfile(stellarAddress);
+  }
+
   @Patch('admin/:id/role')
   @ApiOperation({ summary: "[Admin] Change a user's role" })
   @ApiResponse({ status: 200, description: 'Updated user profile' })

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -188,6 +188,27 @@ export class MilestonesController {
   }
 
   /**
+   * GET /api/v1/shipments/:shipmentId/milestones/:index/evidence/:evidenceId
+   * Fetch a single dispute evidence record by ID.
+   * Includes the IPFS gateway URL when an ipfsCid is present.
+   */
+  @Get(':index/evidence/:evidenceId')
+  @ApiOperation({ summary: 'Fetch a single dispute evidence record by ID' })
+  @ApiResponse({ status: 200, description: 'Evidence record with ipfsUrl populated' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  @ApiResponse({ status: 404, description: 'Evidence not found or wrong shipment/milestone combination' })
+  async getOneEvidence(
+    @Param('shipmentId') shipmentId: string,
+    @Param('index', ParseIntPipe) index: number,
+    @Param('evidenceId') evidenceId: string,
+    @CurrentUser() user: any,
+  ) {
+    const callerAddress: string = user?.stellarAddress ?? user?.sub;
+    const isAdmin: boolean = user?.role === 'ADMIN';
+    return this.milestonesService.getOneEvidence(shipmentId, index, evidenceId, callerAddress, isAdmin);
+  }
+
+  /**
    * GET /api/v1/shipments/:shipmentId/milestones/:index/evidence/:evidenceId/download
    * Download a dispute evidence file through the backend proxy.
    */

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -424,6 +424,68 @@ export class MilestonesService {
   }
 
   /**
+   * Fetch a single dispute evidence record by ID.
+   * Verifies the evidence belongs to the correct milestone.
+   * Accessible by shipment participants or admins.
+   */
+  async getOneEvidence(
+    shipmentId: string,
+    milestoneIndex: number,
+    evidenceId: string,
+    requestedBy: string,
+    isAdmin: boolean,
+  ) {
+    const milestone = await this.prisma.milestone.findUnique({
+      where: { shipmentId_milestoneIndex: { shipmentId, milestoneIndex } },
+      include: { shipment: true },
+    });
+
+    if (!milestone) {
+      throw new NotFoundException(
+        `Milestone ${milestoneIndex} not found on shipment ${shipmentId}`,
+      );
+    }
+
+    if (!isAdmin) {
+      const isParticipant = [
+        milestone.shipment.buyerAddress,
+        milestone.shipment.supplierAddress,
+        milestone.shipment.logisticsAddress,
+        milestone.shipment.arbiterAddress,
+      ].includes(requestedBy);
+
+      if (!isParticipant) {
+        throw new ForbiddenException(
+          'Only shipment participants can view dispute evidence',
+        );
+      }
+    }
+
+    const evidence = await this.prisma.disputeEvidence.findFirst({
+      where: { id: evidenceId, milestoneId: milestone.id },
+      include: {
+        user: {
+          select: {
+            stellarAddress: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    if (!evidence) {
+      throw new NotFoundException(
+        `Evidence ${evidenceId} not found or belongs to a different milestone`,
+      );
+    }
+
+    return {
+      ...evidence,
+      ipfsUrl: evidence.ipfsCid ? this.ipfs.getGatewayUrl(evidence.ipfsCid) : null,
+    };
+  }
+
+  /**
    * Download a dispute evidence file through the backend proxy
    */
   async downloadEvidence(

--- a/src/modules/notifications/notifications.service.spec.ts
+++ b/src/modules/notifications/notifications.service.spec.ts
@@ -114,7 +114,14 @@ describe('NotificationsService — preferences', () => {
 
       await service.notifyUser('GABC', NotificationType.PROOF_SUBMITTED, 'title', 'msg');
 
-      expect(sendEmailSpy).toHaveBeenCalledWith('user@example.com', 'title', 'msg');
+      expect(sendEmailSpy).toHaveBeenCalledWith(
+        'user@example.com',
+        'title',
+        'msg',
+        undefined,
+        NotificationType.PROOF_SUBMITTED,
+        undefined,
+      );
     });
   });
 

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as nodemailer from 'nodemailer';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as Handlebars from 'handlebars';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { NotificationType } from '@prisma/client';
 import { NotificationsGateway } from './notifications.gateway';
@@ -70,7 +73,7 @@ export class NotificationsService {
       });
 
       if (emailEnabled && user.email) {
-        await this.sendEmail(user.email, title, message);
+        await this.sendEmail(user.email, title, message, undefined, type, data);
         await this.prisma.notification.update({
           where: { id: notification.id },
           data: { emailSent: true },
@@ -179,14 +182,44 @@ export class NotificationsService {
     return { subject: `Daily digest — ${unread.length} unread notification(s)`, html };
   }
 
-  async sendEmail(to: string, subject: string, text: string, html?: string) {
+  /**
+   * Loads and renders a Handlebars template for the given notification type.
+   * Returns null when no template file exists for that type (triggers plain-text fallback).
+   */
+  private renderTemplate(type: NotificationType, data: Record<string, any>): string | null {
+    const templatePath = path.join(__dirname, 'templates', `${type}.hbs`);
+    if (!fs.existsSync(templatePath)) {
+      return null;
+    }
     try {
+      const source = fs.readFileSync(templatePath, 'utf-8');
+      const template = Handlebars.compile(source);
+      return template(data ?? {});
+    } catch (error) {
+      this.logger.error(`Failed to render template for ${type}`, error.message);
+      return null;
+    }
+  }
+
+  async sendEmail(
+    to: string,
+    subject: string,
+    text: string,
+    html?: string,
+    type?: NotificationType,
+    data?: Record<string, any>,
+  ) {
+    try {
+      let renderedHtml = html;
+      if (!renderedHtml && type) {
+        renderedHtml = this.renderTemplate(type, data ?? {}) ?? undefined;
+      }
       await this.transporter.sendMail({
         from: this.config.get('EMAIL_FROM', 'noreply@chainsetttle.com'),
         to,
         subject: `ChainSettle — ${subject}`,
         text,
-        html: html ?? `
+        html: renderedHtml ?? `
           <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
             <h2 style="color: #1a1a2e;">ChainSettle</h2>
             <p>${text}</p>

--- a/src/modules/notifications/templates/DISPUTE_RAISED.hbs
+++ b/src/modules/notifications/templates/DISPUTE_RAISED.hbs
@@ -1,0 +1,14 @@
+<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+  <h2 style="color: #1a1a2e;">ChainSettle — Dispute Raised</h2>
+  <p>A dispute has been raised for milestone <strong>{{milestoneIndex}}</strong> on shipment <strong>{{shipmentId}}</strong>.</p>
+  <p>Please submit your evidence promptly so the arbiter can review the case.</p>
+  {{#if evidenceUrl}}
+  <p>
+    <a href="{{evidenceUrl}}" style="display:inline-block;background:#1a1a2e;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px;">
+      Submit Evidence
+    </a>
+  </p>
+  {{/if}}
+  <hr />
+  <small style="color: #888;">You're receiving this because you're a participant on ChainSettle.</small>
+</div>

--- a/src/modules/notifications/templates/PAYMENT_RELEASED.hbs
+++ b/src/modules/notifications/templates/PAYMENT_RELEASED.hbs
@@ -1,0 +1,14 @@
+<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+  <h2 style="color: #1a1a2e;">ChainSettle — Payment Released</h2>
+  <p>A payment of <strong>{{amount}} {{tokenSymbol}}</strong> has been released for milestone <strong>{{milestoneIndex}}</strong> on shipment <strong>{{shipmentId}}</strong>.</p>
+  {{#if txHash}}
+  <p>Transaction: <code>{{txHash}}</code></p>
+  {{/if}}
+  <p>
+    <a href="#" style="display:inline-block;background:#1a1a2e;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px;">
+      View Shipment
+    </a>
+  </p>
+  <hr />
+  <small style="color: #888;">You're receiving this because you're a participant on ChainSettle.</small>
+</div>

--- a/src/modules/notifications/templates/PROOF_SUBMITTED.hbs
+++ b/src/modules/notifications/templates/PROOF_SUBMITTED.hbs
@@ -1,0 +1,14 @@
+<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+  <h2 style="color: #1a1a2e;">ChainSettle — Proof Submitted</h2>
+  <p>A proof has been submitted for milestone <strong>{{milestoneName}}</strong> on shipment <strong>{{shipmentId}}</strong>.</p>
+  {{#if ipfsUrl}}
+  <p>
+    <a href="{{ipfsUrl}}" style="display:inline-block;background:#1a1a2e;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px;">
+      View Proof on IPFS
+    </a>
+  </p>
+  {{/if}}
+  <p>Please review and confirm or dispute the submitted proof.</p>
+  <hr />
+  <small style="color: #888;">You're receiving this because you're a participant on ChainSettle.</small>
+</div>

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -331,6 +331,21 @@ export class ShipmentsController {
     return this.shipmentsService.createTracking(id, user.stellarAddress, dto);
   }
 
+  /**
+   * GET /api/v1/shipments/:id/value-released-over-time
+   * Returns a cumulative payment release time series for dashboard charts.
+   * Protected by ShipmentParticipantGuard.
+   */
+  @Get(':id/value-released-over-time')
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'Get cumulative payment release time series for charting' })
+  @ApiResponse({ status: 200, description: 'Payment release time series with summary' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  @ApiResponse({ status: 404, description: 'Shipment not found' })
+  getPaymentTimeSeries(@Param('id') id: string) {
+    return this.shipmentsService.getPaymentTimeSeries(id);
+  }
+
     /**
      * GET /api/v1/shipments/:id/tracking
      * Get all tracking updates for a shipment in chronological order.

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -1097,6 +1097,71 @@ export class ShipmentsService {
   }
 
   // ----------------------------------------------------------
+  // VALUE RELEASED OVER TIME — time series for charting
+  // ----------------------------------------------------------
+
+  async getPaymentTimeSeries(id: string) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id },
+      select: {
+        totalAmount: true,
+        tokenDecimals: true,
+        tokenSymbol: true,
+      },
+    });
+    if (!shipment) throw new NotFoundException(`Shipment ${id} not found`);
+
+    const milestones = await this.prisma.milestone.findMany({
+      where: {
+        shipmentId: id,
+        status: { in: ['CONFIRMED', 'RESOLVED'] as any },
+        confirmedAt: { not: null },
+      },
+      orderBy: { confirmedAt: 'asc' },
+    });
+
+    const decimals: number = shipment.tokenDecimals ?? 7;
+    const totalAmount: bigint = shipment.totalAmount ?? 0n;
+
+    let cumulative = 0n;
+    const entries = milestones.map((m) => {
+      const amount: bigint = m.paymentReleased ?? 0n;
+      cumulative += amount;
+      const percentComplete =
+        totalAmount > 0n
+          ? Math.round(Number((cumulative * 10000n) / totalAmount)) / 100
+          : 0;
+
+      return {
+        milestoneIndex: m.milestoneIndex,
+        name: m.name,
+        releasedAt: m.confirmedAt!.toISOString(),
+        amount: this.stellar.toHumanAmount(amount, decimals),
+        cumulativeReleased: this.stellar.toHumanAmount(cumulative, decimals),
+        percentComplete,
+      };
+    });
+
+    const percentComplete =
+      totalAmount > 0n
+        ? Math.round(Number((cumulative * 10000n) / totalAmount)) / 100
+        : 0;
+
+    return {
+      entries,
+      summary: {
+        totalReleased: this.stellar.toHumanAmount(cumulative, decimals),
+        totalAmount: this.stellar.toHumanAmount(totalAmount, decimals),
+        percentComplete,
+        remainingAmount: this.stellar.toHumanAmount(
+          totalAmount > cumulative ? totalAmount - cumulative : 0n,
+          decimals,
+        ),
+      },
+    };
+  }
+
+  // ----------------------------------------------------------
   // INTERNAL HELPERS
   // ----------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- closes #114
- closes #119
- closes #121
- closes #123

### #114 — GET /shipments/:id/value-released-over-time
- Added `ShipmentsService.getPaymentTimeSeries(id)` querying all `CONFIRMED` and `RESOLVED` milestones ordered by `confirmedAt` ascending.
- Each entry contains `milestoneIndex`, `name`, `releasedAt`, `amount` (formatted), `cumulativeReleased` (formatted), and `percentComplete` (rounded to 2 dp).
- Includes a `summary` with `totalReleased`, `totalAmount`, `percentComplete`, `remainingAmount`.
- Route protected by `ShipmentParticipantGuard`; non-participants receive 403.

### #119 — GET /users/admin/users (admin-only)
- Added `AuthService.findAllUsers()` with Prisma pagination, `role`, `emailVerified`, `page`, `limit`, and `orderBy` (`createdAt` desc or `name` asc) filters.
- Returns `id`, `stellarAddress`, `email`, `emailVerified`, `name`, `role`, `createdAt` — no `pendingEmail` or internal flags.
- Pagination metadata: `total`, `page`, `limit`, `totalPages`.
- Route restricted by `@Roles(UserRole.ADMIN)` (enforced by the global `RolesGuard`); 403 for non-admins.
- Also restored syntactic validity of `users.controller.ts` (pre-existing missing closing brace and missing imports that prevented compilation).

### #121 — GET /shipments/:id/milestones/:index/evidence/:evidenceId
- Added `MilestonesService.getOneEvidence()` that fetches a `DisputeEvidence` by id, verifies it belongs to the queried milestone, and checks the caller is a participant or admin.
- `ipfsUrl` is populated via `IpfsService.getGatewayUrl()` when `ipfsCid` is set.
- Returns 404 if the evidence does not exist or belongs to a different milestone; 403 for non-participants.

### #123 — Handlebars email templates
- Added `NotificationsService.renderTemplate(type, data)` that loads a `.hbs` file from `src/modules/notifications/templates/`, compiles it with Handlebars, and returns the rendered HTML (or `null` if no template exists for that type).
- Created `PROOF_SUBMITTED.hbs` (includes milestone name and IPFS proof link), `PAYMENT_RELEASED.hbs` (includes amount and token symbol), and `DISPUTE_RAISED.hbs` (includes milestone index and evidence CTA).
- Updated `sendEmail()` to accept optional `type` and `data` and call `renderTemplate()`, falling back to the existing plain-text HTML wrapper when no template matches.
- Updated `notifyUser()` to forward `type` and `data` to `sendEmail()`.
- Added handlebars to `package.json` (already present in node_modules as a transitive dep).
- Configured `nest-cli.json` `assets` to copy `.hbs` files to `dist/`.

## Testing/Validation

- `npm run test` — 45/45 individual tests passing (same as baseline; no regressions introduced).
- TypeScript compiler reports zero errors in all modified source files.
- Notification spec updated to match the new `sendEmail` signature (added `type` and `data` args).