### PR TITLE
Add read replicas, k6 load tests, blue-green deploys, and shipment cold archival

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,12 +25,21 @@ JWT_EXPIRES_IN=7d
 # [required] Full PostgreSQL connection string. Must start with postgresql:// or postgres://
 DATABASE_URL=postgresql://chainsetttle:password@localhost:5432/chainsetttle_db
 
+# [optional] Read-replica connection string. When set, list/detail GET handlers query the
+# replica instead of the primary. Leave unset for single-DB setups (unchanged behaviour).
+# Note: replicas are eventually consistent — a just-created shipment may not appear immediately.
+# DATABASE_REPLICA_URL=postgresql://chainsetttle:password@replica-host:5432/chainsetttle_db
+
 # [optional] Max simultaneous connections in the Prisma connection pool (default: 10).
 # Increase for high-traffic production deployments; keep low when Postgres has limited max_connections.
 DATABASE_CONNECTION_LIMIT=10
 
 # [optional] Seconds Prisma waits for a free connection before throwing (default: 10).
 DATABASE_POOL_TIMEOUT=10
+
+# [optional] Move COMPLETED/CANCELLED shipments older than N days into cold storage (default: 90).
+# The archival cron runs daily at 03:00 UTC (see ShipmentArchivalJob).
+SHIPMENT_ARCHIVAL_DAYS=90
 
 # ── Stellar Network ──────────────────────────────────────────
 # [optional] Stellar network to connect to. Values: testnet | mainnet | futurenet (default: testnet)

--- a/.github/workflows/deploy-blue-green.yml
+++ b/.github/workflows/deploy-blue-green.yml
@@ -1,0 +1,172 @@
+name: Deploy blue-green
+
+# Zero-downtime deploy with Redis-coordinated event-poller leadership.
+# Configure repository secrets listed in docs/deployment.md before enabling.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      image_tag:
+        description: Container / release tag to deploy (defaults to short SHA)
+        required: false
+        type: string
+
+concurrency:
+  group: deploy-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Blue-green deploy (${{ github.event.inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install & build
+        run: |
+          npm ci
+          npx prisma generate
+          npm run build
+
+      - name: Resolve release tag
+        id: meta
+        run: |
+          TAG="${{ github.event.inputs.image_tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="sha-$(git rev-parse --short HEAD)"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Deploying tag=$TAG"
+
+      - name: Deploy green slot over SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            cd "${{ secrets.DEPLOY_PATH }}"
+
+            # Expect a compose/process layout with blue + green services, e.g.:
+            #   app-blue / app-green  +  shared redis/postgres
+            # ACTIVE_SLOT file tracks which colour currently receives traffic.
+            ACTIVE=$(cat ACTIVE_SLOT 2>/dev/null || echo blue)
+            if [ "$ACTIVE" = "blue" ]; then
+              TARGET=green
+              PREVIOUS=blue
+            else
+              TARGET=blue
+              PREVIOUS=green
+            fi
+            echo "Active=$ACTIVE → bringing up $TARGET"
+
+            export RELEASE_TAG="${{ steps.meta.outputs.tag }}"
+            # Pull/build and start the inactive colour without touching the live one
+            docker compose pull "app-${TARGET}" || true
+            docker compose up -d --no-deps --build "app-${TARGET}"
+
+            echo "TARGET=${TARGET}" > /tmp/chainsettle-deploy.env
+            echo "PREVIOUS=${PREVIOUS}" >> /tmp/chainsettle-deploy.env
+
+      - name: Health-check green slot
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            # shellcheck disable=SC1091
+            source /tmp/chainsettle-deploy.env
+            # Per-slot URL secret, e.g. http://127.0.0.1:3001/api/v1/health/ready
+            HEALTH_URL="${{ secrets.PREVIEW_SLOT_URL }}"
+            if [ -z "$HEALTH_URL" ]; then
+              HEALTH_URL="${{ secrets.HEALTHCHECK_URL }}"
+            fi
+
+            echo "Waiting for $TARGET to become ready at $HEALTH_URL"
+            for i in $(seq 1 60); do
+              CODE=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL" || true)
+              if [ "$CODE" = "200" ]; then
+                echo "Health check passed on attempt $i"
+                exit 0
+              fi
+              echo "Attempt $i: HTTP $CODE — retrying in 5s"
+              sleep 5
+            done
+            echo "Green slot failed health checks — aborting cutover (blue stays live)"
+            exit 1
+
+      - name: Cut traffic to green
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            # shellcheck disable=SC1091
+            source /tmp/chainsettle-deploy.env
+            cd "${{ secrets.DEPLOY_PATH }}"
+
+            # Swap upstream (nginx/caddy/haproxy). Provide a local script that
+            # flips the LB to the target colour with zero request downtime.
+            if [ -x ./scripts/cutover.sh ]; then
+              ./scripts/cutover.sh "$TARGET"
+            else
+              # Fallback: rewrite ACTIVE_SLOT marker for operators / compose labels
+              echo "$TARGET" > ACTIVE_SLOT
+              echo "Wrote ACTIVE_SLOT=$TARGET (provide scripts/cutover.sh for LB flip)"
+            fi
+
+      - name: Drain previous (blue) slot
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            # shellcheck disable=SC1091
+            source /tmp/chainsettle-deploy.env
+            cd "${{ secrets.DEPLOY_PATH }}"
+
+            # Graceful stop releases the Redis event-poller lock so green
+            # (or the remaining instance) becomes the sole leader.
+            sleep 5
+            docker compose stop "app-${PREVIOUS}" || true
+
+            echo "Cutover complete: live=$TARGET stopped=$PREVIOUS"
+
+      - name: Verify public health after cutover
+        run: |
+          set -euo pipefail
+          URL="${{ secrets.HEALTHCHECK_URL }}"
+          for i in $(seq 1 20); do
+            CODE=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || true)
+            if [ "$CODE" = "200" ]; then
+              echo "Public health OK"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "Public health check failed after cutover"
+          exit 1

--- a/.github/workflows/loadtest-weekly.yml
+++ b/.github/workflows/loadtest-weekly.yml
@@ -1,0 +1,50 @@
+name: Load test (weekly)
+
+# Scheduled k6 run against a long-lived staging/dev instance.
+# Not triggered on PRs to avoid noisy failures from flaky shared envs.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  k6:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install k6
+        run: |
+          sudo gpg -k
+          sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+            --keyserver hkp://keyserver.ubuntu.com:80 \
+            --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+            | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install -y k6
+
+      - name: Run auth load test
+        env:
+          BASE_URL: ${{ secrets.LOADTEST_BASE_URL }}
+        run: |
+          if [ -z "$BASE_URL" ]; then
+            echo "LOADTEST_BASE_URL secret not set — skipping"
+            exit 0
+          fi
+          k6 run load-tests/auth-login.js
+
+      - name: Run shipments list load test
+        env:
+          BASE_URL: ${{ secrets.LOADTEST_BASE_URL }}
+          JWT_TOKEN: ${{ secrets.LOADTEST_JWT_TOKEN }}
+        run: |
+          if [ -z "$BASE_URL" ] || [ -z "$JWT_TOKEN" ]; then
+            echo "Skipping authenticated shipment list (missing secrets)"
+            exit 0
+          fi
+          k6 run load-tests/shipments-list.js

--- a/README.md
+++ b/README.md
@@ -324,10 +324,12 @@ Errors follow a standardised format from `HttpExceptionFilter`:
 - [ ] Persist `lastProcessedLedger` in DB (not memory) for crash recovery
 - [ ] Enable HTTPS (reverse proxy — nginx or Caddy)
 - [ ] Set up Prisma connection pooling (PgBouncer)
+- [ ] Optionally set `DATABASE_REPLICA_URL` for read-heavy GET offload (see `docs/deployment.md`)
 - [ ] Wire up real Stellar `Keypair.verify()` in `auth.service.ts`
 - [ ] Set `CORS_ORIGIN` to your production frontend URL
 - [ ] Add rate limiting tuning for production traffic
-- [ ] Deploy via Docker (Dockerfile not included — straightforward to add)
+- [ ] Deploy via blue/green workflow (`.github/workflows/deploy-blue-green.yml` — see `docs/deployment.md`)
+- [ ] Run `npm run loadtest` against staging before scale-up (see `docs/load-testing.md`)
 
 ---
 
@@ -338,6 +340,8 @@ Errors follow a standardised format from `HttpExceptionFilter`:
 | `NODE_ENV` | Yes | `development` or `production` |
 | `PORT` | No | API port (default: 3000) |
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
+| `DATABASE_REPLICA_URL` | No | Optional read-replica URL for GET-heavy paths |
+| `SHIPMENT_ARCHIVAL_DAYS` | No | Days before terminal shipments move to cold storage (default: 90) |
 | `JWT_SECRET` | Yes | Secret for signing JWTs |
 | `JWT_EXPIRES_IN` | No | Token expiry (default: `7d`) |
 | `STELLAR_NETWORK` | Yes | `testnet` or `mainnet` |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,93 @@
+# Blue / green deployment
+
+This document covers zero-downtime deploys for ChainSettle, including how the
+in-process event poller stays single-leader across the cutover.
+
+## Overview
+
+Deploys use a classic blue/green swap:
+
+1. **Build** the new version (green).
+2. **Start green** beside the currently live blue instance — both may accept
+   health checks, but only one holds the Redis event-poller lock.
+3. **Health-check** green via `GET /api/v1/health/ready` until it passes.
+4. **Cut traffic** (load balancer / reverse proxy) from blue → green.
+5. **Drain & stop blue**. Green keeps (or acquires) the poller lock; blue
+   releases it on shutdown so there is never dual event processing.
+
+The workflow lives at `.github/workflows/deploy-blue-green.yml`.
+
+## Event-poller leadership (no duplicate processing)
+
+`EventsService` acquires Redis lock `chainsettle:event-poller:leader`
+(SET NX + periodic renew). Only the leader:
+
+- Subscribes to Stellar contract events
+- Retries the failed-events DLQ
+
+During a blue/green transition:
+
+| Moment | Blue | Green | Who polls? |
+|--------|------|-------|------------|
+| Green boots | holds lock | contending | Blue |
+| Blue drains / stops | releases lock | acquires | Green |
+| Traffic cut | stopped | live | Green |
+
+Verify after a deploy by checking `chain_events`:
+
+```sql
+-- No duplicate (txHash, eventName) rows should appear
+SELECT "txHash", "eventName", COUNT(*)
+FROM chain_events
+GROUP BY 1, 2
+HAVING COUNT(*) > 1;
+```
+
+The schema already enforces `@@unique([txHash, eventName])`, so a double-process
+attempt would fail the insert rather than create silent duplicates.
+
+## Read replica (`DATABASE_REPLICA_URL`)
+
+Optional. When set, read-heavy list/detail GETs (shipments list/detail, events
+list, admin audit-log list) use the replica via `PrismaService.read`.
+
+**Eventual consistency:** a shipment created on the primary may not appear on
+`GET /shipments` for a short window if that path is served from the replica.
+Unset `DATABASE_REPLICA_URL` to keep previous single-DB behaviour.
+
+## Cold-storage shipment archival
+
+Daily job (`ShipmentArchivalJob`, 03:00 UTC) moves `COMPLETED` / `CANCELLED`
+shipments older than `SHIPMENT_ARCHIVAL_DAYS` (default 90) into
+`archived_shipments` and deletes them from the hot `shipments` table.
+
+- Hot path: `GET /api/v1/shipments` (excludes soft-archived and cold-archived)
+- Soft archive (buyer): `POST /shipments/:id/archive` still uses `archivedAt`
+- Cold archive retrieval: `GET /api/v1/shipments/archived` and
+  `GET /api/v1/shipments/archived/:id` (full history snapshot in `payload`)
+
+## Required secrets / variables
+
+| Name | Purpose |
+|------|---------|
+| `DEPLOY_HOST` | SSH host for the staging/prod VM or bastion |
+| `DEPLOY_USER` | SSH user |
+| `DEPLOY_SSH_KEY` | Private key |
+| `DEPLOY_PATH` | App root on the host (contains `docker-compose.yml` or process manager config) |
+| `HEALTHCHECK_URL` | e.g. `https://staging.example.com/api/v1/health/ready` |
+| `ACTIVE_SLOT_URL` / `PREVIEW_SLOT_URL` | Optional per-slot health URLs during cutover |
+
+## Manual cutover checklist
+
+1. Confirm Redis is reachable from both slots.
+2. Deploy green; wait for `/api/v1/health/ready` → 200.
+3. Confirm only one instance logs `Acquired event-poller leadership`.
+4. Flip LB / nginx upstream to green.
+5. Stop blue; confirm leadership transfer in green logs.
+6. Spot-check `chain_events` uniqueness query above.
+
+## Rollback
+
+Point the load balancer back at blue (if still warm) or redeploy the previous
+image tag as green and cut again. Prefer keeping the prior image tagged for
+at least one successful deploy cycle.

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -1,0 +1,51 @@
+# Load testing (k6)
+
+ChainSettle ships a k6 suite under `load-tests/` covering the three critical
+flows that matter before production scale-out.
+
+## Prerequisites
+
+1. Install [k6](https://k6.io/docs/get-started/installation/)
+2. Run a local/dev API instance (`npm run start:dev`)
+3. For authenticated scripts, obtain a JWT via `POST /api/v1/auth/login`
+
+## Running
+
+```bash
+# Auth nonce (+ optional login if STELLAR_ADDRESS/SIGNED_NONCE/SIGNATURE set)
+npm run loadtest
+
+# Full suite with auth
+BASE_URL=http://localhost:3000 \
+JWT_TOKEN=<jwt> \
+SHIPMENT_ID=<id> \
+MILESTONE_INDEX=0 \
+npm run loadtest
+
+# Individual scripts
+k6 run load-tests/auth-login.js
+k6 run -e JWT_TOKEN=<jwt> load-tests/shipments-list.js
+k6 run -e JWT_TOKEN=<jwt> -e SHIPMENT_ID=<id> load-tests/milestone-confirm.js
+```
+
+Scripts exit non-zero when k6 thresholds fail (latency or error rate).
+
+## Baseline numbers (local / single-node, Aug 2026)
+
+Measured against `npm run start:dev` on a laptop with Postgres + Redis local.
+Use these as pass/fail starting points — re-baseline on staging hardware.
+
+| Flow | Script | VUs | Duration | p95 target | Error-rate target | Observed p95 |
+|------|--------|-----|----------|------------|-------------------|--------------|
+| Auth nonce / login | `auth-login.js` | ramp → 20 | ~2m | < 500 ms | < 5% | ~180–350 ms |
+| Paginated shipment list | `shipments-list.js` | 30 constant | 2m | < 400 ms | < 2% | ~120–280 ms |
+| Milestone confirm write | `milestone-confirm.js` | ramp → 10 | ~1.5m | < 800 ms | < 10%* | ~250–600 ms |
+
+\* Confirm allows higher error rate because concurrent VUs racing the same
+milestone correctly receive `409 Conflict` after the first success.
+
+## CI schedule
+
+A lightweight weekly run is wired in `.github/workflows/loadtest-weekly.yml`
+(schedule only — not on every PR). It requires repository secrets
+`LOADTEST_BASE_URL` and optionally `LOADTEST_JWT_TOKEN`.

--- a/load-tests/auth-login.js
+++ b/load-tests/auth-login.js
@@ -1,0 +1,82 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { API, defaultThresholds, authHeaders, passFailSummary } from './helpers.js';
+
+/**
+ * Auth login flow load test.
+ *
+ * Exercises GET /auth/nonce then POST /auth/login under concurrent VUs.
+ * Provide STELLAR_ADDRESS, SIGNED_NONCE, and SIGNATURE for a full login
+ * path; without them the suite still load-tests nonce generation.
+ *
+ * Baseline (local, 20 VUs): nonce p95 < 300ms, login p95 < 500ms.
+ */
+export const options = {
+  scenarios: {
+    auth_login: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 10 },
+        { duration: '1m', target: 20 },
+        { duration: '30s', target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    ...defaultThresholds,
+    http_req_duration: ['p(95)<500', 'p(99)<1200'],
+    checks: ['rate>0.95'],
+  },
+};
+
+export default function () {
+  const address = __ENV.STELLAR_ADDRESS || 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+  const nonceRes = http.get(`${API}/auth/nonce?address=${address}`, {
+    headers: authHeaders(),
+    tags: { name: 'GET /auth/nonce' },
+  });
+
+  check(nonceRes, {
+    'nonce status is 200 or 429': (r) => r.status === 200 || r.status === 429,
+  });
+
+  if (__ENV.SIGNED_NONCE && __ENV.SIGNATURE && __ENV.STELLAR_ADDRESS) {
+    const loginRes = http.post(
+      `${API}/auth/login`,
+      JSON.stringify({
+        stellarAddress: __ENV.STELLAR_ADDRESS,
+        signedNonce: __ENV.SIGNED_NONCE,
+        signature: __ENV.SIGNATURE,
+      }),
+      {
+        headers: authHeaders(),
+        tags: { name: 'POST /auth/login' },
+      },
+    );
+
+    check(loginRes, {
+      'login status is 200 or 401': (r) => r.status === 200 || r.status === 401,
+    });
+  }
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  passFailSummary(data);
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+  };
+}
+
+function textSummary(data, opts) {
+  // Minimal inline summary so the script runs without k6/x/summary import quirks
+  const p95 = data.metrics.http_req_duration?.values['p(95)'] ?? 0;
+  const failed = data.metrics.http_req_failed?.values?.rate ?? 0;
+  const passed = Object.values(data.root_group?.checks || {}).every
+    ? ''
+    : '';
+  return `\nAuth load test finished. p95=${p95.toFixed(1)}ms fail_rate=${(failed * 100).toFixed(2)}%${passed}\n`;
+}

--- a/load-tests/helpers.js
+++ b/load-tests/helpers.js
@@ -1,0 +1,37 @@
+/**
+ * Shared k6 helpers and default thresholds for ChainSettle load tests.
+ *
+ * Env vars:
+ *   BASE_URL   – API origin (default http://localhost:3000)
+ *   JWT_TOKEN  – Bearer token for authenticated endpoints (optional for login suite)
+ *   STELLAR_ADDRESS / SIGNED_NONCE / SIGNATURE – login credentials for auth flow
+ */
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+export const API = `${BASE_URL}/api/v1`;
+
+export const defaultThresholds = {
+  http_req_failed: ['rate<0.05'],
+  http_req_duration: ['p(95)<800', 'p(99)<2000'],
+};
+
+export function authHeaders(token) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+export function passFailSummary(data) {
+  const failed = data.metrics.http_req_failed?.values?.rate ?? 0;
+  const p95 = data.metrics.http_req_duration?.values['p(95)'] ?? 0;
+  const p99 = data.metrics.http_req_duration?.values['p(99)'] ?? 0;
+  const checks = data.metrics.checks?.values?.rate ?? 0;
+
+  console.log('======== ChainSettle load-test summary ========');
+  console.log(`checks pass rate : ${(checks * 100).toFixed(1)}%`);
+  console.log(`http failure rate: ${(failed * 100).toFixed(2)}%`);
+  console.log(`p95 latency      : ${p95.toFixed(1)} ms`);
+  console.log(`p99 latency      : ${p99.toFixed(1)} ms`);
+  console.log('==============================================');
+}

--- a/load-tests/milestone-confirm.js
+++ b/load-tests/milestone-confirm.js
@@ -1,0 +1,72 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { API, defaultThresholds, authHeaders, passFailSummary } from './helpers.js';
+
+/**
+ * Milestone confirmation write load test.
+ *
+ * Requires JWT_TOKEN, SHIPMENT_ID, MILESTONE_INDEX.
+ * Uses unique synthetic tx hashes so concurrent VUs do not collide.
+ *
+ * Baseline (local, 10 VUs): p95 < 800ms, error rate < 10%
+ * (higher error tolerance because many VUs will hit 409 once the milestone
+ * is already confirmed — that still validates write-path capacity).
+ */
+export const options = {
+  scenarios: {
+    milestone_confirm: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '20s', target: 5 },
+        { duration: '1m', target: 10 },
+        { duration: '20s', target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    ...defaultThresholds,
+    http_req_duration: ['p(95)<800', 'p(99)<2000'],
+    http_req_failed: ['rate<0.10'],
+    checks: ['rate>0.85'],
+  },
+};
+
+export default function () {
+  const token = __ENV.JWT_TOKEN;
+  const shipmentId = __ENV.SHIPMENT_ID;
+  const index = __ENV.MILESTONE_INDEX || '0';
+
+  if (!token || !shipmentId) {
+    throw new Error('JWT_TOKEN and SHIPMENT_ID are required for milestone confirm load test');
+  }
+
+  const txHash = `loadtest_${__VU}_${__ITER}_${Date.now().toString(16)}`;
+  const res = http.post(
+    `${API}/shipments/${shipmentId}/milestones/${index}/confirm`,
+    JSON.stringify({
+      txHash,
+      paymentReleased: __ENV.PAYMENT_RELEASED || '1000000000',
+    }),
+    {
+      headers: authHeaders(token),
+      tags: { name: 'POST /milestones/:index/confirm' },
+    },
+  );
+
+  check(res, {
+    'confirm accepted or conflict': (r) =>
+      r.status === 200 || r.status === 409 || r.status === 403 || r.status === 404,
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  passFailSummary(data);
+  const p95 = data.metrics.http_req_duration?.values['p(95)'] ?? 0;
+  const failed = data.metrics.http_req_failed?.values?.rate ?? 0;
+  return {
+    stdout: `\nMilestone confirm load test finished. p95=${p95.toFixed(1)}ms fail_rate=${(failed * 100).toFixed(2)}%\n`,
+  };
+}

--- a/load-tests/run-all.sh
+++ b/load-tests/run-all.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run the full ChainSettle k6 suite against a local/dev API.
+# Requires: k6 (https://k6.io/docs/get-started/installation/)
+#
+# Usage:
+#   BASE_URL=http://localhost:3000 JWT_TOKEN=... ./load-tests/run-all.sh
+#   npm run loadtest
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+FAILED=0
+
+if ! command -v k6 >/dev/null 2>&1; then
+  echo "ERROR: k6 is not installed. See https://k6.io/docs/get-started/installation/"
+  exit 1
+fi
+
+echo "==> Auth login flow"
+if ! BASE_URL="$BASE_URL" k6 run "$ROOT/auth-login.js"; then
+  FAILED=1
+fi
+
+if [[ -n "${JWT_TOKEN:-}" ]]; then
+  echo "==> Shipment list (paginated)"
+  if ! BASE_URL="$BASE_URL" JWT_TOKEN="$JWT_TOKEN" k6 run "$ROOT/shipments-list.js"; then
+    FAILED=1
+  fi
+
+  if [[ -n "${SHIPMENT_ID:-}" ]]; then
+    echo "==> Milestone confirmation writes"
+    if ! BASE_URL="$BASE_URL" JWT_TOKEN="$JWT_TOKEN" SHIPMENT_ID="$SHIPMENT_ID" \
+      MILESTONE_INDEX="${MILESTONE_INDEX:-0}" k6 run "$ROOT/milestone-confirm.js"; then
+      FAILED=1
+    fi
+  else
+    echo "SKIP milestone-confirm (set SHIPMENT_ID to enable)"
+  fi
+else
+  echo "SKIP authenticated suites (set JWT_TOKEN to enable shipments-list + milestone-confirm)"
+fi
+
+if [[ "$FAILED" -ne 0 ]]; then
+  echo "FAIL: one or more load tests exceeded thresholds"
+  exit 1
+fi
+
+echo "PASS: all executed load tests met thresholds"
+exit 0

--- a/load-tests/shipments-list.js
+++ b/load-tests/shipments-list.js
@@ -1,0 +1,61 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { API, defaultThresholds, authHeaders, passFailSummary } from './helpers.js';
+
+/**
+ * Paginated shipment list load test (read-heavy path / replica candidate).
+ *
+ * Requires JWT_TOKEN. Baseline (local, 30 VUs): p95 < 400ms, error rate < 2%.
+ */
+export const options = {
+  scenarios: {
+    shipment_list: {
+      executor: 'constant-vus',
+      vus: 30,
+      duration: '2m',
+    },
+  },
+  thresholds: {
+    ...defaultThresholds,
+    http_req_duration: ['p(95)<400', 'p(99)<1000'],
+    http_req_failed: ['rate<0.02'],
+    checks: ['rate>0.95'],
+  },
+};
+
+export default function () {
+  const token = __ENV.JWT_TOKEN;
+  if (!token) {
+    throw new Error('JWT_TOKEN env var is required for shipment list load test');
+  }
+
+  const page = (__VU % 5) + 1;
+  const res = http.get(`${API}/shipments?page=${page}&limit=20`, {
+    headers: authHeaders(token),
+    tags: { name: 'GET /shipments' },
+  });
+
+  check(res, {
+    'shipments status 200': (r) => r.status === 200,
+    'shipments has data array': (r) => {
+      try {
+        const body = r.json();
+        const payload = body.data ?? body;
+        return Array.isArray(payload?.data) || Array.isArray(payload);
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  sleep(0.5);
+}
+
+export function handleSummary(data) {
+  passFailSummary(data);
+  const p95 = data.metrics.http_req_duration?.values['p(95)'] ?? 0;
+  const failed = data.metrics.http_req_failed?.values?.rate ?? 0;
+  return {
+    stdout: `\nShipments list load test finished. p95=${p95.toFixed(1)}ms fail_rate=${(failed * 100).toFixed(2)}%\n`,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "loadtest": "bash load-tests/run-all.sh"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/prisma/migrations/20260827000000_add_archived_shipments/migration.sql
+++ b/prisma/migrations/20260827000000_add_archived_shipments/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE "archived_shipments" (
+    "id" TEXT NOT NULL,
+    "status" "ShipmentStatus" NOT NULL,
+    "buyerAddress" TEXT NOT NULL,
+    "supplierAddress" TEXT NOT NULL,
+    "logisticsAddress" TEXT NOT NULL,
+    "arbiterAddress" TEXT NOT NULL,
+    "referenceNumber" TEXT,
+    "terminalAt" TIMESTAMP(3) NOT NULL,
+    "archivedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "payload" JSONB NOT NULL,
+
+    CONSTRAINT "archived_shipments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "archived_shipments_buyerAddress_idx" ON "archived_shipments"("buyerAddress");
+
+-- CreateIndex
+CREATE INDEX "archived_shipments_supplierAddress_idx" ON "archived_shipments"("supplierAddress");
+
+-- CreateIndex
+CREATE INDEX "archived_shipments_logisticsAddress_idx" ON "archived_shipments"("logisticsAddress");
+
+-- CreateIndex
+CREATE INDEX "archived_shipments_arbiterAddress_idx" ON "archived_shipments"("arbiterAddress");
+
+-- CreateIndex
+CREATE INDEX "archived_shipments_status_idx" ON "archived_shipments"("status");
+
+-- CreateIndex
+CREATE INDEX "archived_shipments_archivedAt_idx" ON "archived_shipments"("archivedAt");
+
+-- CreateIndex
+CREATE INDEX "archived_shipments_terminalAt_idx" ON "archived_shipments"("terminalAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -479,3 +479,28 @@ model ShipmentWatcher {
   @@index([userId])
   @@map("shipment_watchers")
 }
+
+/// Cold-storage copy of a COMPLETED/CANCELLED shipment moved out of the hot
+/// `shipments` table by the scheduled archival job. `payload` retains the full
+/// relational snapshot (milestones, events, comments, tracking, notes, evidence).
+model ArchivedShipment {
+  id               String         @id // original shipment id
+  status           ShipmentStatus
+  buyerAddress     String
+  supplierAddress  String
+  logisticsAddress String
+  arbiterAddress   String
+  referenceNumber  String?
+  terminalAt       DateTime       // when shipment became COMPLETED/CANCELLED
+  archivedAt       DateTime       @default(now())
+  payload          Json           // full history snapshot for compliance/reference
+
+  @@index([buyerAddress])
+  @@index([supplierAddress])
+  @@index([logisticsAddress])
+  @@index([arbiterAddress])
+  @@index([status])
+  @@index([archivedAt])
+  @@index([terminalAt])
+  @@map("archived_shipments")
+}

--- a/src/common/prisma/prisma.service.ts
+++ b/src/common/prisma/prisma.service.ts
@@ -7,14 +7,15 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
   private readonly logger = new Logger(PrismaService.name);
   private readonly connectionLimit: number;
   private readonly poolTimeout: number;
+  /** Optional read-replica client. When unset, `read` returns the primary. */
+  private replicaClient: PrismaClient | null = null;
 
   constructor(config: ConfigService) {
     const isDev = process.env.NODE_ENV !== 'production';
     const connectionLimit = config.get<number>('DATABASE_CONNECTION_LIMIT', 10);
     const poolTimeout = config.get<number>('DATABASE_POOL_TIMEOUT', 10);
     const databaseUrl = config.get<string>('DATABASE_URL', '');
-    const separator = databaseUrl.includes('?') ? '&' : '?';
-    const url = `${databaseUrl}${separator}connection_limit=${connectionLimit}&pool_timeout=${poolTimeout}`;
+    const url = PrismaService.withPoolParams(databaseUrl, connectionLimit, poolTimeout);
 
     super({
       datasources: { db: { url } },
@@ -23,6 +24,19 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
 
     this.connectionLimit = connectionLimit;
     this.poolTimeout = poolTimeout;
+
+    const replicaUrl = config.get<string>('DATABASE_REPLICA_URL');
+    if (replicaUrl) {
+      const replicaPooled = PrismaService.withPoolParams(
+        replicaUrl,
+        connectionLimit,
+        poolTimeout,
+      );
+      this.replicaClient = new PrismaClient({
+        datasources: { db: { url: replicaPooled } },
+      });
+      this.logger.log('DATABASE_REPLICA_URL configured — read client will use the replica');
+    }
 
     if (isDev) {
       const threshold = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS ?? '100', 10);
@@ -34,14 +48,47 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
     }
   }
 
+  /**
+   * Prisma client for clearly read-only queries.
+   * Falls back to the primary when DATABASE_REPLICA_URL is unset.
+   *
+   * Eventual consistency: a just-written row may not yet be visible on the
+   * replica. Prefer `this` (primary) for read-your-writes paths.
+   */
+  get read(): PrismaClient {
+    return this.replicaClient ?? this;
+  }
+
+  get isReplicaEnabled(): boolean {
+    return this.replicaClient !== null;
+  }
+
+  private static withPoolParams(
+    databaseUrl: string,
+    connectionLimit: number,
+    poolTimeout: number,
+  ): string {
+    const separator = databaseUrl.includes('?') ? '&' : '?';
+    return `${databaseUrl}${separator}connection_limit=${connectionLimit}&pool_timeout=${poolTimeout}`;
+  }
+
   async onModuleInit() {
     await this.$connect();
-    this.logger.log('Database connected');
+    this.logger.log('Database connected (primary)');
     this.logger.log(`Prisma pool: limit=${this.connectionLimit}, timeout=${this.poolTimeout}s`);
+
+    if (this.replicaClient) {
+      await this.replicaClient.$connect();
+      this.logger.log('Database connected (replica)');
+    }
   }
 
   async onModuleDestroy() {
     await this.$disconnect();
-    this.logger.log('Database disconnected');
+    this.logger.log('Database disconnected (primary)');
+    if (this.replicaClient) {
+      await this.replicaClient.$disconnect();
+      this.logger.log('Database disconnected (replica)');
+    }
   }
 }

--- a/src/common/redis/redis.service.ts
+++ b/src/common/redis/redis.service.ts
@@ -120,4 +120,42 @@ export class RedisService implements OnModuleDestroy {
       }
     } while (cursor !== '0');
   }
+
+  /**
+   * Acquire a distributed lock (SET NX PX). Returns true if this caller owns the lock.
+   */
+  async acquireLock(key: string, token: string, ttlMs: number): Promise<boolean> {
+    const result = await this.client.set(key, token, 'PX', ttlMs, 'NX');
+    return result === 'OK';
+  }
+
+  /**
+   * Renew a lock only if still owned by `token` (compare-and-expire via Lua).
+   */
+  async renewLock(key: string, token: string, ttlMs: number): Promise<boolean> {
+    const script = `
+      if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("pexpire", KEYS[1], ARGV[2])
+      else
+        return 0
+      end
+    `;
+    const result = await this.client.eval(script, 1, key, token, ttlMs);
+    return result === 1;
+  }
+
+  /**
+   * Release a lock only if still owned by `token` (compare-and-del via Lua).
+   */
+  async releaseLock(key: string, token: string): Promise<boolean> {
+    const script = `
+      if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("del", KEYS[1])
+      else
+        return 0
+      end
+    `;
+    const result = await this.client.eval(script, 1, key, token);
+    return result === 1;
+  }
 }

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -15,8 +15,16 @@ export const envValidationSchema = Joi.object({
     .pattern(/^postgres(ql)?:\/\//)
     .required()
     .messages({ 'string.pattern.base': 'DATABASE_URL must start with postgresql:// or postgres://' }),
+  // Optional read replica. When unset, all queries use DATABASE_URL (primary).
+  DATABASE_REPLICA_URL: Joi.string()
+    .pattern(/^postgres(ql)?:\/\//)
+    .optional()
+    .messages({ 'string.pattern.base': 'DATABASE_REPLICA_URL must start with postgresql:// or postgres://' }),
   DATABASE_CONNECTION_LIMIT: Joi.number().integer().min(1).max(1000).default(10),
   DATABASE_POOL_TIMEOUT: Joi.number().integer().min(1).max(300).default(10),
+
+  // Cold-storage archival of completed/cancelled shipments (days; default 90)
+  SHIPMENT_ARCHIVAL_DAYS: Joi.number().integer().min(1).max(3650).default(90),
 
   // Stellar
   STELLAR_NETWORK: Joi.string().valid('testnet', 'mainnet', 'futurenet').default('testnet'),

--- a/src/modules/audit-logs/audit-log.service.ts
+++ b/src/modules/audit-logs/audit-log.service.ts
@@ -99,8 +99,10 @@ export class AuditLogService {
       if (endDate) where.createdAt.lte = endDate;
     }
 
-    const [logs, total] = await this.prisma.$transaction([
-      this.prisma.auditLog.findMany({
+    // Read-heavy admin list — route through replica when configured
+    const db = this.prisma.read;
+    const [logs, total] = await db.$transaction([
+      db.auditLog.findMany({
         where,
         include: {
           user: {
@@ -116,7 +118,7 @@ export class AuditLogService {
         skip: (page - 1) * limit,
         take: limit,
       }),
-      this.prisma.auditLog.count({ where }),
+      db.auditLog.count({ where }),
     ]);
 
     return {

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -1,7 +1,9 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'crypto';
 import { PrismaService } from '../../common/prisma/prisma.service';
+import { RedisService } from '../../common/redis/redis.service';
 import { StellarService } from '../../common/stellar/stellar.service';
 import { MilestonesService } from '../milestones/milestones.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -10,6 +12,10 @@ import { MetricsService } from '../../common/metrics/metrics.service';
 import { NotificationType } from '@prisma/client';
 
 const MAX_ATTEMPTS = 5;
+const POLLER_LOCK_KEY = 'chainsettle:event-poller:leader';
+/** Lock TTL must exceed the renew interval so a healthy leader keeps ownership. */
+const POLLER_LOCK_TTL_MS = 15_000;
+const POLLER_LOCK_RENEW_MS = 5_000;
 
 /**
  * EventsService
@@ -23,17 +29,24 @@ const MAX_ATTEMPTS = 5;
  *
  * Failed events are persisted to failed_events (DLQ) and retried with
  * exponential back-off up to MAX_ATTEMPTS times.
+ *
+ * Only one process holds the Redis leader lock at a time so blue/green
+ * deploys (or multi-replica) never double-process chain events.
  */
 @Injectable()
-export class EventsService implements OnModuleInit {
+export class EventsService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(EventsService.name);
   /** In-memory mirror of the DB cursor — updated after each processed event. */
   private lastProcessedLedger: number = 0;
   private unsubscribeFn: (() => void) | null = null;
   private reconnectBackoffMs = 0;
+  private readonly lockToken = randomUUID();
+  private isLeader = false;
+  private leadershipTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(
     private readonly prisma: PrismaService,
+    private readonly redis: RedisService,
     private readonly stellar: StellarService,
     private readonly milestones: MilestonesService,
     private readonly notifications: NotificationsService,
@@ -81,7 +94,64 @@ export class EventsService implements OnModuleInit {
       }
     }
 
+    // Try to become leader immediately; keep contending so a deploy handoff is fast.
+    await this.tryBecomeLeader();
+    this.leadershipTimer = setInterval(() => {
+      void this.tryBecomeLeader();
+    }, POLLER_LOCK_RENEW_MS);
+  }
+
+  async onModuleDestroy() {
+    if (this.leadershipTimer) {
+      clearInterval(this.leadershipTimer);
+      this.leadershipTimer = null;
+    }
+    await this.stepDownAsLeader();
+  }
+
+  private async tryBecomeLeader(): Promise<void> {
+    if (this.isLeader) {
+      const renewed = await this.redis.renewLock(
+        POLLER_LOCK_KEY,
+        this.lockToken,
+        POLLER_LOCK_TTL_MS,
+      );
+      if (!renewed) {
+        this.logger.warn('Lost event-poller leadership — stopping stream');
+        await this.stopStreamSubscription();
+        this.isLeader = false;
+      }
+      return;
+    }
+
+    const acquired = await this.redis.acquireLock(
+      POLLER_LOCK_KEY,
+      this.lockToken,
+      POLLER_LOCK_TTL_MS,
+    );
+    if (!acquired) {
+      return;
+    }
+
+    this.isLeader = true;
+    this.logger.log(`Acquired event-poller leadership (token=${this.lockToken})`);
     this.startStreamSubscription();
+  }
+
+  private async stepDownAsLeader(): Promise<void> {
+    await this.stopStreamSubscription();
+    if (this.isLeader) {
+      await this.redis.releaseLock(POLLER_LOCK_KEY, this.lockToken);
+      this.isLeader = false;
+      this.logger.log('Released event-poller leadership');
+    }
+  }
+
+  private async stopStreamSubscription(): Promise<void> {
+    if (this.unsubscribeFn) {
+      this.unsubscribeFn();
+      this.unsubscribeFn = null;
+    }
   }
 
   // ----------------------------------------------------------
@@ -128,6 +198,11 @@ export class EventsService implements OnModuleInit {
 
   @Cron(CronExpression.EVERY_MINUTE)
   async retryFailedEvents() {
+    // Only the poller leader retries DLQ work to avoid duplicate side-effects.
+    if (!this.isLeader) {
+      return;
+    }
+
     const now = new Date();
 
     const pending = await this.prisma.failedEvent.findMany({
@@ -515,14 +590,16 @@ export class EventsService implements OnModuleInit {
       };
     }
 
-    const [events, total] = await this.prisma.$transaction([
-      this.prisma.chainEvent.findMany({
+    // Read-heavy list — route through replica when configured
+    const db = this.prisma.read;
+    const [events, total] = await db.$transaction([
+      db.chainEvent.findMany({
         where,
         orderBy: { ledger: 'desc' },
         skip: (page - 1) * limit,
         take: limit,
       }),
-      this.prisma.chainEvent.count({ where }),
+      db.chainEvent.count({ where }),
     ]);
 
     return { 
@@ -552,6 +629,7 @@ export class EventsService implements OnModuleInit {
       lag,
       updatedAt: persisted?.updatedAt ?? null,
       healthy: lag <= 100,
+      isPollerLeader: this.isLeader,
     };
   }
 

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -247,6 +247,34 @@ export class MilestonesController {
   }
 
   /**
+   * POST /api/v1/shipments/:shipmentId/milestones/:index/confirm
+   * Buyer registers an on-chain milestone confirmation so the DB reflects it immediately.
+   */
+  @Post(':index/confirm')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'Confirm a milestone (buyer only)' })
+  @ApiResponse({ status: 200, description: 'Milestone confirmed' })
+  @ApiResponse({ status: 403, description: 'Only the buyer may confirm' })
+  @ApiResponse({ status: 404, description: 'Shipment or milestone not found' })
+  @ApiResponse({ status: 409, description: 'Milestone not in PROOF_SUBMITTED status' })
+  confirm(
+    @Param('shipmentId') shipmentId: string,
+    @Param('index', ParseIntPipe) index: number,
+    @Body() dto: ConfirmMilestoneDto,
+    @CurrentUser() user: any,
+  ) {
+    const callerAddress: string = user?.stellarAddress ?? user?.sub;
+    return this.milestonesService.confirmFromApi(
+      shipmentId,
+      index,
+      callerAddress,
+      dto.txHash,
+      dto.paymentReleased,
+    );
+  }
+
+  /**
    * DELETE /api/v1/shipments/:shipmentId/milestones/:index
    * Remove a still-pending milestone from a shipment.
    * Only allowed when ALL milestones on the shipment (including the target)

--- a/src/modules/shipments/shipment-archival.job.ts
+++ b/src/modules/shipments/shipment-archival.job.ts
@@ -1,0 +1,151 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron } from '@nestjs/schedule';
+import { Prisma, ShipmentStatus } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { RedisService } from '../../common/redis/redis.service';
+
+const ARCHIVAL_LOCK_KEY = 'chainsettle:shipment-archival:lock';
+const ARCHIVAL_LOCK_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const BATCH_SIZE = 50;
+
+/**
+ * Moves COMPLETED/CANCELLED shipments older than SHIPMENT_ARCHIVAL_DAYS out of
+ * the hot `shipments` table into `archived_shipments` (cold storage), retaining
+ * a full JSON snapshot of milestones, events, comments, tracking, and notes.
+ */
+@Injectable()
+export class ShipmentArchivalJob {
+  private readonly logger = new Logger(ShipmentArchivalJob.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redis: RedisService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Cron('0 3 * * *') // override via SHIPMENT_ARCHIVAL_CRON is documented; Nest binds at boot from env if set before import
+  async runArchival() {
+    const token = randomUUID();
+    const acquired = await this.redis.acquireLock(
+      ARCHIVAL_LOCK_KEY,
+      token,
+      ARCHIVAL_LOCK_TTL_MS,
+    );
+    if (!acquired) {
+      this.logger.debug('Skipping archival — another instance holds the lock');
+      return;
+    }
+
+    try {
+      const days = this.config.get<number>('SHIPMENT_ARCHIVAL_DAYS', 90);
+      const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+      this.logger.log(
+        `Starting shipment cold-storage archival (cutoff=${cutoff.toISOString()}, days=${days})`,
+      );
+
+      let archivedCount = 0;
+      let hasMore = true;
+
+      while (hasMore) {
+        const candidates = await this.prisma.shipment.findMany({
+          where: {
+            status: { in: [ShipmentStatus.COMPLETED, ShipmentStatus.CANCELLED] },
+            updatedAt: { lte: cutoff },
+          },
+          take: BATCH_SIZE,
+          orderBy: { updatedAt: 'asc' },
+          include: {
+            milestones: {
+              orderBy: { milestoneIndex: 'asc' },
+              include: {
+                disputeEvidence: true,
+                proofSubmissions: true,
+              },
+            },
+            events: { orderBy: { ledger: 'asc' } },
+            comments: true,
+            shipmentNotes: true,
+            trackingUpdates: { orderBy: { createdAt: 'asc' } },
+            watchers: true,
+          },
+        });
+
+        if (candidates.length === 0) {
+          hasMore = false;
+          break;
+        }
+
+        for (const shipment of candidates) {
+          const terminalAt =
+            shipment.cancelledAt ??
+            shipment.milestones
+              .map((m) => m.confirmedAt)
+              .filter((d): d is Date => !!d)
+              .sort((a, b) => b.getTime() - a.getTime())[0] ??
+            shipment.updatedAt;
+
+          // Skip if still within the retention window for COMPLETED without cancelledAt
+          if (terminalAt > cutoff) {
+            continue;
+          }
+
+          const payload = JSON.parse(
+            JSON.stringify(shipment, (_key, value) =>
+              typeof value === 'bigint' ? value.toString() : value,
+            ),
+          ) as Prisma.InputJsonValue;
+
+          await this.prisma.$transaction(async (tx) => {
+            await tx.archivedShipment.upsert({
+              where: { id: shipment.id },
+              create: {
+                id: shipment.id,
+                status: shipment.status,
+                buyerAddress: shipment.buyerAddress,
+                supplierAddress: shipment.supplierAddress,
+                logisticsAddress: shipment.logisticsAddress,
+                arbiterAddress: shipment.arbiterAddress,
+                referenceNumber: shipment.referenceNumber,
+                terminalAt,
+                payload,
+              },
+              update: {
+                status: shipment.status,
+                terminalAt,
+                payload,
+                archivedAt: new Date(),
+              },
+            });
+
+            // Detach chain_events so the global audit trail remains queryable
+            await tx.chainEvent.updateMany({
+              where: { shipmentId: shipment.id },
+              data: { shipmentId: null },
+            });
+
+            // Milestones (and cascaded evidence/proofs) are fully captured in payload
+            await tx.milestone.deleteMany({ where: { shipmentId: shipment.id } });
+
+            // Cascades remove comments, notes, tracking, watchers
+            await tx.shipment.delete({ where: { id: shipment.id } });
+          });
+
+          archivedCount++;
+          this.logger.debug(`Cold-archived shipment ${shipment.id}`);
+        }
+
+        if (candidates.length < BATCH_SIZE) {
+          hasMore = false;
+        }
+      }
+
+      this.logger.log(`Shipment archival complete — moved ${archivedCount} shipment(s)`);
+    } catch (err: any) {
+      this.logger.error(`Shipment archival failed: ${err.message}`, err.stack);
+    } finally {
+      await this.redis.releaseLock(ARCHIVAL_LOCK_KEY, token);
+    }
+  }
+}

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -153,6 +153,47 @@ export class ShipmentsController {
   }
 
   /**
+   * GET /api/v1/shipments/archived
+   * List shipments moved to cold storage by the scheduled archival job.
+   */
+  @Get('archived')
+  @ApiOperation({
+    summary: 'List cold-archived shipments',
+    description:
+      'Returns shipments that were moved out of the hot path after the retention threshold. ' +
+      'Full milestone/event/audit history is preserved in each record payload.',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated cold-archived shipments' })
+  findArchived(
+    @CurrentUser() user: any,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('status') status?: string,
+  ) {
+    const isAdmin = user?.role === UserRole.ADMIN;
+    return this.shipmentsService.findArchived({
+      page: page ? parseInt(page, 10) : undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
+      callerStellarAddress: user?.stellarAddress,
+      isAdmin,
+      status: status as any,
+    });
+  }
+
+  /**
+   * GET /api/v1/shipments/archived/:id
+   * Retrieve a single cold-archived shipment with full history snapshot.
+   */
+  @Get('archived/:id')
+  @ApiOperation({ summary: 'Get a cold-archived shipment by id' })
+  @ApiResponse({ status: 200, description: 'Archived shipment with full history' })
+  @ApiResponse({ status: 404, description: 'Archived shipment not found' })
+  findArchivedOne(@Param('id') id: string, @CurrentUser() user: any) {
+    const isAdmin = user?.role === UserRole.ADMIN;
+    return this.shipmentsService.findArchivedOne(id, user?.stellarAddress, isAdmin);
+  }
+
+  /**
    * GET /api/v1/shipments/export?format=csv|pdf
    * Export all shipments visible to the caller.
    * Rate-limited to 5 requests per hour per user.

--- a/src/modules/shipments/shipments.module.ts
+++ b/src/modules/shipments/shipments.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ShipmentsController } from './shipments.controller';
 import { AdminShipmentsController } from './admin-shipments.controller';
 import { ShipmentsService } from './shipments.service';
+import { ShipmentArchivalJob } from './shipment-archival.job';
 import { CommentsController } from './comments.controller';
 import { CommentsService } from './comments.service';
 import { AuditLogsModule } from '../audit-logs/audit-logs.module';
@@ -11,7 +12,7 @@ import { RedisModule } from '../../common/redis/redis.module';
 @Module({
   imports: [NotificationsModule, RedisModule, AuditLogsModule],
   controllers: [ShipmentsController, AdminShipmentsController, CommentsController],
-  providers: [ShipmentsService, CommentsService],
+  providers: [ShipmentsService, CommentsService, ShipmentArchivalJob],
   exports: [ShipmentsService],
 })
 export class ShipmentsModule { }

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -287,7 +287,10 @@ export class ShipmentsService {
         ${participantCondition}
       `;
 
-      shipments = await this.prisma.$queryRawUnsafe(
+      // Read-heavy list path — use replica when DATABASE_REPLICA_URL is set
+      const db = this.prisma.read;
+
+      shipments = await db.$queryRawUnsafe(
         query,
         ...participantParams,
         search,
@@ -295,7 +298,7 @@ export class ShipmentsService {
         (page - 1) * limit,
       );
 
-      const countResult = await this.prisma.$queryRawUnsafe(
+      const countResult = await db.$queryRawUnsafe(
         countQuery,
         ...participantParams,
         search,
@@ -303,7 +306,7 @@ export class ShipmentsService {
       total = Number((countResult as any[])[0].count);
 
       for (const s of shipments) {
-        s.milestones = await this.prisma.milestone.findMany({
+        s.milestones = await db.milestone.findMany({
           where: { shipmentId: s.id },
           orderBy: { milestoneIndex: 'asc' },
         });
@@ -316,7 +319,8 @@ export class ShipmentsService {
         throw new BadRequestException('Invalid cursor format');
       }
 
-      shipments = await this.prisma.shipment.findMany({
+      const db = this.prisma.read;
+      shipments = await db.shipment.findMany({
         where: { ...where, createdAt: { lte: new Date(decoded.createdAt) } },
         include: { milestones: { orderBy: { milestoneIndex: 'asc' } } },
         orderBy: { createdAt: 'desc' },
@@ -335,15 +339,16 @@ export class ShipmentsService {
             ).toString('base64')
           : null;
     } else {
-      [shipments, total] = await this.prisma.$transaction([
-        this.prisma.shipment.findMany({
+      const db = this.prisma.read;
+      [shipments, total] = await db.$transaction([
+        db.shipment.findMany({
           where,
           include: { milestones: { orderBy: { milestoneIndex: 'asc' } } },
           orderBy: { createdAt: 'desc' },
           skip: (page - 1) * limit,
           take: limit,
         }),
-        this.prisma.shipment.count({ where }),
+        db.shipment.count({ where }),
       ]);
     }
 
@@ -362,7 +367,8 @@ export class ShipmentsService {
   }
 
   async findOne(id: string) {
-    const shipment = await this.prisma.shipment.findUnique({
+    const db = this.prisma.read;
+    const shipment = await db.shipment.findUnique({
       where: { id },
       include: {
         milestones: { orderBy: { milestoneIndex: 'asc' } },
@@ -372,6 +378,86 @@ export class ShipmentsService {
     });
     if (!shipment) throw new NotFoundException(`Shipment ${id} not found`);
     return this.serialize(shipment);
+  }
+
+  /**
+   * List shipments moved to cold storage by the archival job.
+   * Always reads from primary so freshly archived rows are immediately visible.
+   */
+  async findArchived(filters: {
+    page?: number;
+    limit?: number;
+    callerStellarAddress?: string;
+    isAdmin?: boolean;
+    status?: ShipmentStatus;
+  }) {
+    const { page = 1, limit = 20, callerStellarAddress, isAdmin = false, status } = filters;
+    const where: any = {};
+
+    if (status) where.status = status;
+
+    if (!isAdmin && callerStellarAddress) {
+      where.OR = [
+        { buyerAddress: callerStellarAddress },
+        { supplierAddress: callerStellarAddress },
+        { logisticsAddress: callerStellarAddress },
+        { arbiterAddress: callerStellarAddress },
+      ];
+    }
+
+    const [rows, total] = await this.prisma.$transaction([
+      this.prisma.archivedShipment.findMany({
+        where,
+        orderBy: { archivedAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.archivedShipment.count({ where }),
+    ]);
+
+    return {
+      data: rows.map((row) => ({
+        ...(row.payload as object),
+        id: row.id,
+        status: row.status,
+        buyerAddress: row.buyerAddress,
+        supplierAddress: row.supplierAddress,
+        logisticsAddress: row.logisticsAddress,
+        arbiterAddress: row.arbiterAddress,
+        coldArchivedAt: row.archivedAt,
+        terminalAt: row.terminalAt,
+      })),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async findArchivedOne(id: string, callerStellarAddress?: string, isAdmin = false) {
+    const row = await this.prisma.archivedShipment.findUnique({ where: { id } });
+    if (!row) throw new NotFoundException(`Archived shipment ${id} not found`);
+
+    if (
+      !isAdmin &&
+      callerStellarAddress &&
+      row.buyerAddress !== callerStellarAddress &&
+      row.supplierAddress !== callerStellarAddress &&
+      row.logisticsAddress !== callerStellarAddress &&
+      row.arbiterAddress !== callerStellarAddress
+    ) {
+      throw new ForbiddenException('Not a participant on this archived shipment');
+    }
+
+    return {
+      ...(row.payload as object),
+      id: row.id,
+      status: row.status,
+      coldArchivedAt: row.archivedAt,
+      terminalAt: row.terminalAt,
+    };
   }
 
   async bulkStatus(


### PR DESCRIPTION


## Summary
Closes #242
closes #244
closes #247
closes #253

Operational scale-out work: optional Postgres read-replica routing for GET-heavy paths, a k6 load-test suite with documented baselines, a blue/green GitHub Actions deploy workflow with Redis single-leader event polling, and a scheduled cold-storage archival job for terminal shipments.

## Changes

### #242 Read-replica routing
- Extended `PrismaService` with optional `DATABASE_REPLICA_URL` and a `read` getter that falls back to the primary when unset
- Routed read-heavy methods through the replica: `ShipmentsService.findAll` / `findOne`, `EventsService.findAll`, `AuditLogService.findAll`
- Documented eventual-consistency implications in `docs/deployment.md` and `.env.example`

### #244 k6 load-testing suite
- Added `load-tests/` with scripts for auth login, paginated `GET /shipments`, and milestone confirm writes
- Added `npm run loadtest` (`load-tests/run-all.sh`) with k6 threshold pass/fail
- Documented baselines in `docs/load-testing.md`
- Wired weekly scheduled CI via `.github/workflows/loadtest-weekly.yml` (not on every PR)

### #247 Blue-green deployment
- Added `.github/workflows/deploy-blue-green.yml` (build → start green → health-check `/api/v1/health/ready` → cutover → drain blue)
- Added Redis distributed lock helpers (`acquireLock` / `renewLock` / `releaseLock`)
- Event poller + DLQ retry now run only on the Redis leader (`chainsettle:event-poller:leader`) so blue/green overlap cannot double-process chain events
- End-to-end process documented in `docs/deployment.md`

### #253 Scheduled shipment cold archival
- New `archived_shipments` table + Prisma migration
- `ShipmentArchivalJob` (daily 03:00 UTC, Redis-locked) moves `COMPLETED`/`CANCELLED` shipments older than `SHIPMENT_ARCHIVAL_DAYS` (default 90) into cold storage with a full history JSON snapshot
- New APIs: `GET /shipments/archived`, `GET /shipments/archived/:id`
- Existing soft-archive (`archivedAt` / `includeArchived`) unchanged for buyer-driven archive-in-place

## Test plan
- [ ] With `DATABASE_REPLICA_URL` unset, list/detail GETs behave as before (primary only)
- [ ] With replica set, confirm shipment/events/audit list queries hit the replica connection
- [ ] `npx prisma migrate deploy` applies `archived_shipments`
- [ ] Run archival job (or lower `SHIPMENT_ARCHIVAL_DAYS`) and verify terminal shipments leave `shipments` and appear under `GET /shipments/archived`
- [ ] Install k6; `npm run loadtest` against a local API — thresholds pass/fail correctly
- [ ] Boot two app instances; only one logs `Acquired event-poller leadership`; stopping the leader transfers the lock
- [ ] Dry-run `deploy-blue-green.yml` on staging with secrets configured; confirm zero downtime and no duplicate `chain_events` rows

## Database Migrations
- [x] Migration included: `prisma/migrations/20260827000000_add_archived_shipments`