### PR TITLE
Add bulk-delete, digest frequency, delivery detail, and template preview endpoints

### DIFF
--- a/src/modules/notifications/dto/update-preferences.dto.ts
+++ b/src/modules/notifications/dto/update-preferences.dto.ts
@@ -1,12 +1,26 @@
-import { IsObject } from 'class-validator';
+import { IsIn, IsObject, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { NotificationType } from '@prisma/client';
+import { DigestFrequency } from '../notifications.service';
+
+const DIGEST_FREQUENCIES: DigestFrequency[] = ['instant', 'daily', 'weekly'];
 
 export class UpdatePreferencesDto {
   @ApiProperty({
     description: 'Partial map of NotificationType to channel flags',
     example: { PROOF_SUBMITTED: { inApp: true, email: false } },
+    required: false,
   })
+  @IsOptional()
   @IsObject()
-  preferences: Partial<Record<NotificationType, { inApp: boolean; email: boolean }>>;
+  preferences?: Partial<Record<NotificationType, { inApp: boolean; email: boolean }>>;
+
+  @ApiProperty({
+    description: 'How often to receive the notification digest email',
+    enum: DIGEST_FREQUENCIES,
+    required: false,
+  })
+  @IsOptional()
+  @IsIn(DIGEST_FREQUENCIES)
+  digestFrequency?: DigestFrequency;
 }

--- a/src/modules/notifications/notification-digest.job.ts
+++ b/src/modules/notifications/notification-digest.job.ts
@@ -13,9 +13,12 @@ export class NotificationDigestJob {
     private readonly notifications: NotificationsService,
   ) {}
 
+  // Runs daily; 'weekly' subscribers are only included when this lands on a
+  // Monday (JS Date#getDay() === 1) — a fixed day chosen for simplicity.
   @Cron('0 8 * * *')
   async sendDailyDigests() {
     this.logger.log('Running daily notification digest job');
+    const isWeeklyDigestDay = new Date().getDay() === 1;
 
     const usersWithUnread = await this.prisma.user.findMany({
       where: {
@@ -29,6 +32,10 @@ export class NotificationDigestJob {
     let sent = 0;
     for (const user of usersWithUnread) {
       try {
+        const digestFrequency = await this.notifications.getDigestFrequency(user.id);
+        if (digestFrequency === 'instant') continue;
+        if (digestFrequency === 'weekly' && !isWeeklyDigestDay) continue;
+
         const prefs = await this.notifications.getOrCreatePreferences(user.id);
 
         const allEmailDisabled = Object.values(NotificationType).every(

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Patch, Param, Query, Body, UseGuards, NotFoundException } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Delete, Param, Query, Body, UseGuards, NotFoundException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { NotificationsService } from './notifications.service';
@@ -39,10 +39,16 @@ export class NotificationsController {
     return this.notificationsService.markAllRead(userId);
   }
 
+  @Delete('read')
+  @ApiOperation({ summary: 'Delete all read notifications for the authenticated user' })
+  deleteAllRead(@CurrentUser('id') userId: string) {
+    return this.notificationsService.deleteAllRead(userId);
+  }
+
   @Get('preferences')
   @ApiOperation({ summary: 'Get notification preferences for the authenticated user' })
   getPreferences(@CurrentUser('id') userId: string) {
-    return this.notificationsService.getOrCreatePreferences(userId);
+    return this.notificationsService.getPreferencesResponse(userId);
   }
 
   @Patch('preferences')

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -11,6 +11,10 @@ import { WebhooksService } from '../webhooks/webhooks.service';
 import { UpdatePreferencesDto } from './dto/update-preferences.dto';
 
 type PreferenceMap = Record<NotificationType, { inApp: boolean; email: boolean }>;
+export type DigestFrequency = 'instant' | 'daily' | 'weekly';
+type StoredPreferences = PreferenceMap & { _meta?: { digestFrequency?: DigestFrequency } };
+
+const DEFAULT_DIGEST_FREQUENCY: DigestFrequency = 'daily';
 
 function buildDefaultPreferences(): PreferenceMap {
   return Object.values(NotificationType).reduce((acc, type) => {
@@ -172,13 +176,31 @@ export class NotificationsService {
   }
 
   async updatePreferences(userId: string, dto: UpdatePreferencesDto): Promise<PreferenceMap> {
-    const current = await this.getOrCreatePreferences(userId);
-    const merged = { ...current, ...dto.preferences };
+    const current = (await this.getOrCreatePreferences(userId)) as StoredPreferences;
+    const merged: StoredPreferences = { ...current, ...(dto.preferences ?? {}) };
+    if (dto.digestFrequency) {
+      merged._meta = { ...current._meta, digestFrequency: dto.digestFrequency };
+    }
     const record = await this.prisma.notificationPreference.update({
       where: { userId },
       data: { preferences: merged },
     });
     return record.preferences as PreferenceMap;
+  }
+
+  /**
+   * Resolves the caller's configured digest cadence, defaulting existing
+   * users without a stored value to 'daily' (no migration required).
+   */
+  async getDigestFrequency(userId: string): Promise<DigestFrequency> {
+    const prefs = (await this.getOrCreatePreferences(userId)) as StoredPreferences;
+    return prefs._meta?.digestFrequency ?? DEFAULT_DIGEST_FREQUENCY;
+  }
+
+  async getPreferencesResponse(userId: string) {
+    const prefs = (await this.getOrCreatePreferences(userId)) as StoredPreferences;
+    const { _meta, ...typePreferences } = prefs;
+    return { ...typePreferences, digestFrequency: _meta?.digestFrequency ?? DEFAULT_DIGEST_FREQUENCY };
   }
 
   async findForUser(userId: string, unreadOnly = false, page = 1, limit = 20) {
@@ -214,6 +236,13 @@ export class NotificationsService {
       where: { userId, read: false },
       data: { read: true },
     });
+  }
+
+  async deleteAllRead(userId: string) {
+    const result = await this.prisma.notification.deleteMany({
+      where: { userId, read: true },
+    });
+    return { deletedCount: result.count };
   }
 
   async buildDigest(userId: string): Promise<{ subject: string; html: string } | null> {

--- a/src/modules/shipment-templates/shipment-templates.controller.ts
+++ b/src/modules/shipment-templates/shipment-templates.controller.ts
@@ -61,6 +61,15 @@ export class ShipmentTemplatesController {
     return this.templatesService.findOne(id);
   }
 
+  @Get(':id/preview')
+  @ApiOperation({ summary: 'Preview shipment creation from a template' })
+  @ApiResponse({ status: 200, description: 'Resolved preview of the template' })
+  @ApiResponse({ status: 403, description: 'Private template — owner only' })
+  @ApiResponse({ status: 404, description: 'Template not found' })
+  preview(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.templatesService.preview(id, user.id);
+  }
+
   @Patch(':id')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Update a template (owner only)' })

--- a/src/modules/shipment-templates/shipment-templates.service.ts
+++ b/src/modules/shipment-templates/shipment-templates.service.ts
@@ -81,6 +81,36 @@ export class ShipmentTemplatesService {
     return template;
   }
 
+  async preview(id: string, userId: string) {
+    const template = await this.findOne(id);
+
+    if (!template.isPublic && template.ownerId !== userId) {
+      throw new ForbiddenException('Only the template owner can preview a private template');
+    }
+
+    const milestoneTemplates = (template.milestoneTemplates as any[]) ?? [];
+    const milestones = milestoneTemplates.map((m) => ({
+      name: m.name,
+      paymentPercent: m.paymentPercent,
+      dueDays: m.dueDays ?? null,
+      dueDescription:
+        m.dueDays != null ? `${m.dueDays} day${m.dueDays === 1 ? '' : 's'} after creation` : 'No due date set',
+    }));
+
+    const percentSum = milestones.reduce((sum, m) => sum + m.paymentPercent, 0);
+
+    const missingFields = (['supplierAddress', 'logisticsAddress', 'arbiterAddress', 'tokenAddress'] as const).filter(
+      (field) => !template[field],
+    );
+
+    return {
+      milestones,
+      percentSum,
+      isValid: percentSum === 100,
+      missingFields,
+    };
+  }
+
   async update(
     id: string,
     ownerId: string,

--- a/src/modules/webhooks/webhooks.controller.ts
+++ b/src/modules/webhooks/webhooks.controller.ts
@@ -44,6 +44,17 @@ export class WebhooksController {
     return this.webhooksService.remove(id, userId);
   }
 
+  @Get(':id/deliveries/:deliveryId')
+  @ApiOperation({ summary: 'Get full detail for a single webhook delivery' })
+  @ApiResponse({ status: 404, description: 'Webhook delivery not found' })
+  getDelivery(
+    @Param('id') id: string,
+    @Param('deliveryId') deliveryId: string,
+    @CurrentUser('id') userId: string,
+  ) {
+    return this.webhooksService.getDelivery(userId, id, deliveryId);
+  }
+
   @Post(':id/deliveries/:deliveryId/retry')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Manually retry a failed webhook delivery' })

--- a/src/modules/webhooks/webhooks.service.ts
+++ b/src/modules/webhooks/webhooks.service.ts
@@ -7,6 +7,7 @@ import { NotificationType } from '@prisma/client';
 import { CreateWebhookDto } from './dto/create-webhook.dto';
 
 const MAX_ATTEMPTS = 3;
+const MAX_DELIVERY_RESPONSE_BODY_LENGTH = 10 * 1024; // 10KB, guards against pathological receivers
 
 @Injectable()
 export class WebhooksService {
@@ -105,6 +106,23 @@ export class WebhooksService {
       where: { active: true, events: { has: eventType } },
     });
     await Promise.allSettled(endpoints.map((ep) => this.attempt(ep, eventType, payload, 1)));
+  }
+
+  async getDelivery(userId: string, endpointId: string, deliveryId: string) {
+    const endpoint = await this.prisma.webhookEndpoint.findFirst({
+      where: { id: endpointId, userId },
+    });
+    if (!endpoint) throw new NotFoundException('Webhook endpoint not found');
+
+    const delivery = await this.prisma.webhookDelivery.findFirst({
+      where: { id: deliveryId, endpointId },
+    });
+    if (!delivery) throw new NotFoundException('Webhook delivery not found');
+
+    return {
+      ...delivery,
+      responseBody: delivery.responseBody?.slice(0, MAX_DELIVERY_RESPONSE_BODY_LENGTH) ?? delivery.responseBody,
+    };
   }
 
   async retryDelivery(endpointId: string, deliveryId: string, userId: string) {


### PR DESCRIPTION
## Summary

- **closes #170** — `DELETE /notifications/read`: bulk-deletes the caller's read notifications, returns `{ deletedCount }`. Unread notifications are untouched; scoped to `userId` via `deleteMany`.
- **closes #171** — Digest frequency preference (`instant | daily | weekly`, default `daily`): extended `PATCH /notifications/preferences` to accept `digestFrequency`, stored under a reserved `_meta` key inside the existing `preferences` JSON blob (no migration). `GET /notifications/preferences` now returns the resolved `digestFrequency` alongside per-type settings. The digest cron skips `instant` users entirely and only includes `weekly` users on the Monday run.
- **closes #175** — `GET /webhooks/:id/deliveries/:deliveryId`: returns the full delivery row (`payload`, `statusCode`, `responseBody`, `attemptCount`, `nextRetryAt`, etc.), truncating `responseBody` to 10KB. 404s if the endpoint or delivery isn't the caller's.
- **closes #176** — `GET /shipment-templates/:id/preview`: read-only preview resolving `milestoneTemplates` into human-readable due-day descriptions, computing `percentSum`/`isValid`, and listing `missingFields` (null optional template fields like `arbiterAddress`). Allowed for the owner or anyone on public templates; 403 otherwise.

## Test plan
- [x] `npx tsc --noEmit` — no new type errors (pre-existing unrelated error in `events.controller.ts` confirmed present on `main`)
- [x] `npx jest notifications` — 17/17 passing
- [x] `npx jest webhooks` — pre-existing DI failures in `webhooks.service.spec.ts` confirmed present on `main` before this change (unrelated to this PR)
- [x] Reviewed full diff — changes scoped to the four issues only