### PR TITLE
Add rate-limit headers, mock chain, Helm deploy, and shipment favorites

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Ignore build artifacts and secrets when sending context to Docker
+node_modules
+npm-debug.log
+dist
+coverage
+.env
+.env.*
+!.env.example
+.git
+.github
+*.md
+!README.md
+test

--- a/.env.example
+++ b/.env.example
@@ -37,9 +37,12 @@ DATABASE_POOL_TIMEOUT=10
 STELLAR_NETWORK=testnet
 
 # [required] Soroban RPC endpoint for the chosen network
+# For local UI work without testnet, run `npm run dev:mock-chain` and use:
+# STELLAR_RPC_URL=http://127.0.0.1:8787
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 
 # [required] Horizon REST API endpoint for the chosen network
+# With mock chain: STELLAR_HORIZON_URL=http://127.0.0.1:8788
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
 # [required] Deployed ChainSettle contract ID (set after deploying chainsetttle-contract)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Multi-stage build for ChainSettle NestJS API
+# Build:  docker build -t chainsettle-backend .
+# Run:    docker run --env-file .env -p 3000:3000 chainsettle-backend
+
+# ── Build stage ──────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY prisma ./prisma/
+
+RUN npm ci
+
+COPY . .
+
+RUN npx prisma generate
+RUN npm run build
+
+# ── Runtime stage ────────────────────────────────────────────
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN apk add --no-cache wget \
+  && addgroup -S app && adduser -S app -G app
+
+COPY package.json package-lock.json ./
+COPY prisma ./prisma/
+
+RUN npm ci --omit=dev && npx prisma generate && npm cache clean --force
+
+COPY --from=builder /app/dist ./dist
+
+# Nest copies Handlebars templates into dist via nest-cli assets
+USER app
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/api/v1/health/live || exit 1
+
+CMD ["node", "dist/main"]

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ All endpoints are prefixed with `/api/v1`. Protected routes require `Authorizati
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `POST` | `/shipments` | ✓ | Register on-chain shipment in DB |
-| `GET` | `/shipments` | ✓ | List shipments (filter by buyer, supplier, status) |
-| `GET` | `/shipments/:id` | ✓ | Full shipment detail + milestones + events |
+| `GET` | `/shipments` | ✓ | List shipments (filters: buyer, supplier, status, `favorite=true`) |
+| `GET` | `/shipments/:id` | ✓ | Full shipment detail + milestones + events (`isFavorited`) |
+| `POST` | `/shipments/:id/favorite` | ✓ | Favorite (star) a shipment (participant only; private) |
+| `DELETE` | `/shipments/:id/favorite` | ✓ | Remove shipment from caller's favorites |
 | `POST` | `/shipments/:id/sync` | ✓ | Force sync shipment from Stellar chain |
 
 ### Milestones
@@ -275,6 +277,37 @@ The backend verifies the signature against the public key, then issues a JWT. Wi
 
 ---
 
+## Rate Limiting
+
+All API routes are rate-limited via Redis-backed `@nestjs/throttler`. Defaults are controlled by `THROTTLE_TTL` (window seconds, default `60`) and `THROTTLE_LIMIT` (max requests per key, default `100`). Auth and upload routes use tighter per-route limits; some auth routes key by Stellar address instead of IP.
+
+Every throttled response includes:
+
+| Header | Meaning |
+|--------|---------|
+| `X-RateLimit-Limit` | Max requests allowed in the current window |
+| `X-RateLimit-Remaining` | Requests left in the window (`0` when limited) |
+| `X-RateLimit-Reset` | Seconds until the window resets |
+| `Retry-After` | Present on `429` responses — same value as `X-RateLimit-Reset` |
+
+These headers are CORS-exposed so browser clients can read them. Use `./test-rate-limit.sh` against a running local API to verify success and `429` header behavior.
+
+---
+
+## Local mock Stellar chain (frontend dev)
+
+To iterate on the API/UI without a live testnet RPC:
+
+```bash
+npm run dev:mock-chain
+# set STELLAR_RPC_URL=http://127.0.0.1:8787 and STELLAR_HORIZON_URL=http://127.0.0.1:8788
+npm run start:dev
+```
+
+See [`test/mocks/README.md`](test/mocks/README.md) for tradeoffs. **Dev-only** — not for integration testing of real chain behavior.
+
+---
+
 ## Stellar Event Polling
 
 The `EventsService` runs a cron job every 5 seconds using `@nestjs/schedule`. It:
@@ -327,7 +360,7 @@ Errors follow a standardised format from `HttpExceptionFilter`:
 - [ ] Wire up real Stellar `Keypair.verify()` in `auth.service.ts`
 - [ ] Set `CORS_ORIGIN` to your production frontend URL
 - [ ] Add rate limiting tuning for production traffic
-- [ ] Deploy via Docker (Dockerfile not included — straightforward to add)
+- [x] Deploy via Docker / Helm (see [docs/deployment.md](docs/deployment.md))
 
 ---
 

--- a/deploy/helm/chainsettle-backend/Chart.yaml
+++ b/deploy/helm/chainsettle-backend/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: chainsettle-backend
+description: Helm chart for the ChainSettle NestJS API
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/helm/chainsettle-backend/templates/_helpers.tpl
+++ b/deploy/helm/chainsettle-backend/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+{{- /* Generate full name */ -}}
+{{- define "chainsettle-backend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "chainsettle-backend.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "chainsettle-backend.labels" -}}
+app.kubernetes.io/name: {{ include "chainsettle-backend.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "chainsettle-backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chainsettle-backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "chainsettle-backend.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "chainsettle-backend.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/chainsettle-backend/templates/deployment.yaml
+++ b/deploy/helm/chainsettle-backend/templates/deployment.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chainsettle-backend.fullname" . }}
+  labels:
+    {{- include "chainsettle-backend.labels" . | nindent 4 }}
+spec:
+  # Keep at 1 unless event poller / cron jobs are moved behind a distributed lock.
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chainsettle-backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "chainsettle-backend.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "chainsettle-backend.serviceAccountName" . }}
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.existingSecret }}
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: JWT_SECRET
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: DATABASE_URL
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: REDIS_URL
+            - name: STELLAR_RPC_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: STELLAR_RPC_URL
+            - name: STELLAR_HORIZON_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: STELLAR_HORIZON_URL
+            - name: CHAINSETTTLE_CONTRACT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: CHAINSETTTLE_CONTRACT_ID
+            - name: USDC_TOKEN_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: USDC_TOKEN_ADDRESS
+            - name: STELLAR_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: STELLAR_SECRET_KEY
+            - name: SMTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: SMTP_HOST
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: SMTP_USER
+            - name: SMTP_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: SMTP_PASS
+            - name: EMAIL_FROM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: EMAIL_FROM
+            {{- else if .Values.secretEnv }}
+            {{- range $key, $value := .Values.secretEnv }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "chainsettle-backend.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/chainsettle-backend/templates/secret.yaml
+++ b/deploy/helm/chainsettle-backend/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if and (not .Values.existingSecret) .Values.secretEnv }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chainsettle-backend.fullname" . }}
+  labels:
+    {{- include "chainsettle-backend.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/chainsettle-backend/templates/service.yaml
+++ b/deploy/helm/chainsettle-backend/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chainsettle-backend.fullname" . }}
+  labels:
+    {{- include "chainsettle-backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "chainsettle-backend.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/chainsettle-backend/templates/serviceaccount.yaml
+++ b/deploy/helm/chainsettle-backend/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chainsettle-backend.serviceAccountName" . }}
+  labels:
+    {{- include "chainsettle-backend.labels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/chainsettle-backend/values.yaml
+++ b/deploy/helm/chainsettle-backend/values.yaml
@@ -1,0 +1,73 @@
+# Default replicaCount is 1 — the in-process event poller and cron jobs
+# must not run on multiple pods without a distributed lock.
+replicaCount: 1
+
+image:
+  repository: chainsettle-backend
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 3000
+
+# Container listens on PORT (default 3000)
+containerPort: 3000
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+probes:
+  liveness:
+    path: /api/v1/health/live
+    initialDelaySeconds: 20
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    path: /api/v1/health/ready
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# Non-secret config injected as env vars
+env:
+  NODE_ENV: production
+  PORT: "3000"
+  API_PREFIX: api/v1
+  STELLAR_NETWORK: testnet
+  # Override the rest via --set or a values overlay / Secret
+
+# Names of existing Kubernetes secrets (create these before install)
+# Expected keys mirror .env.example required vars.
+existingSecret: ""
+# When existingSecret is empty, chart creates a Secret from secretEnv (dev only).
+secretEnv: {}
+  # JWT_SECRET: "change-me"
+  # DATABASE_URL: "postgresql://..."
+  # REDIS_URL: "redis://..."
+  # STELLAR_RPC_URL: "https://..."
+  # STELLAR_HORIZON_URL: "https://..."
+  # CHAINSETTTLE_CONTRACT_ID: "C..."
+  # USDC_TOKEN_ADDRESS: "C..."
+  # STELLAR_SECRET_KEY: "S..."
+  # SMTP_HOST: "..."
+  # SMTP_USER: "..."
+  # SMTP_PASS: "..."
+  # EMAIL_FROM: "..."
+
+serviceAccount:
+  create: true
+  name: ""
+
+podAnnotations: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,90 @@
+# Deployment
+
+How to build and run ChainSettle backend with Docker and Kubernetes (Helm).
+
+## Prerequisites
+
+- Node.js 20+ (local builds)
+- Docker
+- Kubernetes cluster + Helm 3
+- Reachable PostgreSQL 15+ and Redis
+- Stellar RPC / Horizon endpoints (or local mock for non-prod only)
+
+## Docker image
+
+```bash
+# From repo root
+docker build -t chainsettle-backend:latest .
+
+# Run (requires a populated .env matching .env.example)
+docker run --rm --env-file .env -p 3000:3000 chainsettle-backend:latest
+```
+
+The image:
+
+1. Installs dependencies and runs `prisma generate` + `nest build` in a builder stage
+2. Ships a slim Node 20 Alpine runtime with `npm ci --omit=dev`
+3. Starts via `node dist/main` on port `3000`
+4. Exposes Docker `HEALTHCHECK` against `GET /api/v1/health/live`
+
+Apply Prisma migrations separately before or during deploy:
+
+```bash
+npx prisma migrate deploy
+# or from a one-shot Job that uses the same image / DATABASE_URL
+```
+
+## Helm chart
+
+Chart path: `deploy/helm/chainsettle-backend`
+
+### Important: single replica for the event poller
+
+The Nest process runs the Stellar event poller and several cron jobs **in-process**. Running multiple replicas without a distributed lock can duplicate event handling and notifications.
+
+**Default `replicaCount` is `1`.** Do not scale above 1 until the poller/crons are extracted or locked.
+
+### Install
+
+```bash
+# 1. Build / push the image to a registry your cluster can pull
+docker build -t <registry>/chainsettle-backend:0.1.0 .
+docker push <registry>/chainsettle-backend:0.1.0
+
+# 2. Create a Secret with required keys (preferred for production)
+kubectl create secret generic chainsettle-backend-secrets \
+  --from-literal=JWT_SECRET='...' \
+  --from-literal=DATABASE_URL='postgresql://...' \
+  --from-literal=REDIS_URL='redis://...' \
+  --from-literal=STELLAR_RPC_URL='https://...' \
+  --from-literal=STELLAR_HORIZON_URL='https://...' \
+  --from-literal=CHAINSETTTLE_CONTRACT_ID='C...' \
+  --from-literal=USDC_TOKEN_ADDRESS='C...' \
+  --from-literal=STELLAR_SECRET_KEY='S...' \
+  --from-literal=SMTP_HOST='...' \
+  --from-literal=SMTP_USER='...' \
+  --from-literal=SMTP_PASS='...' \
+  --from-literal=EMAIL_FROM='...'
+
+# 3. Install the chart
+helm install chainsettle ./deploy/helm/chainsettle-backend \
+  --set image.repository=<registry>/chainsettle-backend \
+  --set image.tag=0.1.0 \
+  --set existingSecret=chainsettle-backend-secrets \
+  --set replicaCount=1
+```
+
+### Probes
+
+| Probe | Path | Purpose |
+|-------|------|---------|
+| Liveness | `GET /api/v1/health/live` | Process is up |
+| Readiness | `GET /api/v1/health/ready` | Postgres (+ IPFS check) reachable |
+
+### Values of note
+
+See `deploy/helm/chainsettle-backend/values.yaml` for resources, env, and probe tuning. Prefer `existingSecret` over embedding secrets in `secretEnv`.
+
+## Local mock chain (not for k8s staging)
+
+For frontend-only local work without testnet, see `test/mocks/README.md` and `npm run dev:mock-chain`. That mock must never be used as a production or staging chain dependency.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "dev:mock-chain": "ts-node --transpile-only test/mocks/stellar-rpc-server.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/prisma/migrations/20260827000000_add_shipment_favorites/migration.sql
+++ b/prisma/migrations/20260827000000_add_shipment_favorites/migration.sql
@@ -1,0 +1,24 @@
+-- Migration: add_shipment_favorites
+-- Per-user private favorites for quick shipment access
+
+CREATE TABLE "shipment_favorites" (
+    "id"         TEXT         NOT NULL,
+    "shipmentId" TEXT         NOT NULL,
+    "userId"     TEXT         NOT NULL,
+    "createdAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "shipment_favorites_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "shipment_favorites_shipmentId_userId_key"
+    ON "shipment_favorites"("shipmentId", "userId");
+
+CREATE INDEX "shipment_favorites_userId_idx" ON "shipment_favorites"("userId");
+
+ALTER TABLE "shipment_favorites"
+    ADD CONSTRAINT "shipment_favorites_shipmentId_fkey"
+    FOREIGN KEY ("shipmentId") REFERENCES "shipments"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "shipment_favorites"
+    ADD CONSTRAINT "shipment_favorites_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,7 @@ model User {
   apiKeys     ApiKey[]
   notificationPreference NotificationPreference?
   shipmentWatchers ShipmentWatcher[] @relation("ShipmentWatchers")
+  shipmentFavorites ShipmentFavorite[] @relation("ShipmentFavorites")
 
   @@map("users")
 }
@@ -153,6 +154,7 @@ model Shipment {
   shipmentNotes ShipmentNote[]
   trackingUpdates TrackingUpdate[]
   watchers  ShipmentWatcher[]
+  favorites ShipmentFavorite[]
 
   isDraft          Boolean         @default(false) // true when created via CSV bulk import; no on-chain backing yet
 
@@ -478,4 +480,18 @@ model ShipmentWatcher {
   @@unique([shipmentId, userId])
   @@index([userId])
   @@map("shipment_watchers")
+}
+
+model ShipmentFavorite {
+  id         String   @id @default(uuid())
+  shipmentId String
+  userId     String
+  createdAt  DateTime @default(now())
+
+  shipment Shipment @relation(fields: [shipmentId], references: [id], onDelete: Cascade)
+  user     User     @relation("ShipmentFavorites", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([shipmentId, userId])
+  @@index([userId])
+  @@map("shipment_favorites")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,11 +1,12 @@
 import { Module, MiddlewareConsumer } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TerminusModule } from '@nestjs/terminus';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { envValidationSchema } from './config/env.validation';
 import { RolesGuard } from './common/guards/roles.guard';
+import { RateLimitThrottlerGuard } from './common/guards/rate-limit-throttler.guard';
 
 import { PrismaModule } from './common/prisma/prisma.module';
 import { StellarModule } from './common/stellar/stellar.module';
@@ -82,10 +83,10 @@ import { ChainModule } from './modules/chain/chain.module';
     ChainModule,
   ],
   providers: [
-    // Apply global throttler guard (can be overridden per route)
+    // Apply global throttler guard (sets X-RateLimit-* on success and 429)
     {
       provide: APP_GUARD,
-      useClass: ThrottlerGuard,
+      useClass: RateLimitThrottlerGuard,
     },
     // Apply global roles guard — enforces @Roles() decorator across all routes
     {

--- a/src/common/filters/throttler-exception.filter.ts
+++ b/src/common/filters/throttler-exception.filter.ts
@@ -1,30 +1,42 @@
-import { ExceptionFilter, Catch, ArgumentsHost, HttpException } from '@nestjs/common';
+import { ExceptionFilter, Catch, ArgumentsHost } from '@nestjs/common';
 import { ThrottlerException } from '@nestjs/throttler';
-import { Response } from 'express';
+import { Request, Response } from 'express';
+import { RateLimitInfo } from '../guards/rate-limit-throttler.guard';
 
 /**
- * Custom exception filter for throttler exceptions
- * Adds Retry-After header to 429 responses
+ * Custom exception filter for throttler exceptions.
+ * Adds Retry-After and X-RateLimit-* headers to 429 responses.
  */
 @Catch(ThrottlerException)
 export class ThrottlerExceptionFilter implements ExceptionFilter {
   catch(exception: ThrottlerException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
+    const request = ctx.getRequest<Request & { rateLimit?: RateLimitInfo }>();
     const response = ctx.getResponse<Response>();
     const status = exception.getStatus();
-    const exceptionResponse = exception.getResponse() as any;
+    const exceptionResponse = exception.getResponse();
 
-    // Calculate retry-after in seconds (default to 60 if not available)
-    const retryAfter = Math.ceil((exceptionResponse.ttl || 60000) / 1000);
+    const rate = request.rateLimit;
+    const reset = rate?.reset ?? 60;
+    const limit = rate?.limit;
+    const remaining = rate?.remaining ?? 0;
+
+    const message =
+      typeof exceptionResponse === 'string'
+        ? exceptionResponse
+        : (exceptionResponse as { message?: string })?.message || 'Too Many Requests';
 
     response
       .status(status)
-      .header('Retry-After', retryAfter.toString())
+      .header('Retry-After', String(reset))
+      .header('X-RateLimit-Limit', limit !== undefined ? String(limit) : '')
+      .header('X-RateLimit-Remaining', String(remaining))
+      .header('X-RateLimit-Reset', String(reset))
       .json({
         statusCode: status,
-        message: exceptionResponse.message || 'Too Many Requests',
+        message,
         error: 'ThrottlerException',
-        retryAfter: `${retryAfter}s`,
+        retryAfter: `${reset}s`,
       });
   }
 }

--- a/src/common/guards/rate-limit-throttler.guard.ts
+++ b/src/common/guards/rate-limit-throttler.guard.ts
@@ -1,0 +1,76 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+export type RateLimitInfo = {
+  limit: number;
+  remaining: number;
+  reset: number;
+};
+
+/**
+ * Extends ThrottlerGuard so X-RateLimit-* headers are set on both allowed
+ * and 429 responses. Stashes rate-limit metadata on the request for the
+ * ThrottlerExceptionFilter.
+ */
+@Injectable()
+export class RateLimitThrottlerGuard extends ThrottlerGuard {
+  protected async handleRequest(
+    context: ExecutionContext,
+    limit: number,
+    ttl: number,
+    throttler: any,
+    getTracker: any,
+    generateKey: any,
+  ): Promise<boolean> {
+    const { req, res } = this.getRequestResponse(context);
+    const ignoreUserAgents = throttler.ignoreUserAgents ?? this.commonOptions.ignoreUserAgents;
+
+    if (Array.isArray(ignoreUserAgents)) {
+      for (const pattern of ignoreUserAgents) {
+        if (pattern.test(req.headers['user-agent'])) {
+          return true;
+        }
+      }
+    }
+
+    const tracker = await getTracker(req);
+    const key = generateKey(context, tracker, throttler.name);
+    const { totalHits, timeToExpire } = await this.storageService.increment(key, ttl);
+    const suffix = throttler.name === 'default' ? '' : `-${throttler.name}`;
+    const remaining = Math.max(0, limit - totalHits);
+    const reset = Math.max(0, Math.ceil(Number(timeToExpire) || 0));
+
+    const setHeaders = (remainingHits: number) => {
+      res.header(`${this.headerPrefix}-Limit${suffix}`, String(limit));
+      res.header(`${this.headerPrefix}-Remaining${suffix}`, String(remainingHits));
+      res.header(`${this.headerPrefix}-Reset${suffix}`, String(reset));
+    };
+
+    if (totalHits > limit) {
+      setHeaders(0);
+      res.header(`Retry-After${suffix}`, String(reset));
+      (req as { rateLimit?: RateLimitInfo }).rateLimit = {
+        limit,
+        remaining: 0,
+        reset,
+      };
+      await this.throwThrottlingException(context, {
+        limit,
+        ttl,
+        key,
+        tracker,
+        totalHits,
+        timeToExpire: reset,
+      });
+    }
+
+    setHeaders(remaining);
+    (req as { rateLimit?: RateLimitInfo }).rateLimit = {
+      limit,
+      remaining,
+      reset,
+    };
+
+    return true;
+  }
+}

--- a/src/common/guards/stellar-address-throttler.guard.ts
+++ b/src/common/guards/stellar-address-throttler.guard.ts
@@ -1,13 +1,14 @@
-import { Injectable, ExecutionContext } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
+import { Injectable } from '@nestjs/common';
+import { RateLimitThrottlerGuard } from './rate-limit-throttler.guard';
 
 /**
  * Custom throttler guard that uses Stellar address as the throttle key
  * instead of IP address. This prevents shared NAT/proxy users from
  * blocking each other while still rate-limiting per address.
+ * Inherits X-RateLimit-* header behavior from RateLimitThrottlerGuard.
  */
 @Injectable()
-export class StellarAddressThrottlerGuard extends ThrottlerGuard {
+export class StellarAddressThrottlerGuard extends RateLimitThrottlerGuard {
   protected async getTracker(req: Record<string, any>): Promise<string> {
     // For GET /auth/nonce, use the address query parameter
     if (req.query?.address) {

--- a/src/common/throttler/redis-throttler-storage.service.ts
+++ b/src/common/throttler/redis-throttler-storage.service.ts
@@ -31,25 +31,30 @@ export class RedisThrottlerStorageService implements ThrottlerStorage, OnModuleD
 
   async increment(key: string, ttl: number): Promise<{ totalHits: number; timeToExpire: number }> {
     const redisKey = `${this.prefix}${key}`;
-    
+
     try {
+      // Fixed window: only set TTL when the key is new so the window does not slide.
       const multi = this.redis.multi();
       multi.incr(redisKey);
-      multi.pexpire(redisKey, ttl);
       multi.pttl(redisKey);
-      
       const results = await multi.exec();
-      
+
       if (!results) {
         throw new Error('Redis multi command failed');
       }
 
       const totalHits = results[0][1] as number;
-      const timeToExpire = results[2][1] as number;
+      let pttl = results[1][1] as number;
 
+      if (pttl < 0) {
+        await this.redis.pexpire(redisKey, ttl);
+        pttl = ttl;
+      }
+
+      // @nestjs/throttler expects timeToExpire in seconds
       return {
         totalHits,
-        timeToExpire: timeToExpire > 0 ? timeToExpire : 0,
+        timeToExpire: pttl > 0 ? Math.ceil(pttl / 1000) : 0,
       };
     } catch (error) {
       console.error('Redis increment error:', error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,7 +81,13 @@ async function bootstrap() {
         : [fallbackOrigin],
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
-    exposedHeaders: ['X-Request-ID'],
+    exposedHeaders: [
+      'X-Request-ID',
+      'X-RateLimit-Limit',
+      'X-RateLimit-Remaining',
+      'X-RateLimit-Reset',
+      'Retry-After',
+    ],
     credentials: true,
   });
 

--- a/src/modules/shipments/dto/find-all-shipments.dto.ts
+++ b/src/modules/shipments/dto/find-all-shipments.dto.ts
@@ -95,4 +95,12 @@ export class FindAllShipmentsDto {
   @IsBoolean()
   @Transform(({ value }) => value === 'true' || value === true)
   isDraft?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'When true, return only shipments favorited by the authenticated user',
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true' || value === true)
+  favorite?: boolean;
 }

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -149,6 +149,8 @@ export class ShipmentsController {
       includeArchived: query.includeArchived,
       search: query.search,
       isDraft: query.isDraft,
+      favorite: query.favorite,
+      callerUserId: user?.id,
     });
   }
 
@@ -319,8 +321,8 @@ export class ShipmentsController {
   @ApiOperation({ summary: 'Get full shipment details including milestones and events' })
   @ApiResponse({ status: 200, description: 'Shipment found' })
   @ApiResponse({ status: 404, description: 'Shipment not found' })
-  findOne(@Param('id') id: string) {
-    return this.shipmentsService.findOne(id);
+  findOne(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.shipmentsService.findOne(id, user?.id);
   }
 
   /**
@@ -357,6 +359,35 @@ export class ShipmentsController {
   @ApiResponse({ status: 404, description: 'Shipment not found or no metadata set' })
   validateMetadata(@Param('id') id: string, @Body() dto: ValidateMetadataDto) {
     return this.shipmentsService.validateMetadata(id, dto.schema);
+  }
+
+  /**
+   * POST /api/v1/shipments/:id/favorite
+   * Star a shipment for quick access (private to the caller).
+   */
+  @Post(':id/favorite')
+  @UseGuards(ShipmentParticipantGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Favorite (star) a shipment for quick access' })
+  @ApiResponse({ status: 200, description: 'Shipment favorited' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  @ApiResponse({ status: 404, description: 'Shipment not found' })
+  favoriteShipment(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.shipmentsService.favoriteShipment(id, user.id);
+  }
+
+  /**
+   * DELETE /api/v1/shipments/:id/favorite
+   * Remove a shipment from the caller's favorites.
+   */
+  @Delete(':id/favorite')
+  @UseGuards(ShipmentParticipantGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Unfavorite a shipment' })
+  @ApiResponse({ status: 200, description: 'Shipment unfavorited' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  unfavoriteShipment(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.shipmentsService.unfavoriteShipment(id, user.id);
   }
 
   /**

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -190,6 +190,8 @@ export class ShipmentsService {
     includeArchived?: boolean;
     search?: string;
     isDraft?: boolean;
+    favorite?: boolean;
+    callerUserId?: string;
   }) {
     const {
       buyerAddress,
@@ -209,6 +211,8 @@ export class ShipmentsService {
       includeArchived = false,
       search,
       isDraft,
+      favorite,
+      callerUserId,
     } = filters;
 
     if (cursor && page && page !== 1) {
@@ -248,6 +252,13 @@ export class ShipmentsService {
       where.isDraft = isDraft;
     }
 
+    if (favorite === true) {
+      if (!callerUserId) {
+        throw new BadRequestException('Authentication required to filter favorites');
+      }
+      where.favorites = { some: { userId: callerUserId } };
+    }
+
     // Scope to shipments where the caller is a participant (buyer/supplier/logistics/arbiter)
     if (!isAdmin && callerStellarAddress) {
       where.AND = where.AND ?? [];
@@ -260,6 +271,10 @@ export class ShipmentsService {
         ],
       });
     }
+
+    const favoriteInclude = callerUserId
+      ? { favorites: { where: { userId: callerUserId }, select: { id: true } } }
+      : {};
 
     let shipments: any[];
     let total: number | null = null;
@@ -307,6 +322,12 @@ export class ShipmentsService {
           where: { shipmentId: s.id },
           orderBy: { milestoneIndex: 'asc' },
         });
+        if (callerUserId) {
+          s.favorites = await this.prisma.shipmentFavorite.findMany({
+            where: { shipmentId: s.id, userId: callerUserId },
+            select: { id: true },
+          });
+        }
       }
     } else if (cursor) {
       let decoded: { createdAt: string; id: string };
@@ -318,7 +339,10 @@ export class ShipmentsService {
 
       shipments = await this.prisma.shipment.findMany({
         where: { ...where, createdAt: { lte: new Date(decoded.createdAt) } },
-        include: { milestones: { orderBy: { milestoneIndex: 'asc' } } },
+        include: {
+          milestones: { orderBy: { milestoneIndex: 'asc' } },
+          ...favoriteInclude,
+        },
         orderBy: { createdAt: 'desc' },
         cursor: { id: decoded.id },
         skip: 1,
@@ -338,7 +362,10 @@ export class ShipmentsService {
       [shipments, total] = await this.prisma.$transaction([
         this.prisma.shipment.findMany({
           where,
-          include: { milestones: { orderBy: { milestoneIndex: 'asc' } } },
+          include: {
+            milestones: { orderBy: { milestoneIndex: 'asc' } },
+            ...favoriteInclude,
+          },
           orderBy: { createdAt: 'desc' },
           skip: (page - 1) * limit,
           take: limit,
@@ -348,7 +375,7 @@ export class ShipmentsService {
     }
 
     return {
-      data: shipments.map((s) => this.serialize(s)),
+      data: shipments.map((s) => this.serialize(s, callerUserId)),
       meta: cursor
         ? { nextCursor, limit }
         : {
@@ -361,17 +388,20 @@ export class ShipmentsService {
     };
   }
 
-  async findOne(id: string) {
+  async findOne(id: string, callerUserId?: string) {
     const shipment = await this.prisma.shipment.findUnique({
       where: { id },
       include: {
         milestones: { orderBy: { milestoneIndex: 'asc' } },
         events: { orderBy: { ledger: 'desc' }, take: 20 },
         trackingUpdates: { orderBy: { createdAt: 'asc' } },
+        ...(callerUserId
+          ? { favorites: { where: { userId: callerUserId }, select: { id: true } } }
+          : {}),
       },
     });
     if (!shipment) throw new NotFoundException(`Shipment ${id} not found`);
-    return this.serialize(shipment);
+    return this.serialize(shipment, callerUserId);
   }
 
   async bulkStatus(
@@ -1066,6 +1096,37 @@ export class ShipmentsService {
     })) || [];
 
     return { valid: false, errors };
+  }
+
+  // ----------------------------------------------------------
+  // FAVORITES
+  // ----------------------------------------------------------
+
+  async favoriteShipment(shipmentId: string, userId: string) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+    });
+    if (!shipment) throw new NotFoundException(`Shipment ${shipmentId} not found`);
+
+    const existing = await this.prisma.shipmentFavorite.findFirst({
+      where: { shipmentId, userId },
+    });
+
+    if (!existing) {
+      await this.prisma.shipmentFavorite.create({
+        data: { shipmentId, userId },
+      });
+    }
+
+    return { favorited: true, shipmentId, userId };
+  }
+
+  async unfavoriteShipment(shipmentId: string, userId: string) {
+    await this.prisma.shipmentFavorite.deleteMany({
+      where: { shipmentId, userId },
+    });
+
+    return { unfavorited: true };
   }
 
   // ----------------------------------------------------------
@@ -1856,7 +1917,7 @@ export class ShipmentsService {
     await this.redis.delByPrefix(`shipments:${callerStellarAddress}:`);
   }
 
-  private serialize(shipment: any) {
+  private serialize(shipment: any, callerUserId?: string) {
     const now = new Date();
     const decimals: number = shipment.tokenDecimals ?? 7;
     const symbol: string = shipment.tokenSymbol ?? 'USDC';
@@ -1876,14 +1937,20 @@ export class ShipmentsService {
       ? trackingUpdates[trackingUpdates.length - 1]
       : null;
 
+    const { favorites, ...rest } = shipment;
+    const isFavorited = callerUserId
+      ? Array.isArray(favorites) && favorites.length > 0
+      : false;
+
     return {
-      ...shipment,
+      ...rest,
       tokenSymbol: symbol,
       tokenDecimals: decimals,
       totalAmount: shipment.totalAmount?.toString(),
       releasedAmount: shipment.releasedAmount?.toString(),
       totalAmountFormatted: this.stellar.toHumanAmount(shipment.totalAmount ?? 0n, decimals),
       releasedAmountFormatted: this.stellar.toHumanAmount(shipment.releasedAmount ?? 0n, decimals),
+      isFavorited,
       milestones: shipment.milestones?.map((m: any) => {
         const isOverdue =
           m.dueAt &&

--- a/test-rate-limit.sh
+++ b/test-rate-limit.sh
@@ -2,9 +2,15 @@
 
 # Test script for rate limiting on auth endpoints
 # Usage: ./test-rate-limit.sh
+# Verifies X-RateLimit-Limit / Remaining / Reset on success and 429 responses.
 
 API_URL="http://localhost:3000/api/v1"
 TEST_ADDRESS="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+print_rate_headers() {
+  local headers="$1"
+  echo "$headers" | grep -iE '^(HTTP/|X-RateLimit-|Retry-After:)' || true
+}
 
 echo "=========================================="
 echo "Testing Rate Limiting on Auth Endpoints"
@@ -15,8 +21,12 @@ echo "1. Testing GET /auth/nonce (limit: 5 per minute)"
 echo "--------------------------------------------------"
 for i in {1..7}; do
   echo "Request $i:"
-  curl -s -w "\nHTTP Status: %{http_code}\n" \
-    "${API_URL}/auth/nonce?address=${TEST_ADDRESS}" | jq -C '.'
+  HEADERS=$(mktemp)
+  BODY=$(curl -s -D "$HEADERS" -o - \
+    "${API_URL}/auth/nonce?address=${TEST_ADDRESS}")
+  print_rate_headers "$(cat "$HEADERS")"
+  echo "$BODY" | jq -C '.' 2>/dev/null || echo "$BODY"
+  rm -f "$HEADERS"
   echo ""
   sleep 1
 done
@@ -26,10 +36,14 @@ echo "2. Testing POST /auth/login (limit: 10 per minute)"
 echo "---------------------------------------------------"
 for i in {1..12}; do
   echo "Request $i:"
-  curl -s -w "\nHTTP Status: %{http_code}\n" \
+  HEADERS=$(mktemp)
+  BODY=$(curl -s -D "$HEADERS" -o - \
     -X POST "${API_URL}/auth/login" \
     -H "Content-Type: application/json" \
-    -d "{\"stellarAddress\":\"${TEST_ADDRESS}\",\"signature\":\"test\",\"signedNonce\":\"test\"}" | jq -C '.'
+    -d "{\"stellarAddress\":\"${TEST_ADDRESS}\",\"signature\":\"test\",\"signedNonce\":\"test\"}")
+  print_rate_headers "$(cat "$HEADERS")"
+  echo "$BODY" | jq -C '.' 2>/dev/null || echo "$BODY"
+  rm -f "$HEADERS"
   echo ""
   sleep 1
 done
@@ -40,7 +54,9 @@ echo "Test Complete"
 echo "=========================================="
 echo ""
 echo "Expected behavior:"
+echo "- Successful responses include X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset"
 echo "- Nonce endpoint: First 5 requests succeed, 6th and 7th return 429"
+echo "- On 429: X-RateLimit-Remaining=0 and X-RateLimit-Reset / Retry-After indicate retry window"
 echo "- Login endpoint: First 10 requests fail with 401 (invalid signature),"
-echo "  11th and 12th return 429 (rate limited)"
+echo "  11th and 12th return 429 (rate limited) with the same rate-limit headers"
 echo ""

--- a/test/mocks/README.md
+++ b/test/mocks/README.md
@@ -1,0 +1,36 @@
+# Mock Stellar chain (DEV ONLY)
+
+Lightweight Soroban JSON-RPC + Horizon stub for local frontend work against this backend **without** a live Stellar testnet connection.
+
+## Quick start
+
+```bash
+# Terminal 1 — mock chain
+npm run dev:mock-chain
+
+# Terminal 2 — point backend at the mock (override in .env)
+STELLAR_RPC_URL=http://127.0.0.1:8787
+STELLAR_HORIZON_URL=http://127.0.0.1:8788
+npm run start:dev
+```
+
+Default ports: RPC `8787`, Horizon `8788` (override with `STELLAR_MOCK_RPC_PORT` / `STELLAR_MOCK_HORIZON_PORT`).
+
+## What works
+
+- Backend boot and `GET /chain/status` (`getHealth` / `getLatestLedger`)
+- Event poller idle loop (`getEvents` → empty)
+- Auth (wallet signature is local — no RPC)
+- Shipment CRUD / favoriting against Postgres (no live chain needed)
+- Soft stubs for `simulateTransaction`, `getLedgerEntries`, Horizon `GET /accounts/:id`
+
+## Tradeoffs (read carefully)
+
+| Capability | Mock behavior |
+|------------|---------------|
+| Signature / tx submission | **Not verified / not submitted** — frontend Freighter writes still need a real network |
+| Contract events | Always empty — no real milestone progression from chain |
+| `simulateTransaction` | Canned envelope — not real XDR / contract state |
+| Ledger progression | Synthetic counter only |
+
+**This is not a staging environment.** Do not use it to validate real Soroban behavior, funding, or event pipelines. Use Stellar testnet for integration tests.

--- a/test/mocks/stellar-rpc-server.ts
+++ b/test/mocks/stellar-rpc-server.ts
@@ -1,0 +1,186 @@
+/**
+ * Lightweight mock Soroban JSON-RPC + Horizon stub for local frontend development.
+ *
+ * DEV ONLY — not a substitute for testnet/mainnet integration testing.
+ * - No real signature verification
+ * - No real event emission or ledger progression beyond a static counter
+ * - simulateTransaction returns canned success envelopes (not real XDR)
+ *
+ * Usage:
+ *   npm run dev:mock-chain
+ *   # then point .env at:
+ *   #   STELLAR_RPC_URL=http://127.0.0.1:8787
+ *   #   STELLAR_HORIZON_URL=http://127.0.0.1:8788
+ */
+
+import * as http from 'http';
+import { URL } from 'url';
+
+const RPC_PORT = Number(process.env.STELLAR_MOCK_RPC_PORT || 8787);
+const HORIZON_PORT = Number(process.env.STELLAR_MOCK_HORIZON_PORT || 8788);
+
+let latestLedger = 1_000_000;
+
+function json(res: http.ServerResponse, status: number, body: unknown) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+function handleRpc(method: string, params: any, id: unknown) {
+  switch (method) {
+    case 'getHealth':
+      return { jsonrpc: '2.0', id, result: { status: 'healthy' } };
+
+    case 'getLatestLedger':
+      latestLedger += 1;
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          id: 'mock-ledger',
+          protocolVersion: 21,
+          sequence: latestLedger,
+        },
+      };
+
+    case 'getEvents':
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          events: [],
+          latestLedger,
+          cursor: String(params?.startLedger ?? latestLedger),
+        },
+      };
+
+    case 'getLedger':
+    case 'getLedgers':
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          ledgers: [
+            {
+              hash: '0'.repeat(64),
+              sequence: params?.startLedger ?? latestLedger,
+              ledgerCloseTime: Math.floor(Date.now() / 1000).toString(),
+            },
+          ],
+          latestLedger,
+        },
+      };
+
+    case 'getAccount':
+      return {
+        jsonrpc: '2.0',
+        id,
+        error: { code: -32600, message: 'Account not found (mock)' },
+      };
+
+    case 'simulateTransaction':
+      // Canned envelope — sync/reconcile paths should tolerate this without live chain.
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          transactionData: '',
+          minResourceFee: '100',
+          cost: { cpuInsns: '0', memBytes: '0' },
+          results: [{ auth: [], xdr: 'AAAAAA==' }],
+          latestLedger,
+          events: [],
+        },
+      };
+
+    case 'getLedgerEntries':
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          entries: [],
+          latestLedger,
+        },
+      };
+
+    default:
+      return {
+        jsonrpc: '2.0',
+        id,
+        error: { code: -32601, message: `Method not found (mock): ${method}` },
+      };
+  }
+}
+
+const rpcServer = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/health') {
+    return json(res, 200, { status: 'ok', service: 'mock-soroban-rpc' });
+  }
+
+  if (req.method !== 'POST') {
+    return json(res, 405, { error: 'Method Not Allowed' });
+  }
+
+  const chunks: Buffer[] = [];
+  req.on('data', (c) => chunks.push(c));
+  req.on('end', () => {
+    try {
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      const response = handleRpc(body.method, body.params, body.id);
+      json(res, 200, response);
+    } catch (err: any) {
+      json(res, 400, {
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: err?.message || 'Parse error' },
+      });
+    }
+  });
+});
+
+const horizonServer = http.createServer((req, res) => {
+  const url = new URL(req.url || '/', `http://127.0.0.1:${HORIZON_PORT}`);
+
+  if (req.method === 'GET' && url.pathname === '/') {
+    return json(res, 200, {
+      horizon_version: 'mock',
+      core_version: 'mock',
+      network_passphrase: 'Test SDF Network ; September 2015',
+    });
+  }
+
+  const accountMatch = url.pathname.match(/^\/accounts\/([A-Z0-9]+)$/);
+  if (req.method === 'GET' && accountMatch) {
+    const address = accountMatch[1];
+    return json(res, 200, {
+      id: address,
+      account_id: address,
+      sequence: '1',
+      balances: [{ asset_type: 'native', balance: '10000.0000000' }],
+      signers: [{ key: address, weight: 1, type: 'ed25519_public_key' }],
+      thresholds: { low_threshold: 0, med_threshold: 0, high_threshold: 0 },
+      flags: { auth_required: false, auth_revocable: false },
+    });
+  }
+
+  json(res, 404, { type: 'https://stellar.org/horizon-errors/not_found', title: 'Resource Missing', status: 404 });
+});
+
+rpcServer.listen(RPC_PORT, '127.0.0.1', () => {
+  console.log(`[mock-chain] Soroban RPC  → http://127.0.0.1:${RPC_PORT}`);
+});
+
+horizonServer.listen(HORIZON_PORT, '127.0.0.1', () => {
+  console.log(`[mock-chain] Horizon stub → http://127.0.0.1:${HORIZON_PORT}`);
+  console.log('');
+  console.log('DEV ONLY — set in .env:');
+  console.log(`  STELLAR_RPC_URL=http://127.0.0.1:${RPC_PORT}`);
+  console.log(`  STELLAR_HORIZON_URL=http://127.0.0.1:${HORIZON_PORT}`);
+  console.log('');
+  console.log('Tradeoffs: no real signatures, events, or on-chain state.');
+  console.log('Do NOT use for integration testing of real chain behavior.');
+});


### PR DESCRIPTION
## Summary

Closes #251
closes #250
closes #248
closes #240

### #251 — Rate-limit response headers
- Extended throttling so every throttled response (success and 429) includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`
- New `RateLimitThrottlerGuard` (global `APP_GUARD`); `StellarAddressThrottlerGuard` inherits the same header behavior
- `ThrottlerExceptionFilter` now attaches the same headers on 429 (plus `Retry-After`)
- Redis storage returns TTL in **seconds** and uses a fixed window (TTL set only when the key is new)
- CORS `exposedHeaders` updated so browsers can read the rate-limit headers
- Documented in README; `test-rate-limit.sh` prints the headers

### #250 — Local mock Stellar RPC
- Added `test/mocks/stellar-rpc-server.ts` (Soroban JSON-RPC on `:8787` + Horizon stub on `:8788`)
- `npm run dev:mock-chain` starts both stubs
- Canned handlers for `getHealth`, `getLatestLedger`, `getEvents`, `simulateTransaction`, etc.
- Documented as **dev-only** in `test/mocks/README.md`, README, and `.env.example` (no real signatures / events / chain state)

### #248 — Docker + Helm
- Multi-stage `Dockerfile` (Node 20 Alpine: build → slim runtime with `prisma generate` + `node dist/main`)
- Helm chart at `deploy/helm/chainsettle-backend` with:
  - configurable env / secrets
  - liveness `/api/v1/health/live` and readiness `/api/v1/health/ready`
  - **default `replicaCount: 1`** (in-process event poller / crons)
- Usage documented in `docs/deployment.md`

### #240 — Shipment favoriting
- Prisma `ShipmentFavorite` join table + migration `20260827000000_add_shipment_favorites`
- `POST /shipments/:id/favorite` and `DELETE /shipments/:id/favorite` (participant-guarded; private per user)
- `GET /shipments?favorite=true` filter
- `isFavorited` on list/detail responses for the authenticated user

## Test plan
- [ ] Run `./test-rate-limit.sh` and confirm `X-RateLimit-*` on 200 and 429
- [ ] `npm run dev:mock-chain`, point `.env` at mock URLs, `npm run start:dev` — auth + shipment list work without testnet
- [ ] `docker build -t chainsettle-backend .` boots with Postgres/Redis env
- [ ] `helm template` / `helm install` with secrets; probes pass; leave replicas at 1
- [ ] `npx prisma migrate deploy` then favorite/unfavorite a shipment; list with `?favorite=true` and confirm `isFavorited`; second user does not see the favorite