### PR TITLE
Feature/issue 157 158 159

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Post, Get, Body, Query, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
+import { Controller, Post, Get, Body, Query, HttpCode, HttpStatus, UseGuards, BadRequestException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { StellarAddressThrottlerGuard } from '../../common/guards/stellar-address-throttler.guard';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -38,5 +40,21 @@ export class AuthController {
   @ApiResponse({ status: 401, description: 'Invalid or expired token' })
   async verifyEmail(@Query('token') token: string) {
     return this.authService.verifyEmail(token);
+  }
+
+  @Post('resend-verification')
+  @UseGuards(JwtAuthGuard)
+  @Throttle({ default: { limit: 1, ttl: 60_000 } })
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Resend the pending email verification link' })
+  @ApiResponse({ status: 200, description: 'Verification email resent' })
+  @ApiResponse({ status: 400, description: 'No pending email to verify' })
+  @ApiResponse({ status: 429, description: 'Too many requests - rate limit exceeded' })
+  async resendVerification(@CurrentUser() user: any) {
+    if (!user?.id) {
+      throw new BadRequestException('User not found');
+    }
+
+    return this.authService.resendVerificationEmail(user.id);
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException, ConflictException, Logger } from '@nestjs/common';
+import { Injectable, UnauthorizedException, ConflictException, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { Keypair } from '@stellar/stellar-sdk';
@@ -31,6 +31,7 @@ export class AuthService {
   private readonly logger = new Logger(AuthService.name);
   private readonly NONCE_PREFIX = 'chainsettle:nonce:';
   private readonly NONCE_TTL_MS = 5 * 60 * 1000; // 5 minutes in milliseconds
+  private readonly EMAIL_VERIFICATION_TOKEN_PREFIX = 'chainsettle:email-verification-token:';
 
 
   constructor(
@@ -160,18 +161,7 @@ export class AuthService {
         throw new ConflictException('Email is already in use');
       }
 
-      const token = this.jwt.sign(
-        { sub: userId, email: dto.email },
-        { expiresIn: '24h' },
-      );
-
-      const verificationLink = `${this.config.get('API_BASE_URL', 'http://localhost:3000')}/api/v1/auth/verify-email?token=${token}`;
-
-      await this.notifications.sendEmail(
-        dto.email,
-        'Verify your email address',
-        `Click this link to verify your email: ${verificationLink}`,
-      );
+      await this.sendVerificationEmail(userId, dto.email);
 
       updateData.pendingEmail = dto.email;
     }
@@ -258,9 +248,15 @@ export class AuthService {
 
   async verifyEmail(token: string) {
     let payload: { sub: string; email: string };
+    let payload: { sub: string; email: string };
     try {
       payload = this.jwt.verify<{ sub: string; email: string }>(token);
     } catch {
+      throw new UnauthorizedException('Invalid or expired verification token');
+    }
+
+    const storedToken = await this.redis.get(this.getVerificationTokenKey(payload.sub));
+    if (!storedToken || storedToken !== token) {
       throw new UnauthorizedException('Invalid or expired verification token');
     }
 
@@ -293,6 +289,48 @@ export class AuthService {
       },
     });
 
+    await this.redis.del(this.getVerificationTokenKey(user.id));
+
     return { message: 'Email verified successfully' };
+  }
+
+  async resendVerificationEmail(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, pendingEmail: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    if (!user.pendingEmail) {
+      throw new BadRequestException('No pending email to verify');
+    }
+
+    return this.sendVerificationEmail(user.id, user.pendingEmail);
+  }
+
+  private getVerificationTokenKey(userId: string) {
+    return `${this.EMAIL_VERIFICATION_TOKEN_PREFIX}${userId}`;
+  }
+
+  private async sendVerificationEmail(userId: string, email: string) {
+    const token = this.jwt.sign(
+      { sub: userId, email },
+      { expiresIn: '24h' },
+    );
+
+    await this.redis.setPx(this.getVerificationTokenKey(userId), token, 24 * 60 * 60 * 1000);
+
+    const verificationLink = `${this.config.get('API_BASE_URL', 'http://localhost:3000')}/api/v1/auth/verify-email?token=${token}`;
+
+    await this.notifications.sendEmail(
+      email,
+      'Verify your email address',
+      `Click this link to verify your email: ${verificationLink}`,
+    );
+
+    return { message: 'Verification email sent' };
   }
 }

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Post,
   Patch,
+  Put,
   Body,
   Param,
   Query,
@@ -147,6 +148,21 @@ export class ShipmentsController {
   bulkStatus(@Body() dto: BulkStatusDto, @CurrentUser() user: any) {
     const isAdmin = user?.role === UserRole.ADMIN;
     return this.shipmentsService.bulkStatus(dto.ids, user.stellarAddress, isAdmin);
+  }
+
+  /**
+   * PUT /api/v1/shipments/:id/tags
+   * Replace all shipment tags in a single request.
+   */
+  @Put(':id/tags')
+  @UseGuards(ShipmentParticipantGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Replace all shipment tags' })
+  @ApiResponse({ status: 200, description: 'Shipment tags replaced successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid tag list' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  replaceTags(@Param('id') id: string, @Body() body: { tags: string[] }, @CurrentUser() user: any) {
+    return this.shipmentsService.replaceTags(id, body?.tags, user?.stellarAddress, user?.id);
   }
 
   /**

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -150,6 +150,17 @@ export class ShipmentsController {
   }
 
   /**
+   * GET /api/v1/shipments/mine/summary
+   * Returns a breakdown of the caller's ACTIVE shipments by participant role.
+   */
+  @Get('mine/summary')
+  @ApiOperation({ summary: "Get ACTIVE shipment counts grouped by the caller's role" })
+  @ApiResponse({ status: 200, description: 'Role summary for the caller' })
+  getRoleSummary(@CurrentUser() user: any) {
+    return this.shipmentsService.getRoleSummary(user.stellarAddress);
+  }
+
+  /**
    * GET /api/v1/shipments/:id/participants
    * Returns all four participant roles with Stellar address and name.
    */

--- a/src/modules/shipments/shipments.module.ts
+++ b/src/modules/shipments/shipments.module.ts
@@ -3,11 +3,12 @@ import { ShipmentsController } from './shipments.controller';
 import { ShipmentsService } from './shipments.service';
 import { CommentsController } from './comments.controller';
 import { CommentsService } from './comments.service';
+import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { RedisModule } from '../../common/redis/redis.module';
 
 @Module({
-  imports: [NotificationsModule, RedisModule],
+  imports: [NotificationsModule, RedisModule, AuditLogsModule],
   controllers: [ShipmentsController, CommentsController],
   providers: [ShipmentsService, CommentsService],
   exports: [ShipmentsService],

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -14,6 +14,7 @@ import { TokenRegistryService } from '../../common/token-registry/token-registry
 import { NotificationsService } from '../notifications/notifications.service';
 import { RedisService } from '../../common/redis/redis.service';
 import { MetricsService } from '../../common/metrics/metrics.service';
+import { AuditLogService } from '../audit-logs/audit-log.service';
 import { CreateShipmentDto, CloneShipmentDto } from './dto/create-shipment.dto';
 import { CreateTrackingDto } from './dto/tracking.dto';
 import { ShipmentStatus, NotificationType, ArbiterStatus } from '@prisma/client';
@@ -33,6 +34,7 @@ export class ShipmentsService {
     private readonly redis: RedisService,
     private readonly config: ConfigService,
     private readonly metrics: MetricsService,
+    private readonly auditLog: AuditLogService,
   ) {
     this.cacheTtl = this.config.get<number>('SHIPMENTS_CACHE_TTL_SECONDS', 30);
   }
@@ -474,6 +476,73 @@ export class ShipmentsService {
 
     this.logger.log(`Shipment updated: ${id}`);
     await this.invalidateUserCache(buyerAddress);
+    return this.serialize(updated);
+  }
+
+  async replaceTags(
+    id: string,
+    tags: string[] | undefined,
+    callerAddress?: string,
+    callerId?: string,
+  ) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id },
+      select: { id: true, tags: true },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${id} not found`);
+    }
+
+    if (!Array.isArray(tags)) {
+      throw new BadRequestException('tags must be an array');
+    }
+
+    const normalizedTags = new Map<string, string>();
+    for (const tag of tags) {
+      if (typeof tag !== 'string') {
+        throw new BadRequestException('each tag must be a string');
+      }
+
+      const trimmed = tag.trim();
+      if (trimmed.length < 1 || trimmed.length > 30) {
+        throw new BadRequestException('each tag must be between 1 and 30 characters');
+      }
+
+      const key = trimmed.toLowerCase();
+      if (!normalizedTags.has(key)) {
+        normalizedTags.set(key, trimmed);
+      }
+    }
+
+    if (normalizedTags.size > 20) {
+      throw new BadRequestException('A shipment can have at most 20 tags');
+    }
+
+    const nextTags = Array.from(normalizedTags.values());
+
+    const updated = await this.prisma.shipment.update({
+      where: { id },
+      data: { tags: nextTags },
+      include: {
+        milestones: { orderBy: { milestoneIndex: 'asc' } },
+        events: { orderBy: { ledger: 'desc' }, take: 20 },
+      },
+    });
+
+    await this.auditLog.record({
+      actorId: callerId,
+      actorAddress: callerAddress ?? 'unknown',
+      action: 'SHIPMENT_TAGS_REPLACED',
+      resourceType: 'Shipment',
+      resourceId: id,
+      metadata: {
+        previousTags: shipment.tags,
+        nextTags,
+      },
+    });
+
+    this.logger.log(`Shipment tags replaced: ${id}`);
     return this.serialize(updated);
   }
 

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -390,6 +390,43 @@ export class ShipmentsService {
     return { results };
   }
 
+  async getRoleSummary(stellarAddress: string): Promise<{
+    asBuyer: number;
+    asSupplier: number;
+    asLogistics: number;
+    asArbiter: number;
+    total: number;
+  }> {
+    const activeWhere = { status: ShipmentStatus.ACTIVE };
+
+    const [asBuyer, asSupplier, asLogistics, asArbiter, shipmentIds] = await Promise.all([
+      this.prisma.shipment.count({ where: { ...activeWhere, buyerAddress: stellarAddress } }),
+      this.prisma.shipment.count({ where: { ...activeWhere, supplierAddress: stellarAddress } }),
+      this.prisma.shipment.count({ where: { ...activeWhere, logisticsAddress: stellarAddress } }),
+      this.prisma.shipment.count({ where: { ...activeWhere, arbiterAddress: stellarAddress } }),
+      this.prisma.shipment.findMany({
+        where: {
+          ...activeWhere,
+          OR: [
+            { buyerAddress: stellarAddress },
+            { supplierAddress: stellarAddress },
+            { logisticsAddress: stellarAddress },
+            { arbiterAddress: stellarAddress },
+          ],
+        },
+        select: { id: true },
+      }),
+    ]);
+
+    return {
+      asBuyer,
+      asSupplier,
+      asLogistics,
+      asArbiter,
+      total: new Set(shipmentIds.map((shipment) => shipment.id)).size,
+    };
+  }
+
   /**
    * Update shipment metadata (description, referenceNumber, metadata, tags).
    * Only the buyer can update a shipment.


### PR DESCRIPTION
## Summary
Adds the new shipment role summary endpoint and bulk tag replacement flow, plus an email verification resend endpoint.
close #157 
close #158 
close #159 
## Changes
- Added `GET /shipments/mine/summary` to show ACTIVE shipment counts by caller role.
- Added `PUT /shipments/:id/tags` for atomic full tag replacement with validation and audit logging.
- Added `POST /auth/resend-verification` to resend a fresh email verification link when a pending email exists.

## Notes
- Existing route ordering was preserved so `GET /shipments/:id` still works correctly.
- Old email verification links are invalidated on resend by replacing the stored token.