### PR TITLE
feat: add POST /milestones/:index/reject for buyer to reject proofs

### DIFF
--- a/prisma/migrations/20260726000002_add_proof_rejected_notification_type/migration.sql
+++ b/prisma/migrations/20260726000002_add_proof_rejected_notification_type/migration.sql
@@ -1,0 +1,4 @@
+-- Migration: add_proof_rejected_notification_type
+-- Adds PROOF_REJECTED to the NotificationType enum for the proof rejection flow
+
+ALTER TYPE "NotificationType" ADD VALUE 'PROOF_REJECTED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ enum NotificationType {
   ARBITER_ACCEPTED
   ARBITER_DECLINED
   TRACKING_UPDATED
+  PROOF_REJECTED
 }
 
 enum CommentVisibility {

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -207,6 +207,58 @@ export class MilestonesController {
   }
 
   /**
+   * POST /api/v1/shipments/:shipmentId/milestones/:index/reject
+   * Buyer rejects a submitted proof, reverting to PENDING for resubmission.
+   */
+  @Post(':index/reject')
+  @UseGuards(ShipmentParticipantGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Reject a submitted proof (buyer only)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['reason'],
+      properties: {
+        reason: { type: 'string', description: 'Reason the proof was rejected' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Proof rejected, milestone reverted to PENDING' })
+  @ApiResponse({ status: 403, description: 'Not the shipment buyer' })
+  @ApiResponse({ status: 404, description: 'Shipment or milestone not found' })
+  @ApiResponse({ status: 409, description: 'Milestone is not in PROOF_SUBMITTED status' })
+  rejectProof(
+    @Param('shipmentId') shipmentId: string,
+    @Param('index', ParseIntPipe) index: number,
+    @Body('reason') reason: string,
+    @CurrentUser() user: any,
+  ) {
+    if (!reason || !reason.trim()) {
+      throw new BadRequestException('A rejection reason is required');
+    }
+
+    const callerAddress: string = user?.stellarAddress ?? user?.sub;
+    return this.milestonesService.rejectProof(shipmentId, index, callerAddress, reason.trim());
+  }
+
+  /**
+   * GET /api/v1/shipments/:shipmentId/milestones/:index/proof-history
+   * Returns the full proof submission history for a milestone, ordered chronologically.
+   */
+  @Get(':index/proof-history')
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'Get full proof submission history for a milestone' })
+  @ApiResponse({ status: 200, description: 'Proof submissions in chronological order' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  @ApiResponse({ status: 404, description: 'Milestone not found' })
+  getProofHistory(
+    @Param('shipmentId') shipmentId: string,
+    @Param('index', ParseIntPipe) index: number,
+  ) {
+    return this.milestonesService.getProofHistory(shipmentId, index);
+  }
+
+  /**
    * GET /api/v1/shipments/:shipmentId/milestones/:index/evidence/:evidenceId
    * Fetch a single dispute evidence record by ID.
    * Includes the IPFS gateway URL when an ipfsCid is present.

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -114,6 +114,15 @@ export class MilestonesService {
     // Persist CID + status transition
     const updated = await this.markProofSubmitted(shipmentId, milestoneIndex, cid);
 
+    // Record proof submission in audit trail (immutable history)
+    await this.prisma.proofSubmission.create({
+      data: {
+        milestoneId: milestone.id,
+        ipfsCid: cid,
+        submittedBy: callerAddress,
+      },
+    });
+
     this.logger.log(
       `Proof submitted for ${shipmentId}[${milestoneIndex}] — CID: ${cid}`,
     );
@@ -536,6 +545,98 @@ export class MilestonesService {
       fileName: evidence.fileName || 'download',
       mimeType: evidence.mimeType || 'application/octet-stream',
     };
+  }
+
+  // ----------------------------------------------------------
+  // PROOF REJECTION — buyer sends proof back for resubmission
+  // ----------------------------------------------------------
+
+  /**
+   * Rejects a submitted proof, reverting the milestone to PENDING.
+   * Only the shipment buyer may call this. Milestone must be PROOF_SUBMITTED.
+   * The proofHash is cleared (the value lives on in ProofSubmission history).
+   * Notifies the supplier with the buyer's reason.
+   */
+  async rejectProof(
+    shipmentId: string,
+    milestoneIndex: number,
+    buyerAddress: string,
+    reason: string,
+  ) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    }
+
+    if (shipment.buyerAddress !== buyerAddress) {
+      throw new ForbiddenException('Only the shipment buyer may reject a proof');
+    }
+
+    const milestone = await this.findOne(shipmentId, milestoneIndex);
+
+    if (milestone.status !== MilestoneStatus.PROOF_SUBMITTED) {
+      throw new ConflictException(
+        `Milestone ${milestoneIndex} must be in PROOF_SUBMITTED status to reject (currently ${milestone.status})`,
+      );
+    }
+
+    const updated = await this.prisma.milestone.update({
+      where: { shipmentId_milestoneIndex: { shipmentId, milestoneIndex } },
+      data: {
+        status: MilestoneStatus.PENDING,
+        proofHash: null,
+      },
+    });
+
+    this.logger.log(
+      `Proof rejected for ${shipmentId}[${milestoneIndex}] by buyer ${buyerAddress}`,
+    );
+
+    // Notify supplier with the rejection reason
+    await this.notifications.notifyUser(
+      shipment.supplierAddress,
+      NotificationType.PROOF_REJECTED,
+      'Proof rejected — resubmission requested',
+      `Your proof for milestone ${milestoneIndex} ("${milestone.name}") on shipment ${shipmentId} was rejected. Reason: ${reason}`,
+      { shipmentId, milestoneIndex, reason },
+    );
+
+    return updated;
+  }
+
+  // ----------------------------------------------------------
+  // PROOF HISTORY — immutable audit trail of all proof submissions
+  // ----------------------------------------------------------
+
+  /**
+   * Returns all ProofSubmission rows for a milestone in chronological order.
+   * Pre-migration milestones with no history rows will return an empty array.
+   * Access is gated by ShipmentParticipantGuard in the controller.
+   */
+  async getProofHistory(shipmentId: string, milestoneIndex: number) {
+    const milestone = await this.prisma.milestone.findUnique({
+      where: { shipmentId_milestoneIndex: { shipmentId, milestoneIndex } },
+    });
+
+    if (!milestone) {
+      throw new NotFoundException(
+        `Milestone ${milestoneIndex} not found on shipment ${shipmentId}`,
+      );
+    }
+
+    const submissions = await this.prisma.proofSubmission.findMany({
+      where: { milestoneId: milestone.id },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    return submissions.map((s) => ({
+      ipfsCid: s.ipfsCid,
+      submittedBy: s.submittedBy,
+      createdAt: s.createdAt.toISOString(),
+    }));
   }
 
   // ----------------------------------------------------------


### PR DESCRIPTION
Closes #167. Adds POST :index/reject endpoint allowing buyers to reject submitted proofs without escalating to a formal dispute. Milestone reverts to PENDING, proofHash is cleared (preserved in ProofSubmission history), and supplier is notified with the rejection reason.