### PR TITLE
feat: add proof submission history for milestone proof resubmissions

### DIFF
--- a/prisma/migrations/20260726000001_add_proof_submissions/migration.sql
+++ b/prisma/migrations/20260726000001_add_proof_submissions/migration.sql
@@ -1,0 +1,23 @@
+-- Migration: add_proof_submissions
+-- Adds proof_submissions table for audit trail of proof uploads per milestone
+
+CREATE TABLE "proof_submissions" (
+    "id"           TEXT         NOT NULL,
+    "milestoneId"  TEXT         NOT NULL,
+    "ipfsCid"      TEXT         NOT NULL,
+    "submittedBy"  TEXT         NOT NULL,
+    "createdAt"    TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "proof_submissions_pkey" PRIMARY KEY ("id")
+);
+
+-- Enable fast lookups by milestone
+CREATE INDEX "proof_submissions_milestoneId_idx" ON "proof_submissions"("milestoneId");
+
+-- Enable queries by submitter
+CREATE INDEX "proof_submissions_submittedBy_idx" ON "proof_submissions"("submittedBy");
+
+-- FK to milestones (cascade delete when milestone is removed)
+ALTER TABLE "proof_submissions"
+    ADD CONSTRAINT "proof_submissions_milestoneId_fkey"
+    FOREIGN KEY ("milestoneId") REFERENCES "milestones"("id") ON DELETE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -172,9 +172,25 @@ model Milestone {
   // Relations
   shipment        Shipment          @relation(fields: [shipmentId], references: [id])
   disputeEvidence DisputeEvidence[]
+  proofSubmissions ProofSubmission[]
 
   @@unique([shipmentId, milestoneIndex])
   @@map("milestones")
+}
+
+model ProofSubmission {
+  id          String   @id @default(uuid())
+  milestoneId String
+  ipfsCid     String   // IPFS CID of the uploaded proof
+  submittedBy String   // Stellar address of whoever uploaded
+  createdAt   DateTime @default(now())
+
+  // Relations
+  milestone Milestone @relation(fields: [milestoneId], references: [id], onDelete: Cascade)
+
+  @@index([milestoneId])
+  @@index([submittedBy])
+  @@map("proof_submissions")
 }
 
 model DisputeEvidence {

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -207,6 +207,23 @@ export class MilestonesController {
   }
 
   /**
+   * GET /api/v1/shipments/:shipmentId/milestones/:index/proof-history
+   * Returns the full proof submission history for a milestone, ordered chronologically.
+   */
+  @Get(':index/proof-history')
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'Get full proof submission history for a milestone' })
+  @ApiResponse({ status: 200, description: 'Proof submissions in chronological order' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  @ApiResponse({ status: 404, description: 'Milestone not found' })
+  getProofHistory(
+    @Param('shipmentId') shipmentId: string,
+    @Param('index', ParseIntPipe) index: number,
+  ) {
+    return this.milestonesService.getProofHistory(shipmentId, index);
+  }
+
+  /**
    * GET /api/v1/shipments/:shipmentId/milestones/:index/evidence/:evidenceId
    * Fetch a single dispute evidence record by ID.
    * Includes the IPFS gateway URL when an ipfsCid is present.

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -114,6 +114,15 @@ export class MilestonesService {
     // Persist CID + status transition
     const updated = await this.markProofSubmitted(shipmentId, milestoneIndex, cid);
 
+    // Record proof submission in audit trail (immutable history)
+    await this.prisma.proofSubmission.create({
+      data: {
+        milestoneId: milestone.id,
+        ipfsCid: cid,
+        submittedBy: callerAddress,
+      },
+    });
+
     this.logger.log(
       `Proof submitted for ${shipmentId}[${milestoneIndex}] — CID: ${cid}`,
     );
@@ -536,6 +545,38 @@ export class MilestonesService {
       fileName: evidence.fileName || 'download',
       mimeType: evidence.mimeType || 'application/octet-stream',
     };
+  }
+
+  // ----------------------------------------------------------
+  // PROOF HISTORY — immutable audit trail of all proof submissions
+  // ----------------------------------------------------------
+
+  /**
+   * Returns all ProofSubmission rows for a milestone in chronological order.
+   * Pre-migration milestones with no history rows will return an empty array.
+   * Access is gated by ShipmentParticipantGuard in the controller.
+   */
+  async getProofHistory(shipmentId: string, milestoneIndex: number) {
+    const milestone = await this.prisma.milestone.findUnique({
+      where: { shipmentId_milestoneIndex: { shipmentId, milestoneIndex } },
+    });
+
+    if (!milestone) {
+      throw new NotFoundException(
+        `Milestone ${milestoneIndex} not found on shipment ${shipmentId}`,
+      );
+    }
+
+    const submissions = await this.prisma.proofSubmission.findMany({
+      where: { milestoneId: milestone.id },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    return submissions.map((s) => ({
+      ipfsCid: s.ipfsCid,
+      submittedBy: s.submittedBy,
+      createdAt: s.createdAt.toISOString(),
+    }));
   }
 
   // ----------------------------------------------------------


### PR DESCRIPTION
Closes #166. Adds ProofSubmission model and GET :index/proof-history endpoint for immutable audit trail of all proof uploads per milestone.