### PR TITLE
feat: add GET /shipments/:id/refund endpoint for refund status detail

### DIFF
--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -417,6 +417,19 @@ export class ShipmentsController {
   }
 
   /**
+   * GET /api/v1/shipments/:id/refund
+   * Returns refund details for a cancelled shipment.
+   */
+  @Get(':id/refund')
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'Get refund details for a cancelled shipment' })
+  @ApiResponse({ status: 200, description: 'Refund details' })
+  @ApiResponse({ status: 404, description: 'Shipment not found or not cancelled' })
+  getRefund(@Param('id') id: string) {
+    return this.shipmentsService.getRefundDetail(id);
+  }
+
+  /**
    * GET /api/v1/shipments/:id/value-released-over-time
    * Returns a cumulative payment release time series for dashboard charts.
    * Protected by ShipmentParticipantGuard.

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -5,6 +5,7 @@ import {
   ConflictException,
   ForbiddenException,
   BadRequestException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHash } from 'crypto';
@@ -748,7 +749,12 @@ export class ShipmentsService {
 
     const updated = await this.prisma.shipment.update({
       where: { id },
-      data: { status: ShipmentStatus.CANCELLED, txHash },
+      data: {
+        status: ShipmentStatus.CANCELLED,
+        txHash,
+        cancelledAt: new Date(),
+        refundTxHash: txHash || undefined,
+      },
       include: { milestones: { orderBy: { milestoneIndex: 'asc' } } },
     });
 
@@ -765,6 +771,70 @@ export class ShipmentsService {
     );
 
     return this.serialize(updated);
+  }
+
+  // ----------------------------------------------------------
+  // REFUND DETAIL
+  // ----------------------------------------------------------
+
+  /**
+   * Returns refund details for a cancelled shipment.
+   * Looks up the shipment_cancelled ChainEvent to extract the refunded amount.
+   */
+  async getRefundDetail(id: string) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${id} not found`);
+    }
+
+    if (!shipment.cancelledAt) {
+      throw new NotFoundException(`Shipment ${id} has not been cancelled`);
+    }
+
+    // Look up the corresponding ChainEvent for refund amount
+    const cancelEvent = await this.prisma.chainEvent.findFirst({
+      where: {
+        shipmentId: id,
+        eventName: 'shipment_cancelled',
+      },
+      orderBy: { ledger: 'desc' },
+    });
+
+    if (!cancelEvent) {
+      throw new InternalServerErrorException(
+        `Cancellation chain event not found for shipment ${id}. The on-chain event may not have been processed yet.`,
+      );
+    }
+
+    // Extract refunded amount from the event payload.
+    // Payload is expected to be [shipmentId, refundedAmount].
+    // Falls back to totalAmount if payload doesn't include amount.
+    let refundedAmountRaw: bigint;
+    try {
+      const payload = cancelEvent.payload as any;
+      if (Array.isArray(payload) && payload.length >= 2) {
+        refundedAmountRaw = BigInt(payload[1] ?? 0);
+      } else {
+        refundedAmountRaw = shipment.totalAmount;
+      }
+    } catch {
+      this.logger.warn(
+        `Failed to parse refund amount from payload for shipment ${id}, falling back to totalAmount`,
+      );
+      refundedAmountRaw = shipment.totalAmount;
+    }
+
+    const decimals: number = shipment.tokenDecimals ?? 7;
+
+    return {
+      cancelledAt: shipment.cancelledAt.toISOString(),
+      refundTxHash: shipment.refundTxHash ?? cancelEvent.txHash,
+      refundedAmount: this.stellar.toHumanAmount(refundedAmountRaw, decimals),
+      refundedTo: shipment.buyerAddress,
+    };
   }
 
   // ----------------------------------------------------------


### PR DESCRIPTION
Closes #163. Adds GET /shipments/:id/refund protected by ShipmentParticipantGuard. Returns 404 if not cancelled, 500 if chain event missing. Returns cancelledAt, refundTxHash, refundedAmount (formatted with tokenDecimals), refundedTo.