### PR TITLE
feat: add DELETE /shipments/:id/milestones/:index — remove pending milestone (#165)

### DIFF
--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -218,6 +218,32 @@ export class MilestonesController {
   }
 
   /**
+   * DELETE /api/v1/shipments/:shipmentId/milestones/:index
+   * Remove a still-pending milestone from a shipment.
+   * Only allowed when ALL milestones on the shipment (including the target)
+   * are still PENDING. The removed milestone's data is captured in the audit log.
+   * Restricted to the shipment buyer.
+   */
+  @Delete(':index')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'Remove a still-pending milestone (buyer only)' })
+  @ApiResponse({ status: 200, description: 'Milestone removed' })
+  @ApiResponse({ status: 400, description: 'Cannot remove the only milestone' })
+  @ApiResponse({ status: 403, description: 'Not the shipment buyer' })
+  @ApiResponse({ status: 404, description: 'Milestone not found' })
+  @ApiResponse({ status: 409, description: 'Milestone not PENDING or work has started' })
+  removeMilestone(
+    @Param('shipmentId') shipmentId: string,
+    @Param('index', ParseIntPipe) index: number,
+    @CurrentUser() user: any,
+  ) {
+    const callerAddress: string = user?.stellarAddress ?? user?.sub;
+    const callerId: string | undefined = user?.id;
+    return this.milestonesService.removeMilestone(shipmentId, index, callerAddress, callerId);
+  }
+
+  /**
    * GET /api/v1/shipments/:shipmentId/milestones/:index/proof-history
    * Returns the full proof submission history for a milestone, ordered chronologically.
    */

--- a/src/modules/milestones/milestones.module.ts
+++ b/src/modules/milestones/milestones.module.ts
@@ -6,9 +6,10 @@ import { MilestoneDeadlineJob } from './milestone-deadline.job';
 import { DisputeEscalationJob } from './dispute-escalation.job';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { ShipmentsModule } from '../shipments/shipments.module';
+import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 
 @Module({
-  imports: [NotificationsModule, ShipmentsModule],
+  imports: [NotificationsModule, ShipmentsModule, AuditLogsModule],
   controllers: [MilestonesController],
   providers: [MilestonesService, MilestoneDeadlineJob, DisputeEscalationJob],
   exports: [MilestonesService],

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -10,6 +10,7 @@ import { PrismaService } from '../../common/prisma/prisma.service';
 import { IpfsService } from '../../common/ipfs/ipfs.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { ShipmentsService } from '../shipments/shipments.service';
+import { AuditLogService } from '../audit-logs/audit-log.service';
 import { MilestoneStatus, NotificationType, DisputeRole, ArbiterStatus } from '@prisma/client';
 
 @Injectable()
@@ -21,6 +22,7 @@ export class MilestonesService {
     private readonly ipfs: IpfsService,
     private readonly notifications: NotificationsService,
     private readonly shipments: ShipmentsService,
+    private readonly auditLog: AuditLogService,
   ) {}
 
   async findByShipment(shipmentId: string, status?: string, overdueOnly = false) {
@@ -676,6 +678,109 @@ export class MilestonesService {
       submittedBy: s.submittedBy,
       createdAt: s.createdAt.toISOString(),
     }));
+  }
+
+  // ----------------------------------------------------------
+  // REMOVE MILESTONE — delete a still-pending milestone
+  // ----------------------------------------------------------
+
+  /**
+   * Removes a pending milestone from a shipment. Only allowed when ALL
+   * milestones on the shipment (including the target) are still PENDING.
+   * Restricted to the shipment buyer.
+   *
+   * The removed milestone's data is preserved in an audit log entry.
+   */
+  async removeMilestone(
+    shipmentId: string,
+    milestoneIndex: number,
+    callerAddress: string,
+    callerId?: string,
+  ) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    }
+
+    if (shipment.buyerAddress !== callerAddress) {
+      throw new ForbiddenException('Only the shipment buyer may remove milestones');
+    }
+
+    const milestone = await this.prisma.milestone.findUnique({
+      where: { shipmentId_milestoneIndex: { shipmentId, milestoneIndex } },
+    });
+
+    if (!milestone) {
+      throw new NotFoundException(
+        `Milestone ${milestoneIndex} not found on shipment ${shipmentId}`,
+      );
+    }
+
+    // Reject if the target milestone has left PENDING
+    if (milestone.status !== MilestoneStatus.PENDING) {
+      throw new ConflictException(
+        `Cannot remove milestone ${milestoneIndex} ("${milestone.name}"): ` +
+        `status is ${milestone.status}, expected PENDING.`,
+      );
+    }
+
+    const allMilestones = await this.prisma.milestone.findMany({
+      where: { shipmentId },
+    });
+
+    // Reject if any OTHER milestone has left PENDING
+    const otherNonPending = allMilestones.find(
+      (m) => m.milestoneIndex !== milestoneIndex && m.status !== MilestoneStatus.PENDING,
+    );
+    if (otherNonPending) {
+      throw new ConflictException(
+        `Cannot remove milestone: milestone ${otherNonPending.milestoneIndex} ("${otherNonPending.name}") ` +
+        `is in status ${otherNonPending.status}, expected PENDING. ` +
+        `Work has already started on this shipment.`,
+      );
+    }
+
+    // Reject if this is the only remaining milestone
+    if (allMilestones.length <= 1) {
+      throw new BadRequestException(
+        'Cannot remove the only milestone on a shipment. A shipment must have at least one milestone.',
+      );
+    }
+
+    // Capture milestone data for audit before deletion
+    const milestoneData = {
+      id: milestone.id,
+      milestoneIndex: milestone.milestoneIndex,
+      name: milestone.name,
+      paymentPercent: milestone.paymentPercent,
+      status: milestone.status,
+      dueAt: milestone.dueAt?.toISOString() ?? null,
+    };
+
+    await this.prisma.milestone.delete({
+      where: { id: milestone.id },
+    });
+
+    await this.auditLog.record({
+      actorId: callerId,
+      actorAddress: callerAddress,
+      action: 'milestone.removed',
+      resourceType: 'Milestone',
+      resourceId: milestone.id,
+      metadata: {
+        shipmentId,
+        removedMilestone: milestoneData,
+      },
+    });
+
+    this.logger.log(
+      `Milestone ${milestoneIndex} ("${milestone.name}") removed from ${shipmentId} by buyer ${callerAddress}`,
+    );
+
+    return { removed: true, milestone: milestoneData };
   }
 
   // ----------------------------------------------------------


### PR DESCRIPTION
## Description

Closes #165

This PR adds a **DELETE /shipments/:id/milestones/:index** endpoint that allows a buyer to remove a still-pending milestone from a shipment. This is the companion to issue #164 (append milestone) — if a milestone was added by mistake or the parties change their minds before any proof has been submitted, they can now remove it.

### Changes Made

#### Module (`src/modules/milestones/milestones.module.ts`)
- Added `AuditLogsModule` to imports so the service can record audit log entries for milestone removal

#### Service (`src/modules/milestones/milestones.service.ts`)
- Added `removeMilestone(shipmentId, milestoneIndex, callerAddress, callerId?)` method:
  - **404** — shipment or milestone not found
  - **403** — caller is not the shipment buyer
  - **409** — target milestone's status is not `PENDING` (work may have started)
  - **409** — any OTHER milestone on the shipment has left `PENDING` (work has started elsewhere)
  - **400** — this is the shipment's **only remaining milestone** (a shipment must have at least one)
  - Captures the milestone's full data **before deletion** into a `milestoneData` object
  - Deletes the milestone row
  - Writes an `AuditLog` entry with `action: 'milestone.removed'` containing the captured milestone data in `metadata.removedMilestone`
  - Returns `{ removed: true, milestone: milestoneData }`

#### Controller (`src/modules/milestones/milestones.controller.ts`)
- Added `DELETE /shipments/:shipmentId/milestones/:index` endpoint:
  - Protected by `@UseGuards(ShipmentParticipantGuard)` + class-level `JwtAuthGuard`
  - Restricted to the shipment buyer (enforced in service)
  - Passes `user.id` as `callerId` for audit logging
  - Fully documented with Swagger decorators

### Acceptance Criteria
- ✅ Removing the **last remaining milestone** returns **400 Bad Request**
- ✅ Removing a milestone once **any milestone has left PENDING** returns **409 Conflict**
- ✅ The removed milestone's data is **captured in the audit log**, not lost
- ✅ Audit log entry includes `milestoneIndex`, `name`, `paymentPercent`, `status`, `dueAt`

Closes #165
