### PR TITLE
feat: add POST /shipments/import — CSV bulk import of draft shipments (#162)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "compression": "^1.8.1",
+        "csv-parse": "^5.6.0",
         "form-data": "^4.0.5",
         "handlebars": "^4.7.9",
         "helmet": "^7.1.0",
@@ -5468,6 +5469,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
     },
     "node_modules/dag-jose": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "compression": "^1.8.1",
+    "csv-parse": "^5.6.0",
     "form-data": "^4.0.5",
     "handlebars": "^4.7.9",
     "helmet": "^7.1.0",

--- a/prisma/migrations/add_isDraft_to_shipments/migration.sql
+++ b/prisma/migrations/add_isDraft_to_shipments/migration.sql
@@ -1,0 +1,6 @@
+-- Migration: add_isDraft_to_shipments
+-- Issue #162: Add isDraft column to support CSV bulk import of draft shipments
+
+ALTER TABLE shipments ADD COLUMN IF NOT EXISTS is_draft BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN shipments.is_draft IS 'True when created via CSV bulk import; no on-chain backing yet';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,6 +153,8 @@ model Shipment {
   trackingUpdates TrackingUpdate[]
   watchers  ShipmentWatcher[]
 
+  isDraft          Boolean         @default(false) // true when created via CSV bulk import; no on-chain backing yet
+
   @@map("shipments")
 }
 

--- a/src/modules/shipments/dto/find-all-shipments.dto.ts
+++ b/src/modules/shipments/dto/find-all-shipments.dto.ts
@@ -89,4 +89,10 @@ export class FindAllShipmentsDto {
   @IsBoolean()
   @Transform(({ value }) => value === 'true' || value === true)
   includeArchived?: boolean;
+
+  @ApiPropertyOptional({ description: 'Filter by draft status (true = drafts only, false = on-chain only, omit = both)' })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true' || value === true)
+  isDraft?: boolean;
 }

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -10,6 +10,8 @@ import {
   Query,
   Res,
   UseGuards,
+  UseInterceptors,
+  UploadedFile,
   HttpCode,
   HttpStatus,
   ForbiddenException,
@@ -23,8 +25,12 @@ import {
   ApiResponse,
   ApiQuery,
   ApiBearerAuth,
+  ApiConsumes,
+  ApiBody,
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
 import { ShipmentsService } from './shipments.service';
 import { CreateShipmentDto, UpdateShipmentDto, CancelShipmentDto, CloneShipmentDto, BulkStatusDto } from './dto/create-shipment.dto';
 import { CreateTrackingDto } from './dto/tracking.dto';
@@ -103,6 +109,7 @@ export class ShipmentsController {
       isAdmin,
       includeArchived: query.includeArchived,
       search: query.search,
+      isDraft: query.isDraft,
     });
   }
 
@@ -154,6 +161,56 @@ export class ShipmentsController {
   bulkStatus(@Body() dto: BulkStatusDto, @CurrentUser() user: any) {
     const isAdmin = user?.role === UserRole.ADMIN;
     return this.shipmentsService.bulkStatus(dto.ids, user.stellarAddress, isAdmin);
+  }
+
+  /**
+   * POST /api/v1/shipments/import
+   * Bulk-import draft shipments from a CSV file.
+   * Accepts multipart/form-data with a "file" field containing the CSV.
+   * Each row creates a single draft shipment (isDraft=true, no on-chain backing).
+   * Maximum 100 rows per request; rows beyond that are rejected with 400.
+   * Malformed rows are reported individually — valid rows still succeed.
+   */
+  @Post('import')
+  @HttpCode(HttpStatus.CREATED)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+      limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB max
+    }),
+  )
+  @ApiOperation({ summary: 'Bulk-import draft shipments from CSV (max 100 rows)' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description:
+            'CSV file with columns: supplierAddress, logisticsAddress, arbiterAddress, ' +
+            'tokenAddress, totalAmount, description, referenceNumber',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Import results with per-row status' })
+  @ApiResponse({ status: 400, description: 'File too large, no file, or too many rows' })
+  async importCsv(
+    @UploadedFile() file: Express.Multer.File,
+    @CurrentUser() user: any,
+  ) {
+    if (!file) {
+      throw new BadRequestException('A CSV file must be provided in the "file" field');
+    }
+
+    return this.shipmentsService.importDrafts(
+      user?.id,
+      user?.stellarAddress ?? user?.sub,
+      file.buffer,
+    );
   }
 
   /**

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -21,6 +21,7 @@ import { CreateTrackingDto } from './dto/tracking.dto';
 import { ShipmentStatus, NotificationType, ArbiterStatus } from '@prisma/client';
 import { nativeToScVal } from '@stellar/stellar-sdk';
 import { randomUUID } from 'crypto';
+import { parse } from 'csv-parse/sync';
 import Ajv from 'ajv';
 import { metadataSchemas } from './schemas/metadata.schemas';
 
@@ -188,6 +189,7 @@ export class ShipmentsService {
     isAdmin?: boolean;
     includeArchived?: boolean;
     search?: string;
+    isDraft?: boolean;
   }) {
     const {
       buyerAddress,
@@ -206,6 +208,7 @@ export class ShipmentsService {
       isAdmin = false,
       includeArchived = false,
       search,
+      isDraft,
     } = filters;
 
     if (cursor && page && page !== 1) {
@@ -239,6 +242,10 @@ export class ShipmentsService {
 
     if (!includeArchived) {
       where.archivedAt = null;
+    }
+
+    if (isDraft !== undefined) {
+      where.isDraft = isDraft;
     }
 
     // Scope to shipments where the caller is a participant (buyer/supplier/logistics/arbiter)
@@ -1588,6 +1595,154 @@ export class ShipmentsService {
         ),
       },
     };
+  }
+
+  // ----------------------------------------------------------
+  // CSV BULK IMPORT — create draft shipments from CSV
+  // ----------------------------------------------------------
+
+  /**
+   * Parses a CSV buffer and creates draft shipment records.
+   * Each row is processed independently — a malformed row does not affect
+   * valid rows. The caller (buyer) is set as the buyerAddress for all rows.
+   *
+   * CSV columns (case-insensitive header):
+   *   supplierAddress, logisticsAddress, arbiterAddress, tokenAddress,
+   *   totalAmount, description, referenceNumber
+   *
+   * @returns Per-row result array with { row, status, shipmentId?, error? }
+   */
+  async importDrafts(
+    userId: string,
+    buyerAddress: string,
+    csvBuffer: Buffer,
+  ): Promise<{ results: Array<{ row: number; status: 'created' | 'error'; shipmentId?: string; error?: string }> }> {
+    const raw: string = csvBuffer.toString('utf-8').replace(/^\uFEFF/, ''); // strip BOM
+
+    const records: any[] = parse(raw, {
+      columns: true,
+      skip_empty_lines: true,
+      trim: true,
+      relax_column_count: true,
+      relax_quotes: true,
+    });
+
+    if (records.length > 100) {
+      throw new BadRequestException(
+        `CSV file has ${records.length} rows; maximum allowed is 100 rows per import.`,
+      );
+    }
+
+    const results: Array<{ row: number; status: 'created' | 'error'; shipmentId?: string; error?: string }> = [];
+    const tokenRegistry = this.tokenRegistry;
+
+    for (let i = 0; i < records.length; i++) {
+      const rowNum = i + 2; // 1-indexed + header row
+      const r = records[i];
+
+      try {
+        // Normalise header names (case-insensitive)
+        const supplierAddress = (r.supplierAddress ?? r.supplieraddress ?? '').trim();
+        const logisticsAddress = (r.logisticsAddress ?? r.logisticsaddress ?? '').trim();
+        const arbiterAddress = (r.arbiterAddress ?? r.arbiteraddress ?? '').trim();
+        const tokenAddress = (r.tokenAddress ?? r.tokenaddress ?? '').trim();
+        const totalAmount = (r.totalAmount ?? r.totalamount ?? '').trim();
+        const description = (r.description ?? '').trim();
+        const referenceNumber = (r.referenceNumber ?? r.referencenumber ?? '').trim();
+
+        // Validate required fields
+        if (!supplierAddress) throw new Error('supplierAddress is required');
+        if (!logisticsAddress) throw new Error('logisticsAddress is required');
+        if (!arbiterAddress) throw new Error('arbiterAddress is required');
+        if (!tokenAddress) throw new Error('tokenAddress is required');
+        if (!totalAmount) throw new Error('totalAmount is required');
+
+        // Validate totalAmount is a positive integer string
+        const amountMatch = totalAmount.match(/^\d+$/);
+        if (!amountMatch) {
+          throw new Error(`totalAmount must be a positive integer (got "${totalAmount}")`);
+        }
+        const amountBigInt = BigInt(totalAmount);
+        if (amountBigInt <= 0n) {
+          throw new Error(`totalAmount must be greater than 0 (got ${totalAmount})`);
+        }
+
+        // Validate description length
+        if (description && description.length > 1000) {
+          throw new Error('description must be at most 1000 characters');
+        }
+
+        // Check for duplicate referenceNumber
+        if (referenceNumber) {
+          const existing = await this.prisma.shipment.findUnique({
+            where: { referenceNumber },
+          });
+          if (existing) {
+            throw new Error(`referenceNumber "${referenceNumber}" is already in use by shipment ${existing.id}`);
+          }
+        }
+
+        // Resolve token metadata
+        let token: { decimals: number; symbol: string };
+        try {
+          token = tokenRegistry.getToken(tokenAddress);
+        } catch {
+          throw new Error(`Unknown tokenAddress "${tokenAddress}"`);
+        }
+
+        const shipmentId = randomUUID();
+
+        const shipment = await this.prisma.shipment.create({
+          data: {
+            id: shipmentId,
+            buyerAddress,
+            supplierAddress,
+            logisticsAddress,
+            arbiterAddress,
+            tokenAddress,
+            tokenDecimals: token.decimals,
+            tokenSymbol: token.symbol,
+            totalAmount: amountBigInt,
+            description: description || null,
+            referenceNumber: referenceNumber || null,
+            isDraft: true,
+            // Draft shipments have no txHash, createdLedger, milestones, or on-chain backing
+          },
+        });
+
+        results.push({
+          row: rowNum,
+          status: 'created',
+          shipmentId: shipment.id,
+        });
+      } catch (err: any) {
+        results.push({
+          row: rowNum,
+          status: 'error',
+          error: err.message || 'Unknown error',
+        });
+      }
+    }
+
+    await this.auditLog.record({
+      actorId: userId,
+      actorAddress: buyerAddress,
+      action: 'shipment.csv_import',
+      resourceType: 'Shipment',
+      metadata: {
+        totalRows: records.length,
+        created: results.filter((r) => r.status === 'created').length,
+        errors: results.filter((r) => r.status === 'error').length,
+      },
+    });
+
+    this.logger.log(
+      `CSV import completed by buyer ${buyerAddress}: ` +
+        `${results.filter((r) => r.status === 'created').length} created, ` +
+        `${results.filter((r) => r.status === 'error').length} errors`,
+    );
+
+    return { results };
   }
 
   // ----------------------------------------------------------


### PR DESCRIPTION
## Description

Closes #162

This PR adds a **POST /shipments/import** endpoint for bulk-creating draft shipment records from a CSV file, enabling suppliers to onboard many trade relationships at once without requiring individual on-chain transactions.

### Changes Made

#### Database (`prisma/schema.prisma` + migration)
- Added `isDraft` Boolean column (`@default(false)`) to the `Shipment` model
- Draft shipments are clearly distinguishable from on-chain-backed shipments
- Created migration `add_isDraft_to_shipments/migration.sql`

#### Service (`src/modules/shipments/shipments.service.ts`)
- Added `importDrafts(userId, buyerAddress, csvBuffer)` method:
  - Parses CSV using `csv-parse/sync` with column mapping
  - Supported columns: `supplierAddress`, `logisticsAddress`, `arbiterAddress`, `tokenAddress`, `totalAmount`, `description`, `referenceNumber`
  - Per-row validation with independent try/catch — malformed rows never block valid ones
  - Validates: required fields, positive integer `totalAmount`, description max 1000 chars, duplicate `referenceNumber`, token registry resolution
  - Caps at **100 rows** — rejects larger files with `400 Bad Request` before any DB writes
  - Creates each row as a draft shipment (`isDraft: true`) with auto-generated UUID
  - Returns per-row result array: `{ row, status: 'created' | 'error', shipmentId?, error? }`
  - Records audit log entry on completion

#### Controller (`src/modules/shipments/shipments.controller.ts`)
- Added `POST /shipments/import` endpoint:
  - Accepts `multipart/form-data` with a `file` field (CSV)
  - Uses `FileInterceptor` with `memoryStorage()` (same pattern as milestone proof uploads)
  - 5 MB file size limit
  - Protected by `JwtAuthGuard` (class-level)
  - Fully documented with Swagger decorators

#### Filtering (`dto/find-all-shipments.dto.ts` + controller + service)
- Added optional `isDraft` query parameter to `GET /shipments`
  - `?isDraft=true` — shows only draft shipments
  - `?isDraft=false` — shows only on-chain-backed shipments
  - Omitted — shows both (existing behavior)

#### Dependencies
- Added `csv-parse` ^5.x for robust CSV parsing with edge-case handling

### Acceptance Criteria
✅ CSV with one malformed row still imports valid rows and reports the bad one by row number
✅ Draft shipments are clearly distinguishable from on-chain-backed shipments via `?isDraft` filter
✅ Files over 100 rows are rejected with 400 before any DB writes
✅ Per-row result array with `row`, `status`, `shipmentId`, and `error` fields
✅ No on-chain transaction triggered — draft records only

Closes #162
