### PR TITLE
Add IPFS pin status, admin user tools, and shipment-derived templates

### DIFF
--- a/src/common/ipfs/ipfs.controller.ts
+++ b/src/common/ipfs/ipfs.controller.ts
@@ -21,6 +21,20 @@ const CID_REGEX = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{58,})$/;
 export class IpfsController {
   constructor(private readonly ipfs: IpfsService) {}
 
+  @Get(':cid/status')
+  @Throttle({ default: { limit: 20, ttl: 60_000 } })
+  @ApiOperation({ summary: 'Check IPFS pin status for a CID without downloading its content' })
+  @ApiResponse({ status: 200, description: '{ cid, pinned, sizeBytes? }' })
+  @ApiResponse({ status: 400, description: 'Invalid CID format' })
+  @ApiResponse({ status: 429, description: 'Rate limit exceeded (20 req/min per user)' })
+  async getPinStatus(@Param('cid') cid: string) {
+    if (!CID_REGEX.test(cid)) {
+      throw new BadRequestException(`Invalid CID format: ${cid}`);
+    }
+
+    return this.ipfs.checkPinStatus(cid);
+  }
+
   @Get(':cid')
   @Throttle({ default: { limit: 20, ttl: 60_000 } })
   @ApiOperation({ summary: 'Proxy-fetch a file from IPFS by CID (JWT-guarded)' })

--- a/src/common/ipfs/ipfs.service.ts
+++ b/src/common/ipfs/ipfs.service.ts
@@ -154,6 +154,46 @@ export class IpfsService implements OnModuleInit {
   }
 
   /**
+   * Checks whether a CID is pinned/available without downloading its content.
+   * Issues a HEAD request against the same gateway used by getFile(), so a
+   * true result here means getFile() would succeed too.
+   *
+   * @param cid - IPFS CID to check
+   * @returns { cid, pinned, sizeBytes? } — sizeBytes omitted if the gateway
+   *          doesn't report a Content-Length header
+   * @throws InternalServerErrorException on unexpected (non-404) failures
+   */
+  async checkPinStatus(cid: string): Promise<{ cid: string; pinned: boolean; sizeBytes?: number }> {
+    if (!this.apiKey) {
+      this.logger.warn(
+        'IPFS_API_KEY not configured — cannot check pin status in development',
+      );
+      return { cid, pinned: false };
+    }
+
+    try {
+      const response = await axios.head(`${this.gateway}/${cid}`, { timeout: 10_000 });
+      const lengthHeader = response.headers['content-length'];
+      const sizeBytes = lengthHeader !== undefined ? Number(lengthHeader) : undefined;
+
+      return {
+        cid,
+        pinned: true,
+        ...(sizeBytes !== undefined && !Number.isNaN(sizeBytes) ? { sizeBytes } : {}),
+      };
+    } catch (error) {
+      const status = error.response?.status;
+      if (status && status >= 400 && status < 500) {
+        return { cid, pinned: false };
+      }
+
+      const detail = error.response?.data?.error?.details ?? error.message;
+      this.logger.error(`Failed to check IPFS pin status for ${cid}`, detail);
+      throw new InternalServerErrorException(`IPFS pin status check failed: ${detail}`);
+    }
+  }
+
+  /**
    * Fetches a file from IPFS by CID and returns its buffer and MIME type.
    *
    * @param cid - IPFS CID of the file

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -206,6 +206,113 @@ export class AuthService {
     };
   }
 
+  /**
+   * Admin-only suspension/reversal of a user account. Reuses the
+   * deactivatedAt column introduced for self-service deactivation, but
+   * skips the active-shipment check (admins may need to suspend accounts
+   * mid-shipment for fraud response). Idempotent: setting a user to the
+   * state they're already in is a no-op, not an error.
+   */
+  async adminSetActive(id: string, active: boolean, adminId: string, adminAddress: string) {
+    if (!active && id === adminId) {
+      throw new BadRequestException(
+        'Admins cannot deactivate their own account via this route. Use DELETE /users/me instead.',
+      );
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+      select: { id: true, stellarAddress: true, deactivatedAt: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const isCurrentlyActive = !user.deactivatedAt;
+    if (isCurrentlyActive === active) {
+      return {
+        message: `Account is already ${active ? 'active' : 'deactivated'}`,
+        deactivatedAt: user.deactivatedAt,
+      };
+    }
+
+    const deactivatedAt = active ? null : new Date();
+
+    await this.prisma.user.update({
+      where: { id },
+      data: { deactivatedAt },
+    });
+
+    await this.auditLog.record({
+      actorId: adminId,
+      actorAddress: adminAddress,
+      action: active ? 'ADMIN_USER_REACTIVATED' : 'ADMIN_USER_DEACTIVATED',
+      resourceType: 'User',
+      resourceId: id,
+      metadata: { targetUserId: id, targetStellarAddress: user.stellarAddress },
+    });
+
+    this.logger.log(
+      `User ${user.stellarAddress} (${id}) ${active ? 'reactivated' : 'deactivated'} by admin ${adminId}`,
+    );
+
+    return {
+      message: `Account ${active ? 'reactivated' : 'deactivated'} successfully`,
+      deactivatedAt,
+    };
+  }
+
+  /**
+   * Full admin detail view of a single user: the raw User record plus
+   * operational counts, computed via parallel aggregate queries (no N+1).
+   */
+  async getAdminUserDetail(id: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        stellarAddress: true,
+        email: true,
+        emailVerified: true,
+        pendingEmail: true,
+        name: true,
+        role: true,
+        deactivatedAt: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const [shipmentCount, activeApiKeyCount, webhookCount, unreadNotificationCount] = await Promise.all([
+      this.prisma.shipment.count({
+        where: {
+          OR: [
+            { buyerAddress: user.stellarAddress },
+            { supplierAddress: user.stellarAddress },
+            { logisticsAddress: user.stellarAddress },
+            { arbiterAddress: user.stellarAddress },
+          ],
+        },
+      }),
+      this.prisma.apiKey.count({ where: { userId: id, revokedAt: null } }),
+      this.prisma.webhookEndpoint.count({ where: { userId: id } }),
+      this.prisma.notification.count({ where: { userId: id, read: false } }),
+    ]);
+
+    return {
+      ...user,
+      shipmentCount,
+      activeApiKeyCount,
+      webhookCount,
+      unreadNotificationCount,
+    };
+  }
+
   async getPublicProfile(stellarAddress: string) {
     const user = await this.prisma.user.findUnique({
       where: { stellarAddress },

--- a/src/modules/auth/users.controller.ts
+++ b/src/modules/auth/users.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Post,
   Patch,
   Delete,
   Param,
@@ -95,6 +96,51 @@ export class UsersController {
       limit: limit ? parseInt(limit, 10) : undefined,
       orderBy,
     });
+  }
+
+  /**
+   * POST /api/v1/users/admin/:id/deactivate
+   * Admin-only suspension, bypassing the self-service active-shipment check.
+   */
+  @Post('admin/:id/deactivate')
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '[Admin] Deactivate a user account, bypassing the active-shipment check' })
+  @ApiResponse({ status: 200, description: 'Account deactivated (or already deactivated)' })
+  @ApiResponse({ status: 400, description: 'Admins cannot deactivate their own account via this route' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  deactivateUserAsAdmin(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.authService.adminSetActive(id, false, user.id, user.stellarAddress);
+  }
+
+  /**
+   * POST /api/v1/users/admin/:id/reactivate
+   */
+  @Post('admin/:id/reactivate')
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: '[Admin] Reactivate a previously deactivated user account' })
+  @ApiResponse({ status: 200, description: 'Account reactivated (or already active)' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  reactivateUserAsAdmin(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.authService.adminSetActive(id, true, user.id, user.stellarAddress);
+  }
+
+  /**
+   * GET /api/v1/users/admin/:id
+   * Registered after admin/users (list) so the literal segment isn't
+   * shadowed by this param route, and before :stellarAddress below.
+   */
+  @Get('admin/:id')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: '[Admin] Get full detail view of a single user' })
+  @ApiResponse({ status: 200, description: 'Full user record plus computed operational counts' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  getAdminUserDetail(@Param('id') id: string) {
+    return this.authService.getAdminUserDetail(id);
   }
 
   @Get(':stellarAddress')

--- a/src/modules/shipment-templates/dto/create-template-from-shipment.dto.ts
+++ b/src/modules/shipment-templates/dto/create-template-from-shipment.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateTemplateFromShipmentDto {
+  @ApiProperty({ example: 'Standard China Import' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ required: false, example: 'Derived from shipment SHIP-001' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ required: false, default: false, description: 'Whether template is visible to all users' })
+  @IsOptional()
+  @IsBoolean()
+  isPublic?: boolean;
+}

--- a/src/modules/shipment-templates/shipment-templates.controller.ts
+++ b/src/modules/shipment-templates/shipment-templates.controller.ts
@@ -20,8 +20,10 @@ import {
 } from '@nestjs/swagger';
 import { ShipmentTemplatesService } from './shipment-templates.service';
 import { CreateShipmentTemplateDto, UpdateShipmentTemplateDto } from './dto/create-shipment-template.dto';
+import { CreateTemplateFromShipmentDto } from './dto/create-template-from-shipment.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { ShipmentParticipantGuard } from '../shipments/guards/shipment-participant.guard';
 
 @ApiTags('shipment-templates')
 @ApiBearerAuth()
@@ -39,6 +41,21 @@ export class ShipmentTemplatesController {
     @CurrentUser() user: any,
   ) {
     return this.templatesService.create(dto, user.id);
+  }
+
+  @Post('from-shipment/:id')
+  @UseGuards(ShipmentParticipantGuard)
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a shipment template from an existing shipment (buyer only)' })
+  @ApiResponse({ status: 201, description: 'Template created from shipment' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant, or not the buyer' })
+  @ApiResponse({ status: 404, description: 'Shipment not found' })
+  createFromShipment(
+    @Param('id') shipmentId: string,
+    @Body() dto: CreateTemplateFromShipmentDto,
+    @CurrentUser() user: any,
+  ) {
+    return this.templatesService.createFromShipment(user.id, user.stellarAddress, shipmentId, dto);
   }
 
   @Get()

--- a/src/modules/shipment-templates/shipment-templates.service.ts
+++ b/src/modules/shipment-templates/shipment-templates.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { CreateShipmentTemplateDto, UpdateShipmentTemplateDto } from './dto/create-shipment-template.dto';
+import { CreateTemplateFromShipmentDto } from './dto/create-template-from-shipment.dto';
 
 @Injectable()
 export class ShipmentTemplatesService {
@@ -67,6 +68,56 @@ export class ShipmentTemplatesService {
         pages: Math.ceil(total / limit),
       },
     };
+  }
+
+  /**
+   * Derives a new template from an existing shipment's structure.
+   * Restricted to the shipment's buyer (ShipmentParticipantGuard only
+   * confirms participancy, so the buyer check happens here).
+   */
+  async createFromShipment(
+    ownerId: string,
+    callerAddress: string,
+    shipmentId: string,
+    dto: CreateTemplateFromShipmentDto,
+  ) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+      include: { milestones: { orderBy: { milestoneIndex: 'asc' } } },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    }
+
+    if (shipment.buyerAddress !== callerAddress) {
+      throw new ForbiddenException('Only the shipment buyer can create a template from it');
+    }
+
+    const msPerDay = 24 * 60 * 60 * 1000;
+    const milestoneTemplates = shipment.milestones.map((m) => ({
+      name: m.name,
+      paymentPercent: m.paymentPercent,
+      ...(m.dueAt
+        ? { dueDays: Math.round((m.dueAt.getTime() - shipment.createdAt.getTime()) / msPerDay) }
+        : {}),
+    }));
+
+    this.validateMilestonePercentages(milestoneTemplates);
+
+    return this.prisma.shipmentTemplate.create({
+      data: {
+        ownerId,
+        name: dto.name,
+        description: dto.description,
+        supplierAddress: shipment.supplierAddress,
+        logisticsAddress: shipment.logisticsAddress,
+        arbiterAddress: shipment.arbiterAddress,
+        tokenAddress: shipment.tokenAddress,
+        milestoneTemplates: milestoneTemplates as any,
+        isPublic: dto.isPublic ?? false,
+      },
+    });
   }
 
   async findOne(id: string) {


### PR DESCRIPTION
Closes #177, Closes #180, Closes #181, Closes #182

## Summary

This PR adds IPFS pin status checking, admin user deactivation/reactivation controls, shipment-to-template derivation, and admin single-user detail aggregations to `chainsettle-backend`.

---

## Key Changes

### 1. IPFS Pin Status Check (#182)
- **`src/common/ipfs/`**: Added `GET /ipfs/:cid/status` in `IpfsController` and `checkPinStatus` in `IpfsService`.
- Issues a lightweight `HEAD` request to the IPFS gateway to return `{ cid, pinned: true, sizeBytes }` without fetching file content. Gracefully handles 404/unpinned CIDs by returning `{ cid, pinned: false }`. Protected by `@Throttle()` rate limiting.

### 2. Admin Account Suspension & Reactivation (#181)
- **`src/modules/auth/`**: Added `POST /users/admin/:id/deactivate` and `POST /users/admin/:id/reactivate` restricted to `UserRole.ADMIN`.
- **Logic**: Reuses `deactivatedAt`, bypasses active shipment checks (allowing admin intervention during investigations), and blocks admin self-deactivation (`400 Bad Request`). Writes `ADMIN_USER_DEACTIVATED` and `ADMIN_USER_REACTIVATED` audit log entries.

### 3. Template Creation from Shipment (#177)
- **`src/modules/shipment-templates/`**: Added `POST /shipment-templates/from-shipment/:id` restricted to shipment buyers via `ShipmentParticipantGuard`.
- Maps existing shipment milestones into template entries, computing relative `dueDays` offsets (`dueAt - createdAt`) and copying participant roles (`supplierAddress`, `logisticsAddress`, `arbiterAddress`, `tokenAddress`).

### 4. Admin Single-User Operational Detail (#180)
- **`src/modules/auth/`**: Added `GET /users/admin/:id` for `UserRole.ADMIN`.
- Computes operational counts (`shipmentCount`, `activeApiKeyCount`, `webhookCount`, `unreadNotificationCount`) alongside full user metadata using efficient parallel Prisma `count()` queries (preventing N+1 query overhead).

---

## Verification

- [x] **Route Alignment**: Verified endpoints adhere to existing `users/admin/` and `shipment-templates/` controller route patterns.
- [x] **Audit & Security**: Verified self-deactivation prevention and immutable audit log writes.
- [x] **Compilation**: Verified local TypeScript compilation and Jest unit tests.