### PR TITLE
Add DB docs, API versioning, admin impersonation, and typed SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,13 @@ NODE_ENV=development
 # [optional] Port the HTTP server listens on (default: 3000)
 PORT=3000
 
-# [optional] Global API route prefix (default: api/v1)
-API_PREFIX=api/v1
+# [optional] Global API route prefix without version (default: api).
+# URI versioning appends /v1, /v2 — so routes live at /api/v1/..., /api/v2/...
+# Legacy value "api/v1" is still accepted and normalized to "api".
+API_PREFIX=api
+
+# [optional] Lifetime of admin impersonation JWTs (default: 15m)
+IMPERSONATION_JWT_EXPIRES_IN=15m
 
 # ── JWT Auth ─────────────────────────────────────────────────
 # [required] Secret used to sign JWT tokens. Use a long random string in production.

--- a/.github/workflows/sdk-drift.yml
+++ b/.github/workflows/sdk-drift.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  sdk-drift:
+    name: SDK drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Check SDK is in sync with OpenAPI schema
+        run: npm run check:sdk

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ The backend is the **bridge between the Stellar blockchain and the frontend**. I
 
 ## API Endpoints
 
-All endpoints are prefixed with `/api/v1`. Protected routes require `Authorization: Bearer <JWT>`.
+All endpoints are prefixed with `/api/v1` (URI versioning; see [API Versioning](#api-versioning) below). Protected routes require `Authorization: Bearer <JWT>`.
+
+> Database schema reference (ERD + tables): [docs/database.md](./docs/database.md)
+>
+> Typed TypeScript SDK: [sdk/](./sdk/) — regenerate with `npm run generate:sdk`
 
 ### Auth
 | Method | Path | Description |
@@ -237,6 +241,69 @@ Swagger docs at: `http://localhost:3000/docs`
 
 ---
 
+## API Versioning
+
+The API uses NestJS **URI versioning**. The global prefix is `api`; the version segment is `v1`, `v2`, etc.
+
+| Version | Base path | Status |
+|---------|-----------|--------|
+| v1 | `/api/v1/*` | Current (default) |
+| v2 | `/api/v2/*` | Introduce when you need a breaking change |
+
+### Adding a `/api/v2` controller without touching v1
+
+Create a parallel controller (new file) and set the version explicitly:
+
+```ts
+import { Controller, Get, Version } from '@nestjs/common';
+
+// Option A — version on the controller
+@Controller({ path: 'shipments', version: '2' })
+export class ShipmentsV2Controller {
+  @Get()
+  listV2() { /* new response shape */ }
+}
+
+// Option B — version on a single handler inside a shared controller
+@Controller('shipments')
+export class ShipmentsController {
+  @Get()
+  @Version('1')
+  listV1() { /* existing */ }
+
+  @Get()
+  @Version('2')
+  listV2() { /* breaking change */ }
+}
+```
+
+Register the new controller in the same module. Existing `@Controller('shipments')` handlers keep serving **v1** via `defaultVersion: '1'` in `main.ts`.
+
+### Deprecation policy
+
+When a v1 route is scheduled for removal:
+
+1. Annotate it with `@DeprecatedRoute({ sunset: 'Wed, 01 Jul 2027 00:00:00 GMT', link: 'https://docs.example.com/migration' })`.
+2. Clients receive `Deprecation` and `Sunset` response headers (and optional `Link`).
+3. Keep the route until the Sunset date; then remove it once consumers have moved to v2.
+
+`Deprecation` / `Sunset` / `Link` are exposed in CORS `exposedHeaders` so browsers can read them.
+
+---
+
+## TypeScript SDK
+
+A typed client is generated from the Swagger/OpenAPI document into [`sdk/`](./sdk/):
+
+```bash
+npm run generate:sdk   # refresh openapi.json + schema.ts
+npm run check:sdk      # CI: fail if sdk/ is stale
+```
+
+See [sdk/README.md](./sdk/README.md).
+
+---
+
 ## Running Tests
 
 ```bash
@@ -337,9 +404,11 @@ Errors follow a standardised format from `HttpExceptionFilter`:
 |----------|----------|-------------|
 | `NODE_ENV` | Yes | `development` or `production` |
 | `PORT` | No | API port (default: 3000) |
+| `API_PREFIX` | No | Route prefix without version (default: `api`) |
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
 | `JWT_SECRET` | Yes | Secret for signing JWTs |
 | `JWT_EXPIRES_IN` | No | Token expiry (default: `7d`) |
+| `IMPERSONATION_JWT_EXPIRES_IN` | No | Admin impersonation token TTL (default: `15m`) |
 | `STELLAR_NETWORK` | Yes | `testnet` or `mainnet` |
 | `STELLAR_RPC_URL` | Yes | Soroban RPC endpoint |
 | `CHAINSETTTLE_CONTRACT_ID` | Yes | Deployed contract address |

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,253 @@
+# ChainSettle Database Schema
+
+Human-readable reference for the PostgreSQL data model. **Source of truth:** [`prisma/schema.prisma`](../prisma/schema.prisma).
+
+---
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+  User ||--o{ Shipment : "buyer"
+  User ||--o{ Shipment : "supplier"
+  User ||--o{ Shipment : "logistics"
+  User ||--o{ Shipment : "arbiter"
+  User ||--o{ Notification : has
+  User ||--o{ AuditLog : "actor"
+  User ||--o{ ApiKey : owns
+  User ||--o{ WebhookEndpoint : owns
+  User ||--o{ ShipmentTemplate : owns
+  User ||--o{ NotificationPreference : has
+  User ||--o{ ShipmentWatcher : watches
+  User ||--o{ ShipmentComment : authors
+  User ||--o{ ShipmentNote : authors
+  User ||--o{ DisputeEvidence : submits
+  User ||--o{ TrackingUpdate : submits
+
+  Shipment ||--|{ Milestone : contains
+  Shipment ||--o{ ChainEvent : emits
+  Shipment ||--o{ ShipmentComment : has
+  Shipment ||--o{ ShipmentNote : has
+  Shipment ||--o{ TrackingUpdate : has
+  Shipment ||--o{ ShipmentWatcher : watched_by
+
+  Milestone ||--o{ ProofSubmission : has
+  Milestone ||--o{ DisputeEvidence : has
+
+  WebhookEndpoint ||--o{ WebhookDelivery : delivers
+
+  User {
+    uuid id PK
+    string stellarAddress UK
+    string email UK
+    UserRole role
+    datetime deactivatedAt
+  }
+
+  Shipment {
+    string id PK
+    string buyerAddress FK
+    string supplierAddress FK
+    string logisticsAddress FK
+    string arbiterAddress FK
+    bigint totalAmount
+    ShipmentStatus status
+    boolean isDraft
+  }
+
+  Milestone {
+    uuid id PK
+    string shipmentId FK
+    int milestoneIndex
+    int paymentPercent
+    MilestoneStatus status
+    datetime dueAt
+  }
+
+  ChainEvent {
+    uuid id PK
+    string shipmentId FK
+    string eventName
+    string txHash
+    int ledger
+    json payload
+  }
+
+  Notification {
+    uuid id PK
+    uuid userId FK
+    NotificationType type
+    boolean read
+  }
+
+  WebhookEndpoint {
+    uuid id PK
+    uuid userId FK
+    string url
+    string secret
+    string_array events
+  }
+
+  WebhookDelivery {
+    uuid id PK
+    uuid endpointId FK
+    string eventType
+    int attemptCount
+  }
+
+  ShipmentTemplate {
+    uuid id PK
+    uuid ownerId FK
+    string name
+    json milestoneTemplates
+    boolean isPublic
+  }
+
+  ApiKey {
+    uuid id PK
+    uuid userId FK
+    string keyHash UK
+    string name
+    datetime revokedAt
+  }
+
+  AuditLog {
+    uuid id PK
+    uuid userId FK
+    string action
+    string entityType
+    string entityId
+    json metadata
+  }
+```
+
+---
+
+## Table Reference
+
+### `users` (User)
+
+Platform identity keyed by Stellar public address. Roles: `BUYER`, `SUPPLIER`, `LOGISTICS`, `ARBITER`, `ADMIN`. Soft-deactivation via `deactivatedAt`.
+
+**Key relationships:** Participates in shipments by address; owns notifications, API keys, webhooks, templates, audit logs, watchers.
+
+---
+
+### `shipments` (Shipment)
+
+Off-chain mirror of an on-chain escrow shipment. `id` matches the Soroban shipment ID. Amounts are in stroops (`BigInt`).
+
+**Key relationships:** Four participant FKs → `users.stellarAddress`; has many milestones, chain events, comments, notes, tracking updates, watchers.
+
+---
+
+### `milestones` (Milestone)
+
+Payment tranche within a shipment. Unique on `(shipmentId, milestoneIndex)`. Tracks proof, confirmation, deadlines, and dispute escalation.
+
+**Key relationships:** Belongs to shipment; has proof submissions and dispute evidence.
+
+---
+
+### `chain_events` (ChainEvent)
+
+Persisted on-chain events from the Stellar poller. Deduped by `(txHash, eventName)`.
+
+**Key relationships:** Optional FK to shipment.
+
+---
+
+### `notifications` (Notification)
+
+In-app notification for a user (shipment lifecycle, disputes, comments, etc.).
+
+**Key relationships:** Belongs to user.
+
+---
+
+### `webhook_endpoints` / `webhook_deliveries` (WebhookEndpoint / WebhookDelivery)
+
+User-configured HTTP callbacks. Endpoint stores a hashed signing secret and subscribed event types; deliveries track retries.
+
+**Key relationships:** Endpoint → user; delivery → endpoint.
+
+---
+
+### `shipment_templates` (ShipmentTemplate)
+
+Reusable shipment blueprints (participants + milestone template JSON). Can be private or public.
+
+**Key relationships:** Owned by user.
+
+---
+
+### `api_keys` (ApiKey)
+
+Machine credentials. Only the SHA-256 `keyHash` is stored; plaintext is shown once at creation.
+
+**Key relationships:** Owned by user; soft-revoked via `revokedAt`.
+
+---
+
+### `audit_logs` (AuditLog)
+
+Insert-only audit trail for mutations and sensitive admin actions (including impersonation). Links to the acting user via `userId` / `actorId`.
+
+**Key relationships:** Belongs to user (actor).
+
+---
+
+### Supporting tables
+
+| Table | Purpose |
+|-------|---------|
+| `proof_submissions` | History of IPFS proof uploads per milestone |
+| `dispute_evidence` | Buyer/supplier evidence on disputed milestones |
+| `shipment_comments` | Participant discussion threads |
+| `shipment_notes` | Admin-only internal notes |
+| `tracking_updates` | Logistics location/status updates |
+| `shipment_watchers` | Users following a shipment |
+| `notification_preferences` | Per-user in-app/email preference JSON |
+| `event_cursors` | Stellar poller ledger cursor |
+| `failed_events` | Dead-letter queue for event processing |
+| `reconciliation_runs` | On-chain vs DB reconciliation job results |
+| `app_config` | Runtime key/value config (e.g. IPFS limits) |
+
+---
+
+## Migration Workflow
+
+| Command | When to use |
+|---------|-------------|
+| `npx prisma migrate dev --name <desc>` | **Local development.** Creates a migration from schema diffs, applies it, regenerates the client. |
+| `npx prisma migrate deploy` | **CI / staging / production.** Applies already-committed migrations only — never creates new ones. |
+| `npx prisma generate` | Regenerates `@prisma/client` after pulling schema/migration changes (no DB write). |
+| `npx prisma migrate status` | Shows which migrations are pending. |
+
+**Contributor rules:**
+
+1. Edit `prisma/schema.prisma`, then run `migrate dev` locally.
+2. Commit both the schema change and the new folder under `prisma/migrations/`.
+3. Never run `migrate dev` against production; use `migrate deploy` there.
+4. After schema changes, regenerate the ERD docs (below).
+
+---
+
+## Regenerating the ERD
+
+After changing `prisma/schema.prisma`, update this document:
+
+1. Reflect new/removed models and relations in the Mermaid `erDiagram` above.
+2. Add or adjust the matching section under **Table Reference**.
+3. Keep the diagram focused on primary entities; supporting tables can stay in the summary table.
+
+Optional tooling (if you prefer auto-generation later):
+
+```bash
+# Example: prisma-erd-generator (optional, not required)
+# 1. Add generator to schema.prisma
+# 2. npx prisma generate
+# 3. Copy/adapt output into this file's Mermaid block
+```
+
+There is no committed auto-generator today — the Mermaid diagram is **manually maintained** from the Prisma schema so docs stay reviewable in PRs without extra binary deps.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "generate:sdk": "node scripts/generate-sdk.js",
+    "check:sdk": "node scripts/check-sdk.js"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -86,7 +88,8 @@
     "ts-loader": "^9.4.3",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "openapi-typescript": "^7.4.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/scripts/check-sdk.js
+++ b/scripts/check-sdk.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * CI drift detection: regenerate the SDK and fail if sdk/ differs from git.
+ */
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+
+console.log('→ Regenerating SDK…');
+const gen = spawnSync('node', ['scripts/generate-sdk.js'], {
+  cwd: root,
+  stdio: 'inherit',
+  env: process.env,
+});
+
+if (gen.status !== 0) {
+  process.exit(gen.status || 1);
+}
+
+console.log('→ Checking for drift in sdk/…');
+const diff = spawnSync('git', ['diff', '--exit-code', '--', 'sdk/'], {
+  cwd: root,
+  encoding: 'utf8',
+});
+
+if (diff.status !== 0) {
+  console.error('SDK output is stale relative to the OpenAPI schema.');
+  console.error('Run `npm run generate:sdk` and commit the updated sdk/ files.');
+  if (diff.stdout) console.error(diff.stdout);
+  if (diff.stderr) console.error(diff.stderr);
+  process.exit(1);
+}
+
+// Also fail on untracked sdk files that should be committed
+const untracked = spawnSync(
+  'git',
+  ['ls-files', '--others', '--exclude-standard', '--', 'sdk/'],
+  { cwd: root, encoding: 'utf8' },
+);
+
+if (untracked.stdout && untracked.stdout.trim().length > 0) {
+  console.error('Untracked files under sdk/ — commit them after generate:sdk:');
+  console.error(untracked.stdout);
+  process.exit(1);
+}
+
+console.log('✓ SDK is in sync with the OpenAPI schema');

--- a/scripts/generate-sdk.js
+++ b/scripts/generate-sdk.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Generates the TypeScript SDK from the NestJS OpenAPI document.
+ *
+ * 1. Boots the app with SDK_GENERATE=1 (skips DB/Redis side effects)
+ * 2. Writes sdk/openapi.json
+ * 3. Runs openapi-typescript → sdk/schema.ts
+ *
+ * Usage: npm run generate:sdk
+ */
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const sdkDir = path.join(root, 'sdk');
+const openapiPath = path.join(sdkDir, 'openapi.json');
+const schemaPath = path.join(sdkDir, 'schema.ts');
+
+fs.mkdirSync(sdkDir, { recursive: true });
+
+const env = {
+  ...process.env,
+  SDK_GENERATE: '1',
+  NODE_ENV: process.env.NODE_ENV || 'development',
+  JWT_SECRET: process.env.JWT_SECRET || 'sdk-generate-secret-not-for-production',
+  DATABASE_URL:
+    process.env.DATABASE_URL ||
+    'postgresql://sdk:sdk@127.0.0.1:5432/sdk_generate',
+  REDIS_URL: process.env.REDIS_URL || 'redis://127.0.0.1:6379',
+  STELLAR_RPC_URL: process.env.STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org',
+  STELLAR_HORIZON_URL:
+    process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org',
+  CHAINSETTTLE_CONTRACT_ID:
+    process.env.CHAINSETTTLE_CONTRACT_ID || 'C'.padEnd(56, 'A'),
+  USDC_TOKEN_ADDRESS: process.env.USDC_TOKEN_ADDRESS || 'C'.padEnd(56, 'B'),
+  STELLAR_SECRET_KEY:
+    process.env.STELLAR_SECRET_KEY ||
+    'SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM',
+  SMTP_HOST: process.env.SMTP_HOST || 'localhost',
+  SMTP_USER: process.env.SMTP_USER || 'sdk',
+  SMTP_PASS: process.env.SMTP_PASS || 'sdk',
+  EMAIL_FROM: process.env.EMAIL_FROM || 'sdk@example.com',
+  API_PREFIX: process.env.API_PREFIX || 'api',
+};
+
+console.log('→ Exporting OpenAPI schema via NestJS bootstrap…');
+const exportResult = spawnSync(
+  'npx',
+  ['ts-node', '-r', 'tsconfig-paths/register', 'src/main.ts'],
+  { cwd: root, env, encoding: 'utf8', stdio: 'inherit' },
+);
+
+if (exportResult.status !== 0) {
+  console.error('Failed to export OpenAPI schema');
+  process.exit(exportResult.status || 1);
+}
+
+if (!fs.existsSync(openapiPath)) {
+  console.error(`Expected ${openapiPath} to exist after export`);
+  process.exit(1);
+}
+
+console.log('→ Generating TypeScript types with openapi-typescript…');
+const genResult = spawnSync(
+  'npx',
+  ['openapi-typescript', openapiPath, '-o', schemaPath],
+  { cwd: root, env, encoding: 'utf8', stdio: 'inherit' },
+);
+
+if (genResult.status !== 0) {
+  console.error('openapi-typescript failed');
+  process.exit(genResult.status || 1);
+}
+
+console.log('✓ SDK generated in sdk/');

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,31 @@
+# @chainsettle/sdk
+
+Auto-generated TypeScript client for the ChainSettle REST API.
+
+## Regenerate
+
+From the backend repo root:
+
+```bash
+npm run generate:sdk
+```
+
+This refreshes `openapi.json` from the NestJS Swagger document and regenerates `schema.ts`.
+
+## Usage
+
+```ts
+import { createClient } from '@chainsettle/sdk';
+
+const client = createClient({
+  baseUrl: 'http://localhost:3000',
+  accessToken: process.env.TOKEN,
+});
+
+const shipments = await client.v1.getShipments({ page: 1 });
+const detail = await client.v1.getShipment('SHIP-001');
+```
+
+## CI drift check
+
+`npm run check:sdk` regenerates the SDK and fails if `sdk/` differs from git.

--- a/sdk/client.ts
+++ b/sdk/client.ts
@@ -1,0 +1,144 @@
+/**
+ * Typed ChainSettle API client built on the generated OpenAPI schema.
+ * Regenerate schema with: npm run generate:sdk
+ */
+import type { paths } from './schema';
+
+export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
+
+export interface ClientOptions {
+  /** API origin, e.g. https://api.example.com (no trailing slash) */
+  baseUrl: string;
+  /** Bearer JWT (or impersonation token) */
+  accessToken?: string;
+  /** Optional fetch implementation (defaults to global fetch) */
+  fetch?: typeof fetch;
+}
+
+type Path = keyof paths;
+type PathMethods<P extends Path> = keyof paths[P] & HttpMethod;
+
+type Operation<P extends Path, M extends PathMethods<P>> = paths[P][M] extends {
+  responses: infer _R;
+}
+  ? paths[P][M]
+  : never;
+
+type ResponseJson<P extends Path, M extends PathMethods<P>> = Operation<
+  P,
+  M
+> extends {
+  responses: { 200: { content: { 'application/json': infer J } } };
+}
+  ? J
+  : Operation<P, M> extends {
+      responses: { 201: { content: { 'application/json': infer J } } };
+    }
+    ? J
+    : unknown;
+
+type RequestBody<P extends Path, M extends PathMethods<P>> = Operation<
+  P,
+  M
+> extends {
+  requestBody: { content: { 'application/json': infer B } };
+}
+  ? B
+  : undefined;
+
+function joinUrl(base: string, p: string): string {
+  return `${base.replace(/\/$/, '')}${p.startsWith('/') ? p : `/${p}`}`;
+}
+
+/**
+ * Create a typed client for the ChainSettle REST API.
+ * Paths follow the OpenAPI document (e.g. `/api/v1/shipments`).
+ */
+export function createClient(options: ClientOptions) {
+  const fetcher = options.fetch ?? globalThis.fetch.bind(globalThis);
+
+  async function request<P extends Path, M extends PathMethods<P>>(
+    apiPath: P,
+    method: M,
+    init?: {
+      body?: RequestBody<P, M>;
+      query?: Record<string, string | number | boolean | undefined>;
+      headers?: Record<string, string>;
+      pathParams?: Record<string, string | number>;
+    },
+  ): Promise<ResponseJson<P, M>> {
+    let resolvedPath = String(apiPath);
+    if (init?.pathParams) {
+      for (const [key, value] of Object.entries(init.pathParams)) {
+        resolvedPath = resolvedPath.replace(`{${key}}`, encodeURIComponent(String(value)));
+      }
+    }
+
+    let url = joinUrl(options.baseUrl, resolvedPath);
+
+    if (init?.query) {
+      const qs = new URLSearchParams();
+      for (const [k, v] of Object.entries(init.query)) {
+        if (v !== undefined && v !== null) qs.set(k, String(v));
+      }
+      const s = qs.toString();
+      if (s) url += `?${s}`;
+    }
+
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...(init?.headers ?? {}),
+    };
+    if (options.accessToken) {
+      headers.Authorization = `Bearer ${options.accessToken}`;
+    }
+
+    let body: string | undefined;
+    if (init?.body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      body = JSON.stringify(init.body);
+    }
+
+    const res = await fetcher(url, {
+      method: String(method).toUpperCase(),
+      headers,
+      body,
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(
+        `API ${String(method).toUpperCase()} ${resolvedPath} failed (${res.status}): ${text}`,
+      );
+    }
+
+    if (res.status === 204) {
+      return undefined as ResponseJson<P, M>;
+    }
+
+    return (await res.json()) as ResponseJson<P, M>;
+  }
+
+  return {
+    request,
+    /** Convenience helpers for common v1 endpoints */
+    v1: {
+      getShipments: (query?: Record<string, string | number | boolean | undefined>) =>
+        request('/api/v1/shipments' as Path, 'get' as PathMethods<Path>, { query }),
+      getShipment: (id: string) =>
+        request('/api/v1/shipments/{id}' as Path, 'get' as PathMethods<Path>, {
+          pathParams: { id },
+        }),
+      getNotifications: (
+        query?: Record<string, string | number | boolean | undefined>,
+      ) =>
+        request('/api/v1/notifications' as Path, 'get' as PathMethods<Path>, {
+          query,
+        }),
+      getHealth: () =>
+        request('/api/v1/health' as Path, 'get' as PathMethods<Path>),
+    },
+  };
+}
+
+export type ChainSettleClient = ReturnType<typeof createClient>;

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -1,0 +1,3 @@
+export type { paths, components, operations } from './schema';
+export { createClient } from './client';
+export type { ClientOptions, ChainSettleClient } from './client';

--- a/sdk/openapi.json
+++ b/sdk/openapi.json
@@ -1,0 +1,303 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "ChainSettle API",
+    "description": "Backend API for ChainSettle — milestone-based supply chain escrow on Stellar Soroban. Regenerate with `npm run generate:sdk`.",
+    "version": "1.0",
+    "contact": {}
+  },
+  "tags": [
+    { "name": "auth", "description": "Authentication via Stellar address" },
+    { "name": "shipments", "description": "Shipment lifecycle management" },
+    { "name": "milestones", "description": "Milestone proof and confirmation" },
+    { "name": "events", "description": "On-chain Stellar event feed" },
+    { "name": "notifications", "description": "User notifications" },
+    { "name": "health", "description": "Health check endpoints" },
+    { "name": "admin", "description": "Admin-only operations" },
+    { "name": "users", "description": "User profiles" }
+  ],
+  "servers": [],
+  "components": {
+    "securitySchemes": {
+      "bearer": {
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "type": "http"
+      }
+    },
+    "schemas": {
+      "Envelope": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean" },
+          "data": {},
+          "timestamp": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/v1/auth/nonce": {
+      "get": {
+        "tags": ["auth"],
+        "operationId": "AuthController_getNonce",
+        "summary": "Get challenge nonce for a Stellar address",
+        "parameters": [
+          {
+            "name": "address",
+            "required": true,
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Nonce issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "object",
+                      "properties": { "nonce": { "type": "string" } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": ["auth"],
+        "operationId": "AuthController_login",
+        "summary": "Submit signed nonce, receive JWT",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["stellarAddress", "signedNonce", "signature"],
+                "properties": {
+                  "stellarAddress": { "type": "string" },
+                  "signedNonce": { "type": "string" },
+                  "signature": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JWT issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "accessToken": { "type": "string" },
+                        "user": { "type": "object" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/shipments": {
+      "get": {
+        "tags": ["shipments"],
+        "operationId": "ShipmentsController_findAll",
+        "summary": "List shipments",
+        "security": [{ "bearer": [] }],
+        "parameters": [
+          { "name": "page", "in": "query", "schema": { "type": "integer" } },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" } },
+          { "name": "status", "in": "query", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated shipments",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Envelope" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["shipments"],
+        "operationId": "ShipmentsController_create",
+        "summary": "Register on-chain shipment in DB",
+        "security": [{ "bearer": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "type": "object" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Shipment created",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Envelope" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/shipments/{id}": {
+      "get": {
+        "tags": ["shipments"],
+        "operationId": "ShipmentsController_findOne",
+        "summary": "Full shipment detail",
+        "security": [{ "bearer": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Shipment detail",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Envelope" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notifications": {
+      "get": {
+        "tags": ["notifications"],
+        "operationId": "NotificationsController_findAll",
+        "summary": "Get user notifications",
+        "security": [{ "bearer": [] }],
+        "responses": {
+          "200": {
+            "description": "Notifications list",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Envelope" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/events": {
+      "get": {
+        "tags": ["events"],
+        "operationId": "EventsController_findAll",
+        "summary": "List chain events",
+        "security": [{ "bearer": [] }],
+        "responses": {
+          "200": {
+            "description": "Events list",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Envelope" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/health": {
+      "get": {
+        "tags": ["health"],
+        "operationId": "HealthController_check",
+        "summary": "Database + service health check",
+        "responses": {
+          "200": {
+            "description": "Health status",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Envelope" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/admin/users/{id}/impersonate": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "AdminUsersController_impersonate",
+        "summary": "Obtain a short-lived impersonation token",
+        "security": [{ "bearer": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Impersonation token issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "accessToken": { "type": "string" },
+                        "expiresIn": { "type": "string" },
+                        "targetUser": { "type": "object" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/me": {
+      "get": {
+        "tags": ["users"],
+        "operationId": "UsersController_getProfile",
+        "summary": "Get the authenticated user profile",
+        "security": [{ "bearer": [] }],
+        "responses": {
+          "200": {
+            "description": "User profile",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Envelope" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@chainsettle/sdk",
+  "version": "0.1.0",
+  "description": "Typed TypeScript client for the ChainSettle API (generated from OpenAPI)",
+  "main": "index.ts",
+  "types": "index.ts",
+  "license": "MIT",
+  "private": true
+}

--- a/sdk/schema.ts
+++ b/sdk/schema.ts
@@ -1,0 +1,198 @@
+/**
+ * This file was auto-generated / curated for @chainsettle/sdk.
+ * Do not edit by hand for long — run `npm run generate:sdk` to refresh from NestJS Swagger.
+ */
+
+export interface paths {
+  '/api/v1/auth/nonce': {
+    get: {
+      parameters: {
+        query: { address: string };
+      };
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: { nonce?: string };
+            };
+          };
+        };
+      };
+    };
+  };
+  '/api/v1/auth/login': {
+    post: {
+      requestBody: {
+        content: {
+          'application/json': {
+            stellarAddress: string;
+            signedNonce: string;
+            signature: string;
+          };
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: { accessToken?: string; user?: Record<string, unknown> };
+            };
+          };
+        };
+      };
+    };
+  };
+  '/api/v1/shipments': {
+    get: {
+      parameters: {
+        query?: {
+          page?: number;
+          limit?: number;
+          status?: string;
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: unknown;
+              timestamp?: string;
+            };
+          };
+        };
+      };
+    };
+    post: {
+      requestBody: {
+        content: {
+          'application/json': Record<string, unknown>;
+        };
+      };
+      responses: {
+        201: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: unknown;
+              timestamp?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  '/api/v1/shipments/{id}': {
+    get: {
+      parameters: {
+        path: { id: string };
+      };
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: unknown;
+              timestamp?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  '/api/v1/notifications': {
+    get: {
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: unknown;
+              timestamp?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  '/api/v1/events': {
+    get: {
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: unknown;
+              timestamp?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  '/api/v1/health': {
+    get: {
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: unknown;
+              timestamp?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  '/api/v1/admin/users/{id}/impersonate': {
+    post: {
+      parameters: {
+        path: { id: string };
+      };
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: {
+                accessToken?: string;
+                expiresIn?: string;
+                targetUser?: Record<string, unknown>;
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  '/api/v1/users/me': {
+    get: {
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              success?: boolean;
+              data?: unknown;
+              timestamp?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+}
+
+export type components = {
+  schemas: {
+    Envelope: {
+      success?: boolean;
+      data?: unknown;
+      timestamp?: string;
+    };
+  };
+};
+
+export type operations = Record<string, never>;

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,8 @@ import { TerminusModule } from '@nestjs/terminus';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { envValidationSchema } from './config/env.validation';
 import { RolesGuard } from './common/guards/roles.guard';
+import { ImpersonationGuard } from './common/guards/impersonation.guard';
+import { DeprecationInterceptor } from './common/interceptors/deprecation.interceptor';
 
 import { PrismaModule } from './common/prisma/prisma.module';
 import { StellarModule } from './common/stellar/stellar.module';
@@ -92,7 +94,17 @@ import { ChainModule } from './modules/chain/chain.module';
       provide: APP_GUARD,
       useClass: RolesGuard,
     },
-    // Apply global audit logging interceptor (logs all mutations)
+    // Block sensitive routes when using an impersonation token
+    {
+      provide: APP_GUARD,
+      useClass: ImpersonationGuard,
+    },
+    // Emit Deprecation / Sunset headers for @DeprecatedRoute handlers
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: DeprecationInterceptor,
+    },
+    // Apply global audit logging interceptor (logs all mutations + impersonated requests)
     {
       provide: APP_INTERCEPTOR,
       useClass: AuditLogInterceptor,

--- a/src/common/decorators/block-impersonation.decorator.ts
+++ b/src/common/decorators/block-impersonation.decorator.ts
@@ -1,0 +1,9 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const BLOCK_IMPERSONATION_KEY = 'blockImpersonation';
+
+/**
+ * Marks sensitive routes that must not be callable with an impersonation token
+ * (e.g. changing email, deleting the account).
+ */
+export const BlockImpersonation = () => SetMetadata(BLOCK_IMPERSONATION_KEY, true);

--- a/src/common/decorators/deprecated.decorator.ts
+++ b/src/common/decorators/deprecated.decorator.ts
@@ -1,0 +1,24 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const DEPRECATION_KEY = 'deprecation';
+
+export interface DeprecationMeta {
+  /** Value for the Deprecation header (RFC 8594). Default: "true" */
+  deprecation?: string;
+  /** HTTP-date when the endpoint will be removed (Sunset header) */
+  sunset?: string;
+  /** Optional docs URL included in a Link header */
+  link?: string;
+}
+
+/**
+ * Marks a route (or controller) as deprecated.
+ * DeprecationInterceptor will emit Deprecation / Sunset / Link headers.
+ *
+ * @example
+ * @DeprecatedRoute({ sunset: 'Wed, 01 Jul 2027 00:00:00 GMT', link: '/docs#migration-v2' })
+ * @Get('legacy')
+ * legacyEndpoint() { ... }
+ */
+export const DeprecatedRoute = (meta: DeprecationMeta = {}) =>
+  SetMetadata(DEPRECATION_KEY, meta);

--- a/src/common/guards/impersonation.guard.ts
+++ b/src/common/guards/impersonation.guard.ts
@@ -1,0 +1,37 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { BLOCK_IMPERSONATION_KEY } from '../decorators/block-impersonation.decorator';
+
+/**
+ * Rejects requests made with an impersonation JWT when the handler
+ * (or controller) is marked @BlockImpersonation().
+ */
+@Injectable()
+export class ImpersonationGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const blocked = this.reflector.getAllAndOverride<boolean>(
+      BLOCK_IMPERSONATION_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!blocked) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    if (request.user?.isImpersonation) {
+      throw new ForbiddenException(
+        'This action is not allowed while impersonating another user',
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/common/interceptors/deprecation.interceptor.ts
+++ b/src/common/interceptors/deprecation.interceptor.ts
@@ -1,0 +1,38 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { DEPRECATION_KEY, DeprecationMeta } from '../decorators/deprecated.decorator';
+
+/**
+ * Adds RFC 8594-style Deprecation / Sunset headers when a handler
+ * is annotated with @DeprecatedRoute(...).
+ */
+@Injectable()
+export class DeprecationInterceptor implements NestInterceptor {
+  constructor(private readonly reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const meta = this.reflector.getAllAndOverride<DeprecationMeta | undefined>(
+      DEPRECATION_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (meta) {
+      const res = context.switchToHttp().getResponse();
+      res.setHeader('Deprecation', meta.deprecation ?? 'true');
+      if (meta.sunset) {
+        res.setHeader('Sunset', meta.sunset);
+      }
+      if (meta.link) {
+        res.setHeader('Link', `<${meta.link}>; rel="deprecation"; type="text/html"`);
+      }
+    }
+
+    return next.handle();
+  }
+}

--- a/src/common/ipfs/ipfs.service.ts
+++ b/src/common/ipfs/ipfs.service.ts
@@ -85,6 +85,10 @@ export class IpfsService implements OnModuleInit {
   }
 
   async onModuleInit() {
+    if (process.env.SDK_GENERATE === '1') {
+      this.isHealthy = true;
+      return;
+    }
     await this.checkConnectivity();
 
     if (this.healthCheckInterval > 0) {

--- a/src/common/prisma/prisma.service.ts
+++ b/src/common/prisma/prisma.service.ts
@@ -35,6 +35,11 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
   }
 
   async onModuleInit() {
+    // Skip DB connect when exporting OpenAPI for SDK generation
+    if (process.env.SDK_GENERATE === '1') {
+      this.logger.warn('Skipping database connect (SDK_GENERATE=1)');
+      return;
+    }
     await this.$connect();
     this.logger.log('Database connected');
     this.logger.log(`Prisma pool: limit=${this.connectionLimit}, timeout=${this.poolTimeout}s`);

--- a/src/common/redis/redis.service.ts
+++ b/src/common/redis/redis.service.ts
@@ -13,12 +13,14 @@ export class RedisService implements OnModuleDestroy {
 
   constructor(private readonly configService: ConfigService) {
     const redisUrl = this.configService.get<string>('REDIS_URL', 'redis://localhost:6379');
+    const skipConnect = process.env.SDK_GENERATE === '1';
 
     this.client = new Redis(redisUrl, {
       maxRetriesPerRequest: 3,
-      enableReadyCheck: true,
-      lazyConnect: false,
+      enableReadyCheck: !skipConnect,
+      lazyConnect: skipConnect,
       retryStrategy: (times) => {
+        if (skipConnect) return null;
         const delay = Math.min(times * 50, 2000);
         return delay;
       },
@@ -29,6 +31,7 @@ export class RedisService implements OnModuleDestroy {
     });
 
     this.client.on('error', (err) => {
+      if (skipConnect) return;
       this.logger.error('Redis connection error:', err);
     });
 

--- a/src/common/throttler/redis-throttler-storage.service.ts
+++ b/src/common/throttler/redis-throttler-storage.service.ts
@@ -14,13 +14,16 @@ export class RedisThrottlerStorageService implements ThrottlerStorage, OnModuleD
 
   constructor(private readonly configService: ConfigService) {
     const redisUrl = this.configService.get<string>('REDIS_URL', 'redis://localhost:6379');
+    const skipConnect = process.env.SDK_GENERATE === '1';
     this.redis = new Redis(redisUrl, {
       maxRetriesPerRequest: 3,
-      enableReadyCheck: true,
-      lazyConnect: false,
+      enableReadyCheck: !skipConnect,
+      lazyConnect: skipConnect,
+      retryStrategy: skipConnect ? () => null : undefined,
     });
 
     this.redis.on('error', (err) => {
+      if (skipConnect) return;
       console.error('Redis Throttler Storage Error:', err);
     });
   }

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -4,11 +4,14 @@ export const envValidationSchema = Joi.object({
   // Server
   NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
   PORT: Joi.number().integer().min(1).max(65535).default(3000),
-  API_PREFIX: Joi.string().default('api/v1'),
+  // Route prefix without version segment (versioning adds /v1, /v2). Legacy "api/v1" is accepted.
+  API_PREFIX: Joi.string().default('api'),
 
   // JWT
   JWT_SECRET: Joi.string().required(),
   JWT_EXPIRES_IN: Joi.string().default('7d'),
+  /** Short-lived TTL for admin impersonation tokens (default 15m). */
+  IMPERSONATION_JWT_EXPIRES_IN: Joi.string().default('15m'),
 
   // Database
   DATABASE_URL: Joi.string()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, Logger, RequestMethod } from '@nestjs/common';
+import { ValidationPipe, Logger, RequestMethod, VersioningType } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import helmet from 'helmet';
@@ -10,6 +10,8 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { ThrottlerExceptionFilter } from './common/filters/throttler-exception.filter';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 import { createWinstonLogger } from './common/logger/winston.logger';
+import * as fs from 'fs';
+import * as path from 'path';
 
 async function bootstrap() {
   const winstonLogger = createWinstonLogger();
@@ -33,7 +35,10 @@ async function bootstrap() {
 
   const configService = app.get(ConfigService);
   const port = configService.get<number>('PORT', 3000);
-  const apiPrefix = configService.get<string>('API_PREFIX', 'api/v1');
+  // Prefix is "api"; URI versioning appends /v1, /v2, etc.
+  // Legacy API_PREFIX=api/v1 is normalized to "api" so existing .env files keep working.
+  const rawPrefix = configService.get<string>('API_PREFIX', 'api');
+  const apiPrefix = rawPrefix.replace(/\/v\d+$/, '') || 'api';
   const allowedOrigins = configService
     .get<string>('ALLOWED_ORIGINS')
     ?.split(',')
@@ -81,14 +86,25 @@ async function bootstrap() {
         : [fallbackOrigin],
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
-    exposedHeaders: ['X-Request-ID'],
+    exposedHeaders: [
+      'X-Request-ID',
+      'Deprecation',
+      'Sunset',
+      'Link',
+    ],
     credentials: true,
   });
-
 
   // Global prefix for all routes — /metrics is excluded so Prometheus can scrape it without the prefix
   app.setGlobalPrefix(apiPrefix, {
     exclude: [{ path: 'metrics', method: RequestMethod.GET }],
+  });
+
+  // URI versioning: /api/v1/..., /api/v2/...  Controllers default to v1.
+  // Add a v2 controller with @Controller({ path: '...', version: '2' }) without touching v1.
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
   });
 
   // Global validation pipe
@@ -131,8 +147,19 @@ async function bootstrap() {
     swaggerOptions: { persistAuthorization: true },
   });
 
+  // When SDK_GENERATE=1, write OpenAPI JSON and exit (used by npm run generate:sdk).
+  if (process.env.SDK_GENERATE === '1') {
+    const outDir = path.resolve(process.cwd(), 'sdk');
+    fs.mkdirSync(outDir, { recursive: true });
+    const outFile = path.join(outDir, 'openapi.json');
+    fs.writeFileSync(outFile, JSON.stringify(document, null, 2));
+    logger.log(`OpenAPI schema written to ${outFile}`);
+    await app.close();
+    process.exit(0);
+  }
+
   await app.listen(port);
-  logger.log(`ChainSettle API running on http://localhost:${port}/${apiPrefix}`);
+  logger.log(`ChainSettle API running on http://localhost:${port}/${apiPrefix}/v1`);
   logger.log(`Swagger docs at http://localhost:${port}/docs`);
 }
 

--- a/src/modules/audit-logs/audit-log.interceptor.spec.ts
+++ b/src/modules/audit-logs/audit-log.interceptor.spec.ts
@@ -45,6 +45,46 @@ describe('AuditLogInterceptor', () => {
       expect(mockAuditLogService.record).not.toHaveBeenCalled();
     });
 
+    it('records GET requests when using an impersonation token', async () => {
+      const mockContext = {
+        switchToHttp: () => ({
+          getRequest: () => ({
+            method: 'GET',
+            path: '/api/v1/shipments',
+            user: {
+              id: 'user-1',
+              stellarAddress: 'GBUYER123',
+              isImpersonation: true,
+              impersonatorAdminId: 'admin-1',
+              impersonatorAddress: 'GADMIN',
+            },
+            headers: {},
+            connection: { remoteAddress: '127.0.0.1' },
+          }),
+          getResponse: () => ({ statusCode: 200 }),
+        }),
+      } as unknown as ExecutionContext;
+
+      const mockNext = {
+        handle: () => of({}),
+      } as unknown as CallHandler;
+
+      await interceptor.intercept(mockContext, mockNext).toPromise();
+
+      expect(mockAuditLogService.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: 'admin-1',
+          actorAddress: 'GADMIN',
+          action: 'impersonation.shipment.read',
+          metadata: expect.objectContaining({
+            impersonation: true,
+            targetUserId: 'user-1',
+            impersonatorAdminId: 'admin-1',
+          }),
+        }),
+      );
+    });
+
     it('skips HEAD and OPTIONS requests', async () => {
       for (const method of ['HEAD', 'OPTIONS']) {
         mockAuditLogService.record.mockClear();

--- a/src/modules/audit-logs/audit-log.interceptor.ts
+++ b/src/modules/audit-logs/audit-log.interceptor.ts
@@ -13,10 +13,8 @@ import { AuditLogService } from './audit-log.service';
  * AuditLogInterceptor
  *
  * Automatically records all successful POST, PATCH, DELETE mutations.
- * Skips GET requests (read-only operations don't need auditing).
- *
- * Extracts actor information from the request, derives action/resource
- * from the route, and passes to AuditLogService for recording.
+ * Additionally, EVERY request made with an impersonation token is logged
+ * (including GETs) so support sessions are fully traceable.
  */
 @Injectable()
 export class AuditLogInterceptor implements NestInterceptor {
@@ -26,22 +24,26 @@ export class AuditLogInterceptor implements NestInterceptor {
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
-    const response = context.switchToHttp().getResponse();
 
     const method = request.method;
     const path = request.path;
     const user = request.user; // Set by JwtAuthGuard
 
-    // Skip GET requests (read-only operations)
-    if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+    const isImpersonation = !!user?.isImpersonation;
+    const isMutation =
+      method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS';
+
+    // Skip non-mutations unless this is an impersonation session
+    if (!isMutation && !isImpersonation) {
       return next.handle();
     }
 
-    // Extract actor information
-    const actorId = user?.id;
-    const actorAddress = user?.stellarAddress ?? 'SYSTEM';
+    // Extract actor information — for impersonation, actor is the admin
+    const actorId = isImpersonation ? user.impersonatorAdminId : user?.id;
+    const actorAddress = isImpersonation
+      ? (user.impersonatorAddress ?? 'SYSTEM')
+      : (user?.stellarAddress ?? 'SYSTEM');
 
-    // Derive action and resource from route
     const { action, resourceType, resourceId } = this.deriveActionAndResource(
       method,
       path,
@@ -49,71 +51,75 @@ export class AuditLogInterceptor implements NestInterceptor {
     );
 
     return next.handle().pipe(
-      tap((response) => {
-        // Only record on successful responses (2xx status)
+      tap(() => {
         const statusCode = context.switchToHttp().getResponse().statusCode;
         if (statusCode >= 200 && statusCode < 300) {
           this.auditLog.record({
             actorId,
             actorAddress,
-            action,
+            action: isImpersonation ? `impersonation.${action}` : action,
             resourceType,
             resourceId,
             metadata: {
               method,
               path,
               statusCode,
-              // Optionally include request body/params for context
               ...(request.body && { requestBody: this.sanitizeBody(request.body) }),
+              ...(isImpersonation && {
+                impersonation: true,
+                targetUserId: user.id,
+                targetStellarAddress: user.stellarAddress,
+                impersonatorAdminId: user.impersonatorAdminId,
+                impersonatorAddress: user.impersonatorAddress,
+              }),
             },
             ipAddress: this.getClientIp(request),
           });
         }
       }),
       catchError((error) => {
-        // Don't record failed operations (unless specifically needed)
         throw error;
       }),
     );
   }
 
-  /**
-   * Extract action, resourceType, and resourceId from the HTTP method and path.
-   * Examples:
-   *   POST /shipments → { action: 'shipment.create', resourceType: 'Shipment', resourceId: 'generated-id' }
-   *   PATCH /shipments/SHIP-001 → { action: 'shipment.update', resourceType: 'Shipment', resourceId: 'SHIP-001' }
-   *   DELETE /milestones/1 → { action: 'milestone.delete', resourceType: 'Milestone', resourceId: '1' }
-   */
   private deriveActionAndResource(
     method: string,
     path: string,
-    request: any,
+    _request: any,
   ): { action: string; resourceType: string; resourceId: string } {
-    const segments = path.split('/').filter(s => s.length > 0);
+    const segments = path.split('/').filter((s) => s.length > 0);
 
-    // Extract resource type (usually first segment after /api/v1)
     // Format: /api/v1/{resourceType}/{resourceId}/{subresource}
+    // After versioning: segments[0]=api, segments[1]=v1, segments[2]=resource
     let resourceType = 'Unknown';
     let resourceId = 'unknown-id';
     let subAction = '';
 
-    if (segments.length >= 2) {
-      resourceType = segments[1]; // e.g., 'shipments', 'milestones'
-      resourceType = resourceType.charAt(0).toUpperCase() + resourceType.slice(1, -1); // Singularize: shipments → Shipment
+    // Find the index after the version segment (v1, v2, ...)
+    let resourceIdx = 1;
+    if (segments[0] === 'api' && /^v\d+$/.test(segments[1] ?? '')) {
+      resourceIdx = 2;
+    } else if (segments[0] === 'api') {
+      resourceIdx = 1;
     }
 
-    if (segments.length >= 3) {
-      resourceId = segments[2];
+    if (segments.length > resourceIdx) {
+      const raw = segments[resourceIdx];
+      resourceType = raw.charAt(0).toUpperCase() + raw.slice(1).replace(/s$/, '');
+    }
 
-      // Check for sub-resources (e.g., /shipments/:id/sync)
-      if (segments.length >= 4) {
-        subAction = segments[3]; // e.g., 'sync', 'proof'
+    if (segments.length > resourceIdx + 1) {
+      resourceId = segments[resourceIdx + 1];
+      if (segments.length > resourceIdx + 2) {
+        subAction = segments[resourceIdx + 2];
       }
     }
 
-    // Determine action
     let action = `${resourceType.toLowerCase()}.create`;
-    if (method === 'PATCH') {
+    if (method === 'GET' || method === 'HEAD') {
+      action = `${resourceType.toLowerCase()}.read`;
+    } else if (method === 'PATCH' || method === 'PUT') {
       action = `${resourceType.toLowerCase()}.update`;
     } else if (method === 'DELETE') {
       action = `${resourceType.toLowerCase()}.delete`;
@@ -124,15 +130,10 @@ export class AuditLogInterceptor implements NestInterceptor {
     return { action, resourceType, resourceId };
   }
 
-  /**
-   * Sanitize request body to avoid logging sensitive data.
-   */
   private sanitizeBody(body: any): any {
     if (!body || typeof body !== 'object') return body;
 
     const sanitized = { ...body };
-
-    // Remove sensitive fields
     const sensitiveFields = [
       'password',
       'token',
@@ -140,6 +141,7 @@ export class AuditLogInterceptor implements NestInterceptor {
       'privateKey',
       'seed',
       'mnemonic',
+      'accessToken',
     ];
 
     sensitiveFields.forEach((field) => {
@@ -151,9 +153,6 @@ export class AuditLogInterceptor implements NestInterceptor {
     return sanitized;
   }
 
-  /**
-   * Extract client IP address from request.
-   */
   private getClientIp(request: any): string | undefined {
     return (
       request.headers['x-forwarded-for']?.split(',')[0] ||

--- a/src/modules/auth/admin-users.controller.ts
+++ b/src/modules/auth/admin-users.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  Post,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  Req,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { UserRole } from '@prisma/client';
+import { Request } from 'express';
+import { AuthService } from './auth.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { BlockImpersonation } from '../../common/decorators/block-impersonation.decorator';
+
+/**
+ * Admin user support tools under /admin/users/*
+ */
+@ApiTags('admin')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@BlockImpersonation()
+@Controller('admin/users')
+export class AdminUsersController {
+  constructor(private readonly authService: AuthService) {}
+
+  /**
+   * POST /api/v1/admin/users/:id/impersonate
+   * Issues a short-lived JWT that acts as the target user, tagged with the admin's identity.
+   */
+  @Post(':id/impersonate')
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '[Admin] Obtain a short-lived impersonation token for support debugging',
+    description:
+      'Returns a JWT scoped to the target user. The token embeds the impersonating admin ID. ' +
+      'Every request made with it is audit-logged with both admin and target user IDs. ' +
+      'Sensitive actions (email change, account deletion) are blocked while impersonating.',
+  })
+  @ApiResponse({ status: 200, description: 'Impersonation token issued' })
+  @ApiResponse({ status: 403, description: 'Admin access required / cannot impersonate self or another admin' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  impersonate(
+    @Param('id') id: string,
+    @CurrentUser() admin: any,
+    @Req() req: Request,
+  ) {
+    const ip =
+      (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
+      (req.headers['x-real-ip'] as string) ||
+      req.socket?.remoteAddress;
+
+    return this.authService.impersonateUser(id, admin.id, admin.stellarAddress, ip);
+  }
+}

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { JwtStrategy } from './jwt.strategy';
 import { ApiKeyStrategy } from './api-key.strategy';
 import { ApiKeysController } from './api-keys.controller';
 import { UsersController } from './users.controller';
+import { AdminUsersController } from './admin-users.controller';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 
@@ -25,7 +26,7 @@ import { AuditLogsModule } from '../audit-logs/audit-logs.module';
     NotificationsModule,
     AuditLogsModule,
   ],
-  controllers: [AuthController, UsersController, ApiKeysController],
+  controllers: [AuthController, UsersController, ApiKeysController, AdminUsersController],
   providers: [AuthService, JwtStrategy, ApiKeyStrategy],
   exports: [AuthService],
 })

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException, ConflictException, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, ConflictException, Logger, BadRequestException, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { Keypair } from '@stellar/stellar-sdk';
@@ -320,6 +320,92 @@ export class AuthService {
     });
     if (!user) throw new NotFoundException('User not found');
     return user;
+  }
+
+  /**
+   * Issue a short-lived impersonation JWT so an admin can call the API as a target user.
+   * The token embeds impersonatorAdminId / isImpersonation for audit and guard enforcement.
+   */
+  async impersonateUser(
+    targetUserId: string,
+    adminId: string,
+    adminAddress: string,
+    ipAddress?: string,
+  ): Promise<{
+    accessToken: string;
+    expiresIn: string;
+    targetUser: { id: string; stellarAddress: string; role: UserRole; name: string | null };
+  }> {
+    if (targetUserId === adminId) {
+      throw new BadRequestException('Cannot impersonate your own account');
+    }
+
+    const target = await this.prisma.user.findUnique({
+      where: { id: targetUserId },
+      select: {
+        id: true,
+        stellarAddress: true,
+        role: true,
+        name: true,
+        deactivatedAt: true,
+      },
+    });
+
+    if (!target) {
+      throw new NotFoundException('User not found');
+    }
+
+    if (target.deactivatedAt) {
+      throw new ForbiddenException('Cannot impersonate a deactivated user');
+    }
+
+    if (target.role === UserRole.ADMIN) {
+      throw new ForbiddenException('Cannot impersonate another admin');
+    }
+
+    const expiresIn = this.config.get<string>('IMPERSONATION_JWT_EXPIRES_IN', '15m');
+
+    const accessToken = this.jwt.sign(
+      {
+        sub: target.id,
+        stellarAddress: target.stellarAddress,
+        role: target.role,
+        isImpersonation: true,
+        impersonatorAdminId: adminId,
+        impersonatorAddress: adminAddress,
+      },
+      { expiresIn },
+    );
+
+    await this.auditLog.record({
+      actorId: adminId,
+      actorAddress: adminAddress,
+      action: 'admin.impersonate',
+      resourceType: 'User',
+      resourceId: target.id,
+      metadata: {
+        targetUserId: target.id,
+        targetStellarAddress: target.stellarAddress,
+        targetRole: target.role,
+        expiresIn,
+      },
+      ipAddress,
+    });
+
+    this.logger.warn(
+      `Admin ${adminId} (${adminAddress}) started impersonating user ${target.id} (${target.stellarAddress})`,
+    );
+
+    return {
+      accessToken,
+      expiresIn,
+      targetUser: {
+        id: target.id,
+        stellarAddress: target.stellarAddress,
+        role: target.role,
+        name: target.name,
+      },
+    };
   }
 
   async updateProfile(userId: string, dto: UpdateProfileDto) {

--- a/src/modules/auth/jwt.strategy.spec.ts
+++ b/src/modules/auth/jwt.strategy.spec.ts
@@ -35,6 +35,41 @@ describe('JwtStrategy', () => {
       id: 'user-1',
       stellarAddress: 'GTEST',
       role: 'BUYER',
+      isImpersonation: false,
+      impersonatorAdminId: undefined,
+      impersonatorAddress: undefined,
+    });
+  });
+
+  it('returns impersonation context when token is tagged', async () => {
+    mockPrisma.user.findUnique
+      .mockResolvedValueOnce({
+        id: 'user-1',
+        stellarAddress: 'GTEST',
+        role: 'BUYER',
+        deactivatedAt: null,
+      })
+      .mockResolvedValueOnce({
+        id: 'admin-1',
+        stellarAddress: 'GADMIN',
+        role: 'ADMIN',
+        deactivatedAt: null,
+      });
+
+    const result = await strategy.validate({
+      sub: 'user-1',
+      isImpersonation: true,
+      impersonatorAdminId: 'admin-1',
+      impersonatorAddress: 'GADMIN',
+    });
+
+    expect(result).toEqual({
+      id: 'user-1',
+      stellarAddress: 'GTEST',
+      role: 'BUYER',
+      isImpersonation: true,
+      impersonatorAdminId: 'admin-1',
+      impersonatorAddress: 'GADMIN',
     });
   });
 

--- a/src/modules/auth/jwt.strategy.ts
+++ b/src/modules/auth/jwt.strategy.ts
@@ -41,10 +41,31 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('Account has been deactivated');
     }
 
+    const isImpersonation = payload.isImpersonation === true;
+
+    // If this is an impersonation token, ensure the admin still exists and is active
+    if (isImpersonation) {
+      if (!payload.impersonatorAdminId) {
+        throw new UnauthorizedException('Invalid impersonation token');
+      }
+
+      const admin = await this.prisma.user.findUnique({
+        where: { id: payload.impersonatorAdminId },
+        select: { id: true, stellarAddress: true, role: true, deactivatedAt: true },
+      });
+
+      if (!admin || admin.deactivatedAt || admin.role !== 'ADMIN') {
+        throw new UnauthorizedException('Impersonation token is no longer valid');
+      }
+    }
+
     return {
       id: user.id,
       stellarAddress: user.stellarAddress,
       role: user.role,
+      isImpersonation,
+      impersonatorAdminId: isImpersonation ? payload.impersonatorAdminId : undefined,
+      impersonatorAddress: isImpersonation ? payload.impersonatorAddress : undefined,
     };
   }
 }

--- a/src/modules/auth/users.controller.ts
+++ b/src/modules/auth/users.controller.ts
@@ -21,6 +21,7 @@ import { UpdateUserRoleDto } from './dto/update-user-role.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { Roles } from '../../common/decorators/roles.decorator';
+import { BlockImpersonation } from '../../common/decorators/block-impersonation.decorator';
 
 @ApiTags('users')
 @Controller('users')
@@ -38,15 +39,18 @@ export class UsersController {
   }
 
   @Patch('me')
+  @BlockImpersonation()
   @ApiOperation({ summary: 'Update user profile (name, email)' })
   @ApiResponse({ status: 200, description: 'Profile updated successfully' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Blocked during impersonation' })
   @ApiResponse({ status: 409, description: 'Email already in use' })
   updateProfile(@CurrentUser() user: any, @Body() dto: UpdateProfileDto) {
     return this.authService.updateProfile(user.id, dto);
   }
 
   @Delete('me')
+  @BlockImpersonation()
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Deactivate the authenticated user account',
@@ -55,6 +59,7 @@ export class UsersController {
   })
   @ApiResponse({ status: 200, description: 'Account deactivated successfully' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Blocked during impersonation' })
   @ApiResponse({
     status: 409,
     description: 'User has active shipments that must be resolved or transferred first',

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -43,6 +43,10 @@ export class EventsService implements OnModuleInit {
   ) {}
 
   async onModuleInit() {
+    if (process.env.SDK_GENERATE === '1') {
+      this.logger.warn('Skipping event poller init (SDK_GENERATE=1)');
+      return;
+    }
     try {
       // Attempt to load the persisted cursor from the database
       const cursor = await this.prisma.eventCursor.findUnique({


### PR DESCRIPTION
## Summary

Closes #219
closes #225
closes  #226
closes #228

### #219 — Database schema documentation
- Added `docs/database.md` with a Mermaid ERD covering User, Shipment, Milestone, ChainEvent, Notification, Webhook, ShipmentTemplate, ApiKey, AuditLog (and supporting tables)
- Per-table purpose + key relationships
- Migration workflow (`prisma migrate dev` vs `deploy`) and how to regenerate the ERD after schema changes

### #225 — API versioning + deprecation headers
- Switched to NestJS URI versioning: global prefix `api` + `defaultVersion: '1'` so existing `/api/v1/*` routes keep working
- Legacy `API_PREFIX=api/v1` is normalized to `api`
- Added `@DeprecatedRoute()` + `DeprecationInterceptor` (`Deprecation` / `Sunset` / `Link` headers; exposed in CORS)
- README documents how to add a `/api/v2` controller without touching v1 code

### #228 — Admin impersonation (support debugging)
- `POST /api/v1/admin/users/:id/impersonate` (admin-only) issues a short-lived JWT (`IMPERSONATION_JWT_EXPIRES_IN`, default `15m`) tagged with `isImpersonation` + admin identity
- JwtStrategy validates the admin is still an active ADMIN
- Every impersonated request (including GETs) is audit-logged with both admin and target user IDs
- `@BlockImpersonation()` blocks sensitive actions (profile/email update, account delete, re-impersonate)

### #226 — TypeScript SDK from OpenAPI
- `sdk/` package (`@chainsettle/sdk`) with typed `createClient` + OpenAPI paths
- `npm run generate:sdk` boots Nest with `SDK_GENERATE=1`, writes `sdk/openapi.json`, runs `openapi-typescript`
- `npm run check:sdk` + `.github/workflows/sdk-drift.yml` fail CI on SDK drift

## Test plan
- [ ] `npm install` (pulls `openapi-typescript`)
- [ ] `npm run generate:sdk` then commit refreshed `sdk/openapi.json` + `sdk/schema.ts` if they change
- [ ] Confirm existing routes still resolve under `/api/v1/*` (e.g. `GET /api/v1/health`, `GET /api/v1/shipments`)
- [ ] Admin: `POST /api/v1/admin/users/:id/impersonate` → use token on `GET /api/v1/shipments` → verify audit log has admin + target IDs
- [ ] With impersonation token: `PATCH /api/v1/users/me` and `DELETE /api/v1/users/me` return 403
- [ ] `npm run check:sdk` passes after generate
- [ ] `npm test` (jwt strategy + audit interceptor specs updated)