### PR TITLE
Add i18n, bulk milestone confirm, Slack notifications, and SBOM CI

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+name: SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  generate-sbom:
+    name: Generate CycloneDX SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate CycloneDX SBOM
+        run: npx --yes @cyclonedx/cyclonedx-npm@1.19.3 --output-file sbom.cdx.json --output-format JSON --spec-version 1.5
+
+      - name: Validate SBOM exists
+        run: |
+          test -f sbom.cdx.json
+          node -e "const s=require('./sbom.cdx.json'); if(!s.bomFormat && !s.\$schema) process.exit(1); console.log('SBOM OK:', s.bomFormat || 'CycloneDX', s.specVersion || '');"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          if-no-files-found: error
+
+      - name: Attach SBOM to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: sbom.cdx.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.log
 coverage/
 .DS_Store
+sbom.cdx.json

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ All endpoints are prefixed with `/api/v1`. Protected routes require `Authorizati
 |--------|------|------|-------------|
 | `GET` | `/shipments/:id/milestones` | ✓ | List all milestones for a shipment |
 | `GET` | `/shipments/:id/milestones/:index` | ✓ | Get single milestone |
+| `POST` | `/shipments/:id/milestones/:index/confirm` | ✓ | Confirm a single milestone (buyer) |
+| `POST` | `/shipments/:id/milestones/bulk-confirm` | ✓ | Batch-confirm milestones (buyer) |
 
 ### Events (on-chain audit log)
 | Method | Path | Auth | Description |
@@ -103,6 +105,8 @@ All endpoints are prefixed with `/api/v1`. Protected routes require `Authorizati
 | `GET` | `/notifications` | ✓ | Get user notifications |
 | `PATCH` | `/notifications/:id/read` | ✓ | Mark notification as read |
 | `PATCH` | `/notifications/read-all` | ✓ | Mark all as read |
+| `GET` | `/notifications/preferences` | ✓ | Get channel preferences (+ Slack webhook) |
+| `PATCH` | `/notifications/preferences` | ✓ | Update preferences / Slack webhook URL |
 
 ### Health
 | Method | Path | Auth | Description |
@@ -312,6 +316,21 @@ Errors follow a standardised format from `HttpExceptionFilter`:
   "path": "/api/v1/shipments/SHIP-999",
   "message": "Shipment SHIP-999 not found"
 }
+```
+
+Send `Accept-Language: es` to receive Spanish error messages for mapped strings (falls back to English). See [`src/i18n/README.md`](src/i18n/README.md).
+
+---
+
+## SBOM (Software Bill of Materials)
+
+Release builds generate a CycloneDX SBOM via [`.github/workflows/sbom.yml`](.github/workflows/sbom.yml). The artifact `sbom.cdx.json` is uploaded on release/tag runs and attached to GitHub Releases.
+
+Regenerate locally (requires Node 20+ and an installed lockfile):
+
+```bash
+npm run sbom
+# writes ./sbom.cdx.json from package-lock.json
 ```
 
 ---

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,7 +4,10 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "assets": [{ "include": "**/*.hbs", "watchAssets": true }],
+    "assets": [
+      { "include": "**/*.hbs", "watchAssets": true },
+      { "include": "i18n/locales/**/*.json", "watchAssets": true }
+    ],
     "plugins": ["@nestjs/swagger"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "sbom": "npx --yes @cyclonedx/cyclonedx-npm@1.19.3 --output-file sbom.cdx.json --output-format JSON --spec-version 1.5"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/prisma/migrations/20260827000000_add_slack_webhook_url/migration.sql
+++ b/prisma/migrations/20260827000000_add_slack_webhook_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "slackWebhookUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -364,11 +364,12 @@ model AuditLog {
 }
 
 model NotificationPreference {
-  id          String   @id @default(uuid())
-  userId      String   @unique
-  preferences Json     // Record<NotificationType, { inApp: boolean; email: boolean }>
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id              String   @id @default(uuid())
+  userId          String   @unique
+  preferences     Json     // Record<NotificationType, { inApp: boolean; email: boolean; slack: boolean }>
+  slackWebhookUrl String?  // Incoming Slack webhook URL; null disables Slack delivery
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TerminusModule } from '@nestjs/terminus';
-import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { envValidationSchema } from './config/env.validation';
 import { RolesGuard } from './common/guards/roles.guard';
 
@@ -15,6 +15,10 @@ import { TokenRegistryModule } from './common/token-registry/token-registry.modu
 import { RedisThrottlerStorageService } from './common/throttler/redis-throttler-storage.service';
 import { MetricsModule } from './common/metrics/metrics.module';
 import { HttpMetricsInterceptor } from './common/interceptors/http-metrics.interceptor';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { ThrottlerExceptionFilter } from './common/filters/throttler-exception.filter';
+import { I18nModule } from './i18n/i18n.module';
+import { LocaleMiddleware } from './i18n/locale.middleware';
 
 import { AuthModule } from './modules/auth/auth.module';
 import { ShipmentsModule } from './modules/shipments/shipments.module';
@@ -68,6 +72,7 @@ import { ChainModule } from './modules/chain/chain.module';
     IpfsModule,
     TokenRegistryModule,
     MetricsModule,
+    I18nModule,
 
     // Feature modules
     AuthModule,
@@ -102,11 +107,19 @@ import { ChainModule } from './modules/chain/chain.module';
       provide: APP_INTERCEPTOR,
       useClass: HttpMetricsInterceptor,
     },
+    {
+      provide: APP_FILTER,
+      useClass: HttpExceptionFilter,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: ThrottlerExceptionFilter,
+    },
   ],
 })
 export class AppModule {
   configure(consumer: MiddlewareConsumer) {
-    // Runs before JWT guard — attaches X-Request-ID to every request
-    consumer.apply(RequestIdMiddleware).forRoutes('*');
+    // Runs before JWT guard — attaches X-Request-ID and locale to every request
+    consumer.apply(RequestIdMiddleware, LocaleMiddleware).forRoutes('*');
   }
 }

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -5,12 +5,17 @@ import {
   HttpException,
   HttpStatus,
   Logger,
+  Injectable,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { I18nService } from '../../i18n/i18n.service';
 
 @Catch()
+@Injectable()
 export class HttpExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  constructor(private readonly i18n: I18nService) {}
 
   catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
@@ -22,20 +27,37 @@ export class HttpExceptionFilter implements ExceptionFilter {
         ? exception.getStatus()
         : HttpStatus.INTERNAL_SERVER_ERROR;
 
-    const message =
+    const rawMessage =
       exception instanceof HttpException
         ? exception.getResponse()
         : 'Internal server error';
+
+    const locale =
+      request.locale ??
+      this.i18n.resolveLocale(
+        Array.isArray(request.headers['accept-language'])
+          ? request.headers['accept-language'][0]
+          : request.headers['accept-language'],
+      );
+
+    let message: unknown;
+    if (typeof rawMessage === 'string') {
+      message =
+        status === HttpStatus.INTERNAL_SERVER_ERROR && rawMessage === 'Internal server error'
+          ? this.i18n.t('errors.INTERNAL_SERVER_ERROR', locale)
+          : this.i18n.translateErrorMessage(rawMessage, locale);
+    } else if (rawMessage && typeof rawMessage === 'object') {
+      message = this.i18n.translateErrorMessage(rawMessage, locale);
+    } else {
+      message = rawMessage;
+    }
 
     const errorResponse = {
       success: false,
       statusCode: status,
       timestamp: new Date().toISOString(),
       path: request.url,
-      message:
-        typeof message === 'string'
-          ? message
-          : (message as any).message || message,
+      message,
     };
 
     if (status === HttpStatus.INTERNAL_SERVER_ERROR) {

--- a/src/common/filters/throttler-exception.filter.ts
+++ b/src/common/filters/throttler-exception.filter.ts
@@ -1,28 +1,40 @@
-import { ExceptionFilter, Catch, ArgumentsHost, HttpException } from '@nestjs/common';
+import { ExceptionFilter, Catch, ArgumentsHost, Injectable } from '@nestjs/common';
 import { ThrottlerException } from '@nestjs/throttler';
-import { Response } from 'express';
+import { Request, Response } from 'express';
+import { I18nService } from '../../i18n/i18n.service';
 
 /**
  * Custom exception filter for throttler exceptions
  * Adds Retry-After header to 429 responses
  */
 @Catch(ThrottlerException)
+@Injectable()
 export class ThrottlerExceptionFilter implements ExceptionFilter {
+  constructor(private readonly i18n: I18nService) {}
+
   catch(exception: ThrottlerException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
     const status = exception.getStatus();
     const exceptionResponse = exception.getResponse() as any;
 
     // Calculate retry-after in seconds (default to 60 if not available)
     const retryAfter = Math.ceil((exceptionResponse.ttl || 60000) / 1000);
+    const locale =
+      request.locale ??
+      this.i18n.resolveLocale(
+        Array.isArray(request.headers['accept-language'])
+          ? request.headers['accept-language'][0]
+          : request.headers['accept-language'],
+      );
 
     response
       .status(status)
       .header('Retry-After', retryAfter.toString())
       .json({
         statusCode: status,
-        message: exceptionResponse.message || 'Too Many Requests',
+        message: this.i18n.t('errors.TOO_MANY_REQUESTS', locale),
         error: 'ThrottlerException',
         retryAfter: `${retryAfter}s`,
       });

--- a/src/i18n/README.md
+++ b/src/i18n/README.md
@@ -1,0 +1,55 @@
+# Internationalization (i18n)
+
+ChainSettle localizes API error messages and notification-email copy via
+`src/i18n`. Locale is resolved from the `Accept-Language` request header
+(with English as the fallback).
+
+## Supported locales
+
+| Code | Language |
+|------|----------|
+| `en` | English (default) |
+| `es` | Spanish |
+
+## How locale resolution works
+
+1. `LocaleMiddleware` reads `Accept-Language` on every request.
+2. The first supported primary language tag wins (e.g. `es-MX` → `es`).
+3. Missing or unsupported values fall back to `en`.
+
+Example:
+
+```http
+GET /api/v1/shipments/missing-id
+Accept-Language: es
+```
+
+returns a Spanish `message` when that string is mapped in `errors.*`.
+
+## Adding a new locale
+
+1. Create `src/i18n/locales/<code>/common.json` by copying the `en` file.
+2. Translate every string under `errors` and `email`.
+3. Add `<code>` to `SUPPORTED_LOCALES` in `src/i18n/i18n.service.ts`.
+4. Ensure `nest-cli.json` still copies JSON assets (already configured for `i18n/locales/**/*.json`).
+5. Verify with:
+
+```bash
+curl -H "Accept-Language: <code>" http://localhost:3000/api/v1/...
+```
+
+## Error message keys
+
+Services may throw either:
+
+- Plain English strings that already exist as `errors.*` English values
+  (the filter reverse-matches and translates), or
+- Structured payloads: `throw new NotFoundException({ i18nKey: 'errors.SHIPMENT_NOT_FOUND', args: { id } })`
+
+Prefer structured keys for new code so interpolation stays unambiguous.
+
+## Email templates
+
+Handlebars templates under `src/modules/notifications/templates/` can use
+`I18nService.getEmailCopy(type, locale)` for localized subject/body strings.
+Until callers pass a locale, English copy is used.

--- a/src/i18n/i18n.module.ts
+++ b/src/i18n/i18n.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from '@nestjs/common';
+import { I18nService } from './i18n.service';
+import { LocaleMiddleware } from './locale.middleware';
+
+@Global()
+@Module({
+  providers: [I18nService, LocaleMiddleware],
+  exports: [I18nService, LocaleMiddleware],
+})
+export class I18nModule {}

--- a/src/i18n/i18n.service.spec.ts
+++ b/src/i18n/i18n.service.spec.ts
@@ -1,0 +1,28 @@
+import { I18nService } from './i18n.service';
+
+describe('I18nService', () => {
+  const i18n = new I18nService();
+
+  it('falls back to English when locale is missing', () => {
+    expect(i18n.resolveLocale(undefined)).toBe('en');
+    expect(i18n.resolveLocale('')).toBe('en');
+    expect(i18n.resolveLocale('fr-FR')).toBe('en');
+  });
+
+  it('resolves Accept-Language: es to Spanish', () => {
+    expect(i18n.resolveLocale('es')).toBe('es');
+    expect(i18n.resolveLocale('es-MX,es;q=0.9,en;q=0.8')).toBe('es');
+  });
+
+  it('translates a known buyer-confirm error to Spanish', () => {
+    const en = 'Only the shipment buyer may confirm milestones';
+    expect(i18n.translateErrorMessage(en, 'es')).toBe(
+      'Solo el comprador del envío puede confirmar hitos',
+    );
+  });
+
+  it('keeps English when locale is en', () => {
+    const en = 'Only the shipment buyer may confirm milestones';
+    expect(i18n.translateErrorMessage(en, 'en')).toBe(en);
+  });
+});

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -1,0 +1,180 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const DEFAULT_LOCALE = 'en';
+export const SUPPORTED_LOCALES = ['en', 'es'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+type LocaleTree = Record<string, unknown>;
+
+@Injectable()
+export class I18nService {
+  private readonly logger = new Logger(I18nService.name);
+  private readonly catalogs = new Map<string, LocaleTree>();
+
+  constructor() {
+    this.loadLocales();
+  }
+
+  /**
+   * Resolve a BCP-47 Accept-Language value to a supported locale.
+   * Falls back to English when missing or unsupported.
+   */
+  resolveLocale(acceptLanguage?: string | null): SupportedLocale {
+    if (!acceptLanguage) return DEFAULT_LOCALE;
+
+    const candidates = acceptLanguage
+      .split(',')
+      .map((part) => {
+        const [tag, ...params] = part.trim().split(';');
+        const qParam = params.find((p) => p.trim().startsWith('q='));
+        const q = qParam ? parseFloat(qParam.split('=')[1]) : 1;
+        return { tag: tag.trim().toLowerCase(), q: Number.isFinite(q) ? q : 1 };
+      })
+      .sort((a, b) => b.q - a.q);
+
+    for (const { tag } of candidates) {
+      const primary = tag.split('-')[0] as SupportedLocale;
+      if (SUPPORTED_LOCALES.includes(primary)) {
+        return primary;
+      }
+    }
+
+    return DEFAULT_LOCALE;
+  }
+
+  /**
+   * Translate a dotted key (e.g. `errors.ONLY_BUYER_MAY_CONFIRM`).
+   * Falls back to English, then to the key itself.
+   */
+  t(
+    key: string,
+    locale: string = DEFAULT_LOCALE,
+    args: Record<string, string | number> = {},
+  ): string {
+    const raw =
+      this.lookup(locale, key) ??
+      this.lookup(DEFAULT_LOCALE, key) ??
+      key;
+
+    if (typeof raw !== 'string') {
+      return key;
+    }
+
+    return raw.replace(/\{(\w+)\}/g, (_, name: string) =>
+      args[name] !== undefined ? String(args[name]) : `{${name}}`,
+    );
+  }
+
+  /**
+   * Translate a known English error string (or i18n key payload) for the response.
+   * Supports:
+   * - Plain English strings that match an `errors.*` English value
+   * - Objects shaped like `{ i18nKey: 'errors.FOO', args?: {...} }`
+   */
+  translateErrorMessage(message: unknown, locale: string): unknown {
+    if (message && typeof message === 'object' && !Array.isArray(message)) {
+      const payload = message as { i18nKey?: string; args?: Record<string, string | number>; message?: unknown };
+      if (payload.i18nKey) {
+        return this.t(payload.i18nKey, locale, payload.args ?? {});
+      }
+      if (Array.isArray(payload.message)) {
+        return payload.message.map((m) => this.translateErrorMessage(m, locale));
+      }
+      if (typeof payload.message === 'string') {
+        return this.translateErrorMessage(payload.message, locale);
+      }
+      return message;
+    }
+
+    if (Array.isArray(message)) {
+      return message.map((m) => this.translateErrorMessage(m, locale));
+    }
+
+    if (typeof message !== 'string') {
+      return message;
+    }
+
+    // Direct key usage: "errors.ONLY_BUYER_MAY_CONFIRM"
+    if (message.startsWith('errors.') || message.startsWith('email.')) {
+      return this.t(message, locale);
+    }
+
+    const key = this.findErrorKeyByEnglish(message);
+    if (key) {
+      const args = this.extractArgsFromEnglish(message, key);
+      return this.t(`errors.${key}`, locale, args);
+    }
+
+    return message;
+  }
+
+  getEmailCopy(type: string, locale: string): Record<string, string> | null {
+    const value = this.lookup(locale, `email.${type}`) ?? this.lookup(DEFAULT_LOCALE, `email.${type}`);
+    if (!value || typeof value !== 'object') return null;
+    return value as Record<string, string>;
+  }
+
+  private loadLocales() {
+    const localesRoot = path.join(__dirname, 'locales');
+    for (const locale of SUPPORTED_LOCALES) {
+      const filePath = path.join(localesRoot, locale, 'common.json');
+      try {
+        const raw = fs.readFileSync(filePath, 'utf-8');
+        this.catalogs.set(locale, JSON.parse(raw) as LocaleTree);
+      } catch (error) {
+        this.logger.error(`Failed to load locale ${locale} from ${filePath}`, (error as Error).message);
+      }
+    }
+  }
+
+  private lookup(locale: string, key: string): unknown {
+    const catalog = this.catalogs.get(locale) ?? this.catalogs.get(DEFAULT_LOCALE);
+    if (!catalog) return undefined;
+
+    return key.split('.').reduce<unknown>((node, part) => {
+      if (node && typeof node === 'object' && part in (node as LocaleTree)) {
+        return (node as LocaleTree)[part];
+      }
+      return undefined;
+    }, catalog);
+  }
+
+  private findErrorKeyByEnglish(englishMessage: string): string | null {
+    const enErrors = this.lookup(DEFAULT_LOCALE, 'errors');
+    if (!enErrors || typeof enErrors !== 'object') return null;
+
+    for (const [key, template] of Object.entries(enErrors as Record<string, string>)) {
+      if (typeof template !== 'string') continue;
+      if (template === englishMessage) return key;
+
+      const pattern = template.replace(/\{(\w+)\}/g, '(.+)');
+      const regex = new RegExp(`^${pattern}$`);
+      if (regex.test(englishMessage)) return key;
+    }
+
+    return null;
+  }
+
+  private extractArgsFromEnglish(
+    englishMessage: string,
+    key: string,
+  ): Record<string, string> {
+    const template = this.lookup(DEFAULT_LOCALE, `errors.${key}`);
+    if (typeof template !== 'string') return {};
+
+    const names = [...template.matchAll(/\{(\w+)\}/g)].map((m) => m[1]);
+    if (names.length === 0) return {};
+
+    const pattern = template.replace(/\{(\w+)\}/g, '(.+)');
+    const match = englishMessage.match(new RegExp(`^${pattern}$`));
+    if (!match) return {};
+
+    const args: Record<string, string> = {};
+    names.forEach((name, i) => {
+      args[name] = match[i + 1];
+    });
+    return args;
+  }
+}

--- a/src/i18n/locale.middleware.ts
+++ b/src/i18n/locale.middleware.ts
@@ -1,0 +1,21 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { I18nService } from './i18n.service';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    locale?: string;
+  }
+}
+
+@Injectable()
+export class LocaleMiddleware implements NestMiddleware {
+  constructor(private readonly i18n: I18nService) {}
+
+  use(req: Request, _res: Response, next: NextFunction) {
+    const header = req.headers['accept-language'];
+    const value = Array.isArray(header) ? header[0] : header;
+    req.locale = this.i18n.resolveLocale(value);
+    next();
+  }
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,0 +1,40 @@
+{
+  "errors": {
+    "ONLY_BUYER_MAY_CONFIRM": "Only the shipment buyer may confirm milestones",
+    "SHIPMENT_NOT_FOUND": "Shipment {id} not found",
+    "MILESTONE_NOT_FOUND": "Milestone {index} not found on shipment {id}",
+    "MILESTONE_CONFIRM_STATUS": "Milestone {index} must be in PROOF_SUBMITTED status to confirm (currently {status})",
+    "INTERNAL_SERVER_ERROR": "Internal server error",
+    "TOO_MANY_REQUESTS": "Too Many Requests",
+    "NOTIFICATION_NOT_FOUND": "Notification not found",
+    "PROOF_FILE_REQUIRED": "A proof file must be provided in the \"file\" field",
+    "UNSUPPORTED_FILE_TYPE": "Unsupported file type: {mime}. Allowed: PDF, images, MP4.",
+    "CANCELLED_SHIPMENT_CONFIRM": "Cannot confirm a milestone for a cancelled shipment"
+  },
+  "email": {
+    "PROOF_SUBMITTED": {
+      "subject": "Proof Submitted",
+      "heading": "ChainSettle — Proof Submitted",
+      "body": "A proof has been submitted for milestone <strong>{{milestoneName}}</strong> on shipment <strong>{{shipmentId}}</strong>.",
+      "cta": "View Proof on IPFS",
+      "footer_action": "Please review and confirm or dispute the submitted proof.",
+      "footer": "You're receiving this because you're a participant on ChainSettle."
+    },
+    "PAYMENT_RELEASED": {
+      "subject": "Payment Released",
+      "heading": "ChainSettle — Payment Released",
+      "body": "A payment of <strong>{{amount}} {{tokenSymbol}}</strong> has been released for milestone <strong>{{milestoneIndex}}</strong> on shipment <strong>{{shipmentId}}</strong>.",
+      "cta": "View Shipment",
+      "footer": "You're receiving this because you're a participant on ChainSettle."
+    },
+    "DISPUTE_RAISED": {
+      "subject": "Dispute Raised",
+      "heading": "ChainSettle — Dispute Raised",
+      "body": "A dispute has been raised for milestone <strong>{{milestoneIndex}}</strong> on shipment <strong>{{shipmentId}}</strong>.",
+      "action": "Please submit your evidence promptly so the arbiter can review the case.",
+      "cta": "Submit Evidence",
+      "footer": "You're receiving this because you're a participant on ChainSettle."
+    },
+    "GENERIC_FOOTER": "You're receiving this because you're a participant on ChainSettle."
+  }
+}

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1,0 +1,40 @@
+{
+  "errors": {
+    "ONLY_BUYER_MAY_CONFIRM": "Solo el comprador del envío puede confirmar hitos",
+    "SHIPMENT_NOT_FOUND": "Envío {id} no encontrado",
+    "MILESTONE_NOT_FOUND": "Hito {index} no encontrado en el envío {id}",
+    "MILESTONE_CONFIRM_STATUS": "El hito {index} debe estar en estado PROOF_SUBMITTED para confirmar (actualmente {status})",
+    "INTERNAL_SERVER_ERROR": "Error interno del servidor",
+    "TOO_MANY_REQUESTS": "Demasiadas solicitudes",
+    "NOTIFICATION_NOT_FOUND": "Notificación no encontrada",
+    "PROOF_FILE_REQUIRED": "Se debe proporcionar un archivo de prueba en el campo \"file\"",
+    "UNSUPPORTED_FILE_TYPE": "Tipo de archivo no admitido: {mime}. Permitidos: PDF, imágenes, MP4.",
+    "CANCELLED_SHIPMENT_CONFIRM": "No se puede confirmar un hito de un envío cancelado"
+  },
+  "email": {
+    "PROOF_SUBMITTED": {
+      "subject": "Prueba enviada",
+      "heading": "ChainSettle — Prueba enviada",
+      "body": "Se ha enviado una prueba para el hito <strong>{{milestoneName}}</strong> del envío <strong>{{shipmentId}}</strong>.",
+      "cta": "Ver prueba en IPFS",
+      "footer_action": "Revise y confirme o dispute la prueba enviada.",
+      "footer": "Recibe este mensaje porque es participante de ChainSettle."
+    },
+    "PAYMENT_RELEASED": {
+      "subject": "Pago liberado",
+      "heading": "ChainSettle — Pago liberado",
+      "body": "Se ha liberado un pago de <strong>{{amount}} {{tokenSymbol}}</strong> para el hito <strong>{{milestoneIndex}}</strong> del envío <strong>{{shipmentId}}</strong>.",
+      "cta": "Ver envío",
+      "footer": "Recibe este mensaje porque es participante de ChainSettle."
+    },
+    "DISPUTE_RAISED": {
+      "subject": "Disputa iniciada",
+      "heading": "ChainSettle — Disputa iniciada",
+      "body": "Se ha iniciado una disputa para el hito <strong>{{milestoneIndex}}</strong> del envío <strong>{{shipmentId}}</strong>.",
+      "action": "Envíe su evidencia a la brevedad para que el árbitro pueda revisar el caso.",
+      "cta": "Enviar evidencia",
+      "footer": "Recibe este mensaje porque es participante de ChainSettle."
+    },
+    "GENERIC_FOOTER": "Recibe este mensaje porque es participante de ChainSettle."
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,6 @@ import helmet from 'helmet';
 import * as compression from 'compression';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { AppModule } from './app.module';
-import { HttpExceptionFilter } from './common/filters/http-exception.filter';
-import { ThrottlerExceptionFilter } from './common/filters/throttler-exception.filter';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 import { createWinstonLogger } from './common/logger/winston.logger';
 
@@ -80,7 +78,7 @@ async function bootstrap() {
         ? allowedOrigins
         : [fallbackOrigin],
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Request-ID', 'Accept-Language'],
     exposedHeaders: ['X-Request-ID'],
     credentials: true,
   });
@@ -101,11 +99,7 @@ async function bootstrap() {
     }),
   );
 
-  // Global exception filter — standardised error responses
-  app.useGlobalFilters(
-    new HttpExceptionFilter(),
-    new ThrottlerExceptionFilter(),
-  );
+  // Exception filters are registered via APP_FILTER in AppModule (i18n-aware)
 
   // Global response transform — wraps all responses in { success, data, timestamp }
   app.useGlobalInterceptors(new TransformInterceptor());

--- a/src/modules/milestones/dto/bulk-confirm-milestones.dto.ts
+++ b/src/modules/milestones/dto/bulk-confirm-milestones.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class BulkConfirmItemDto {
+  @ApiProperty({ description: 'Zero-based milestone index to confirm' })
+  @IsInt()
+  @Min(0)
+  milestoneIndex: number;
+
+  @ApiProperty({ description: 'On-chain transaction hash of the confirm_milestone call' })
+  @IsString()
+  @IsNotEmpty()
+  txHash: string;
+
+  @ApiProperty({
+    example: '1000000000',
+    description: 'Amount released to the supplier, in stroops',
+  })
+  @IsString()
+  @IsNotEmpty()
+  paymentReleased: string;
+}
+
+export class BulkConfirmMilestonesDto {
+  @ApiProperty({
+    type: [BulkConfirmItemDto],
+    description: 'Milestones to confirm in this batch (1–20)',
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(20)
+  @ValidateNested({ each: true })
+  @Type(() => BulkConfirmItemDto)
+  milestones: BulkConfirmItemDto[];
+}

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -32,6 +32,7 @@ import { Response } from 'express';
 import { MilestonesService } from './milestones.service';
 import { AppendMilestoneDto } from './dto/append-milestone.dto';
 import { ConfirmMilestoneDto } from './dto/confirm-milestone.dto';
+import { BulkConfirmMilestonesDto } from './dto/bulk-confirm-milestones.dto';
 import { RebalanceMilestonesDto } from './dto/rebalance-milestones.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
@@ -244,6 +245,76 @@ export class MilestonesController {
   ) {
     const callerAddress: string = user?.stellarAddress ?? user?.sub;
     return this.milestonesService.rebalance(shipmentId, callerAddress, dto.milestones);
+  }
+
+  /**
+   * POST /api/v1/shipments/:shipmentId/milestones/bulk-confirm
+   *
+   * Confirms multiple PROOF_SUBMITTED milestones in one request.
+   * Valid items are updated in a single Prisma transaction; invalid indexes
+   * are reported per-item without rolling back successful confirms.
+   */
+  @Post('bulk-confirm')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({
+    summary: 'Batch-confirm multiple milestones (buyer only)',
+    description:
+      'Accepts a list of milestone indexes with on-chain tx hashes and payment amounts. ' +
+      'Returns per-index success/failure so partial failures are visible.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Per-index confirmation results',
+    schema: {
+      example: {
+        shipmentId: 'ship-001',
+        results: [
+          { milestoneIndex: 0, success: true, milestone: { status: 'CONFIRMED' } },
+          { milestoneIndex: 1, success: false, error: 'Milestone 1 must be in PROOF_SUBMITTED status to confirm (currently PENDING)' },
+        ],
+        summary: { total: 2, succeeded: 1, failed: 1 },
+      },
+    },
+  })
+  @ApiResponse({ status: 403, description: 'Only the shipment buyer may confirm milestones' })
+  @ApiResponse({ status: 404, description: 'Shipment not found' })
+  bulkConfirm(
+    @Param('shipmentId') shipmentId: string,
+    @Body() dto: BulkConfirmMilestonesDto,
+    @CurrentUser() user: any,
+  ) {
+    const callerAddress: string = user?.stellarAddress ?? user?.sub;
+    return this.milestonesService.bulkConfirmFromApi(shipmentId, callerAddress, dto.milestones);
+  }
+
+  /**
+   * POST /api/v1/shipments/:shipmentId/milestones/:index/confirm
+   *
+   * Buyer registers a milestone confirmation after signing on-chain.
+   */
+  @Post(':index/confirm')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'Confirm a single milestone (buyer only)' })
+  @ApiResponse({ status: 200, description: 'Milestone confirmed' })
+  @ApiResponse({ status: 403, description: 'Only the shipment buyer may confirm milestones' })
+  @ApiResponse({ status: 404, description: 'Shipment or milestone not found' })
+  @ApiResponse({ status: 409, description: 'Milestone is not in PROOF_SUBMITTED status' })
+  confirm(
+    @Param('shipmentId') shipmentId: string,
+    @Param('index', ParseIntPipe) index: number,
+    @Body() dto: ConfirmMilestoneDto,
+    @CurrentUser() user: any,
+  ) {
+    const callerAddress: string = user?.stellarAddress ?? user?.sub;
+    return this.milestonesService.confirmFromApi(
+      shipmentId,
+      index,
+      callerAddress,
+      dto.txHash,
+      dto.paymentReleased,
+    );
   }
 
   /**

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -194,6 +194,137 @@ export class MilestonesService {
     return updated;
   }
 
+  /**
+   * Batch-confirm multiple milestones in one request.
+   * Validates each index independently, applies successful confirms in a single
+   * Prisma transaction, and returns per-index success/failure so partial
+   * failures are visible without silently rolling back the whole batch.
+   */
+  async bulkConfirmFromApi(
+    shipmentId: string,
+    callerAddress: string,
+    items: Array<{ milestoneIndex: number; txHash: string; paymentReleased: string }>,
+  ) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+      include: { milestones: true },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    }
+
+    if (shipment.buyerAddress !== callerAddress) {
+      throw new ForbiddenException('Only the shipment buyer may confirm milestones');
+    }
+
+    if (shipment.status === 'CANCELLED') {
+      throw new ConflictException('Cannot confirm a milestone for a cancelled shipment');
+    }
+
+    const byIndex = new Map(shipment.milestones.map((m) => [m.milestoneIndex, m]));
+    const results: Array<{
+      milestoneIndex: number;
+      success: boolean;
+      milestone?: unknown;
+      error?: string;
+    }> = [];
+    const toConfirm: Array<{
+      milestoneIndex: number;
+      txHash: string;
+      paymentReleased: string;
+    }> = [];
+
+    for (const item of items) {
+      const milestone = byIndex.get(item.milestoneIndex);
+      if (!milestone) {
+        results.push({
+          milestoneIndex: item.milestoneIndex,
+          success: false,
+          error: `Milestone ${item.milestoneIndex} not found on shipment ${shipmentId}`,
+        });
+        continue;
+      }
+      if (milestone.status !== MilestoneStatus.PROOF_SUBMITTED) {
+        results.push({
+          milestoneIndex: item.milestoneIndex,
+          success: false,
+          error: `Milestone ${item.milestoneIndex} must be in PROOF_SUBMITTED status to confirm (currently ${milestone.status})`,
+        });
+        continue;
+      }
+      toConfirm.push(item);
+    }
+
+    const confirmedAt = new Date();
+    const updatedByIndex = new Map<number, unknown>();
+
+    if (toConfirm.length > 0) {
+      const updated = await this.prisma.$transaction(
+        toConfirm.map((item) =>
+          this.prisma.milestone.update({
+            where: {
+              shipmentId_milestoneIndex: {
+                shipmentId,
+                milestoneIndex: item.milestoneIndex,
+              },
+            },
+            data: {
+              status: MilestoneStatus.CONFIRMED,
+              paymentReleased: BigInt(item.paymentReleased),
+              confirmedAt,
+            },
+          }),
+        ),
+      );
+
+      updated.forEach((m, i) => {
+        updatedByIndex.set(toConfirm[i].milestoneIndex, m);
+      });
+
+      await this.shipments.syncStatusFromChain(shipmentId);
+
+      for (const item of toConfirm) {
+        await this.notifications.notifyUser(
+          shipment.supplierAddress,
+          NotificationType.PAYMENT_RELEASED,
+          'Payment released',
+          `Payment has been released for milestone ${item.milestoneIndex} on shipment ${shipmentId}. Tx: ${item.txHash}`,
+          {
+            shipmentId,
+            milestoneIndex: item.milestoneIndex,
+            paymentReleased: item.paymentReleased,
+            txHash: item.txHash,
+          },
+        );
+        results.push({
+          milestoneIndex: item.milestoneIndex,
+          success: true,
+          milestone: updatedByIndex.get(item.milestoneIndex),
+        });
+      }
+    }
+
+    // Preserve request order in the response
+    const resultByIndex = new Map(results.map((r) => [r.milestoneIndex, r]));
+    return {
+      shipmentId,
+      results: items.map(
+        (item) =>
+          resultByIndex.get(item.milestoneIndex) ?? {
+            milestoneIndex: item.milestoneIndex,
+            success: false,
+            error: 'Unknown error',
+          },
+      ),
+      summary: {
+        total: items.length,
+        succeeded: toConfirm.length,
+        failed: items.length - toConfirm.length,
+      },
+    };
+  }
+
   // ----------------------------------------------------------
   // INTERNAL HELPERS (called by EventsService)
   // ----------------------------------------------------------

--- a/src/modules/notifications/dto/update-preferences.dto.ts
+++ b/src/modules/notifications/dto/update-preferences.dto.ts
@@ -1,4 +1,4 @@
-import { IsIn, IsObject, IsOptional } from 'class-validator';
+import { IsIn, IsObject, IsOptional, IsString, IsUrl, ValidateIf } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { NotificationType } from '@prisma/client';
 import { DigestFrequency } from '../notifications.service';
@@ -8,12 +8,14 @@ const DIGEST_FREQUENCIES: DigestFrequency[] = ['instant', 'daily', 'weekly'];
 export class UpdatePreferencesDto {
   @ApiProperty({
     description: 'Partial map of NotificationType to channel flags',
-    example: { PROOF_SUBMITTED: { inApp: true, email: false } },
+    example: { PROOF_SUBMITTED: { inApp: true, email: false, slack: true } },
     required: false,
   })
   @IsOptional()
   @IsObject()
-  preferences?: Partial<Record<NotificationType, { inApp: boolean; email: boolean }>>;
+  preferences?: Partial<
+    Record<NotificationType, { inApp: boolean; email: boolean; slack?: boolean }>
+  >;
 
   @ApiProperty({
     description: 'How often to receive the notification digest email',
@@ -23,4 +25,16 @@ export class UpdatePreferencesDto {
   @IsOptional()
   @IsIn(DIGEST_FREQUENCIES)
   digestFrequency?: DigestFrequency;
+
+  @ApiProperty({
+    description:
+      'Slack Incoming Webhook URL for milestone/shipment events. Pass null or empty string to remove.',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null && v !== '')
+  @IsUrl({ require_tld: false })
+  @IsString()
+  slackWebhookUrl?: string | null;
 }

--- a/src/modules/notifications/notifications.service.spec.ts
+++ b/src/modules/notifications/notifications.service.spec.ts
@@ -3,17 +3,18 @@ import { ConfigService } from '@nestjs/config';
 import { NotificationsService } from './notifications.service';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { NotificationType } from '@prisma/client';
+import { I18nService } from '../../i18n/i18n.service';
 
 const ALL_TYPES = Object.values(NotificationType);
 
 function allEnabled() {
-  return ALL_TYPES.reduce((acc, t) => ({ ...acc, [t]: { inApp: true, email: true } }), {});
+  return ALL_TYPES.reduce((acc, t) => ({ ...acc, [t]: { inApp: true, email: true, slack: true } }), {});
 }
 
 const mockUser = { id: 'user-1', stellarAddress: 'GABC', email: 'user@example.com' };
 const mockNotification = { id: 'notif-1', userId: 'user-1', type: NotificationType.PROOF_SUBMITTED };
 
-function buildPrisma(prefOverride?: object) {
+function buildPrisma(prefOverride?: object, slackWebhookUrl: string | null = null) {
   return {
     user: { findUnique: jest.fn().mockResolvedValue(mockUser) },
     notification: {
@@ -24,8 +25,14 @@ function buildPrisma(prefOverride?: object) {
       updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
     notificationPreference: {
-      upsert: jest.fn().mockResolvedValue({ preferences: prefOverride ?? allEnabled() }),
-      update: jest.fn().mockResolvedValue({ preferences: prefOverride ?? allEnabled() }),
+      upsert: jest.fn().mockResolvedValue({
+        preferences: prefOverride ?? allEnabled(),
+        slackWebhookUrl,
+      }),
+      update: jest.fn().mockResolvedValue({
+        preferences: prefOverride ?? allEnabled(),
+        slackWebhookUrl,
+      }),
     },
     $transaction: jest.fn().mockResolvedValue([[], 0]),
   };
@@ -37,6 +44,13 @@ async function buildService(prisma: any) {
       NotificationsService,
       { provide: PrismaService, useValue: prisma },
       { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue(undefined) } },
+      {
+        provide: I18nService,
+        useValue: {
+          getEmailCopy: jest.fn().mockReturnValue(null),
+          t: jest.fn((key: string) => key),
+        },
+      },
     ],
   }).compile();
   return module.get(NotificationsService);
@@ -57,14 +71,14 @@ describe('NotificationsService — preferences', () => {
       );
     });
 
-    it('all types default to inApp: true, email: true', async () => {
+    it('all types default to inApp: true, email: true, slack: true', async () => {
       const prisma = buildPrisma();
       const service = await buildService(prisma);
 
       const prefs = await service.getOrCreatePreferences('user-1');
 
       ALL_TYPES.forEach((type) => {
-        expect(prefs[type]).toEqual({ inApp: true, email: true });
+        expect(prefs[type]).toEqual({ inApp: true, email: true, slack: true });
       });
     });
   });
@@ -144,6 +158,42 @@ describe('NotificationsService — preferences', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('Slack channel', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      jest.clearAllMocks();
+    });
+
+    it('posts to Slack when webhook URL is configured and slack is enabled', async () => {
+      const prisma = buildPrisma(undefined, 'https://hooks.slack.com/services/T/B/X');
+      const service = await buildService(prisma);
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, text: async () => 'ok' }) as any;
+
+      await service.notifyUser('GABC', NotificationType.PROOF_SUBMITTED, 'Proof in', 'msg', {
+        shipmentId: 'ship-1',
+        milestoneIndex: 0,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://hooks.slack.com/services/T/B/X',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('skips Slack when webhook URL is removed', async () => {
+      const prisma = buildPrisma(undefined, null);
+      const service = await buildService(prisma);
+      global.fetch = jest.fn() as any;
+
+      await service.notifyUser('GABC', NotificationType.PROOF_SUBMITTED, 'Proof in', 'msg');
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(prisma.notification.create).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -9,18 +9,30 @@ import { NotificationType } from '@prisma/client';
 import { NotificationsGateway } from './notifications.gateway';
 import { WebhooksService } from '../webhooks/webhooks.service';
 import { UpdatePreferencesDto } from './dto/update-preferences.dto';
+import { DEFAULT_LOCALE, I18nService } from '../../i18n/i18n.service';
 
-type PreferenceMap = Record<NotificationType, { inApp: boolean; email: boolean }>;
+type ChannelPrefs = { inApp: boolean; email: boolean; slack: boolean };
+type PreferenceMap = Record<NotificationType, ChannelPrefs>;
 export type DigestFrequency = 'instant' | 'daily' | 'weekly';
-type StoredPreferences = PreferenceMap & { _meta?: { digestFrequency?: DigestFrequency } };
+type StoredPreferences = PreferenceMap & {
+  _meta?: { digestFrequency?: DigestFrequency };
+};
 
 const DEFAULT_DIGEST_FREQUENCY: DigestFrequency = 'daily';
 
 function buildDefaultPreferences(): PreferenceMap {
   return Object.values(NotificationType).reduce((acc, type) => {
-    acc[type] = { inApp: true, email: true };
+    acc[type] = { inApp: true, email: true, slack: true };
     return acc;
   }, {} as PreferenceMap);
+}
+
+function normalizeChannelPrefs(raw: Partial<ChannelPrefs> | undefined): ChannelPrefs {
+  return {
+    inApp: raw?.inApp ?? true,
+    email: raw?.email ?? true,
+    slack: raw?.slack ?? true,
+  };
 }
 
 @Injectable()
@@ -31,6 +43,7 @@ export class NotificationsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly config: ConfigService,
+    private readonly i18n: I18nService,
     @Optional() private readonly gateway: NotificationsGateway,
     @Optional() private readonly webhooks: WebhooksService,
   ) {
@@ -49,6 +62,8 @@ export class NotificationsService {
    * Creates an in-app notification for a user (by their Stellar address)
    * and optionally sends an email if they have one registered.
    * Both channels are gated on the user's NotificationPreference record.
+   * When a Slack webhook URL is configured and the type opts into Slack,
+   * a formatted message is also posted to that channel.
    */
   async notifyUser(
     stellarAddress: string,
@@ -67,8 +82,8 @@ export class NotificationsService {
         return;
       }
 
-      const prefs = await this.getOrCreatePreferences(user.id);
-      const { inApp, email: emailEnabled } = prefs[type];
+      const { preferences: prefs, slackWebhookUrl } = await this.getOrCreatePreferenceRecord(user.id);
+      const { inApp, email: emailEnabled, slack: slackEnabled } = normalizeChannelPrefs(prefs[type]);
 
       if (!inApp) return;
 
@@ -82,6 +97,10 @@ export class NotificationsService {
           where: { id: notification.id },
           data: { emailSent: true },
         });
+      }
+
+      if (slackEnabled && slackWebhookUrl) {
+        await this.sendSlackMessage(slackWebhookUrl, type, title, message, data);
       }
 
       this.gateway?.pushToUser(user.id, notification);
@@ -218,25 +237,47 @@ export class NotificationsService {
   }
 
   async getOrCreatePreferences(userId: string): Promise<PreferenceMap> {
+    const record = await this.getOrCreatePreferenceRecord(userId);
+    return record.preferences;
+  }
+
+  private async getOrCreatePreferenceRecord(userId: string): Promise<{
+    preferences: PreferenceMap;
+    slackWebhookUrl: string | null;
+  }> {
     const record = await this.prisma.notificationPreference.upsert({
       where: { userId },
       create: { userId, preferences: buildDefaultPreferences() },
       update: {},
     });
-    return record.preferences as PreferenceMap;
+    return {
+      preferences: record.preferences as PreferenceMap,
+      slackWebhookUrl: record.slackWebhookUrl ?? null,
+    };
   }
 
-  async updatePreferences(userId: string, dto: UpdatePreferencesDto): Promise<PreferenceMap> {
+  async updatePreferences(userId: string, dto: UpdatePreferencesDto) {
     const current = (await this.getOrCreatePreferences(userId)) as StoredPreferences;
     const merged: StoredPreferences = { ...current, ...(dto.preferences ?? {}) };
     if (dto.digestFrequency) {
       merged._meta = { ...current._meta, digestFrequency: dto.digestFrequency };
     }
-    const record = await this.prisma.notificationPreference.update({
+
+    const data: { preferences: StoredPreferences; slackWebhookUrl?: string | null } = {
+      preferences: merged,
+    };
+    if (dto.slackWebhookUrl !== undefined) {
+      data.slackWebhookUrl =
+        dto.slackWebhookUrl === '' || dto.slackWebhookUrl === null
+          ? null
+          : dto.slackWebhookUrl;
+    }
+
+    await this.prisma.notificationPreference.update({
       where: { userId },
-      data: { preferences: merged },
+      data,
     });
-    return record.preferences as PreferenceMap;
+    return this.getPreferencesResponse(userId);
   }
 
   /**
@@ -249,9 +290,14 @@ export class NotificationsService {
   }
 
   async getPreferencesResponse(userId: string) {
-    const prefs = (await this.getOrCreatePreferences(userId)) as StoredPreferences;
-    const { _meta, ...typePreferences } = prefs;
-    return { ...typePreferences, digestFrequency: _meta?.digestFrequency ?? DEFAULT_DIGEST_FREQUENCY };
+    const { preferences, slackWebhookUrl } = await this.getOrCreatePreferenceRecord(userId);
+    const stored = preferences as StoredPreferences;
+    const { _meta, ...typePreferences } = stored;
+    return {
+      ...typePreferences,
+      digestFrequency: _meta?.digestFrequency ?? DEFAULT_DIGEST_FREQUENCY,
+      slackWebhookUrl,
+    };
   }
 
   async findForUser(userId: string, unreadOnly = false, page = 1, limit = 20) {
@@ -339,8 +385,13 @@ export class NotificationsService {
   /**
    * Loads and renders a Handlebars template for the given notification type.
    * Returns null when no template file exists for that type (triggers plain-text fallback).
+   * Localized copy is injected as `t` from the i18n email catalog.
    */
-  private renderTemplate(type: NotificationType, data: Record<string, any>): string | null {
+  private renderTemplate(
+    type: NotificationType,
+    data: Record<string, any>,
+    locale: string = DEFAULT_LOCALE,
+  ): string | null {
     const templatePath = path.join(__dirname, 'templates', `${type}.hbs`);
     if (!fs.existsSync(templatePath)) {
       return null;
@@ -348,7 +399,18 @@ export class NotificationsService {
     try {
       const source = fs.readFileSync(templatePath, 'utf-8');
       const template = Handlebars.compile(source);
-      return template(data ?? {});
+      const emailCopy = this.i18n.getEmailCopy(type, locale);
+      const interpolated = emailCopy
+        ? Object.fromEntries(
+            Object.entries(emailCopy).map(([k, v]) => [
+              k,
+              typeof v === 'string'
+                ? Handlebars.compile(v)(data ?? {})
+                : v,
+            ]),
+          )
+        : {};
+      return template({ ...(data ?? {}), t: interpolated });
     } catch (error) {
       this.logger.error(`Failed to render template for ${type}`, error.message);
       return null;
@@ -362,29 +424,98 @@ export class NotificationsService {
     html?: string,
     type?: NotificationType,
     data?: Record<string, any>,
+    locale: string = DEFAULT_LOCALE,
   ) {
     try {
       let renderedHtml = html;
       if (!renderedHtml && type) {
-        renderedHtml = this.renderTemplate(type, data ?? {}) ?? undefined;
+        renderedHtml = this.renderTemplate(type, data ?? {}, locale) ?? undefined;
       }
+      const localizedSubject =
+        type && this.i18n.getEmailCopy(type, locale)?.subject
+          ? this.i18n.getEmailCopy(type, locale)!.subject
+          : subject;
+      const footer =
+        this.i18n.t('email.GENERIC_FOOTER', locale) ||
+        "You're receiving this because you're a participant on ChainSettle.";
       await this.transporter.sendMail({
         from: this.config.get('EMAIL_FROM', 'noreply@chainsetttle.com'),
         to,
-        subject: `ChainSettle — ${subject}`,
+        subject: `ChainSettle — ${localizedSubject}`,
         text,
         html: renderedHtml ?? `
           <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
             <h2 style="color: #1a1a2e;">ChainSettle</h2>
             <p>${text}</p>
             <hr />
-            <small style="color: #888;">You're receiving this because you're a participant on ChainSettle.</small>
+            <small style="color: #888;">${footer}</small>
           </div>
         `,
       });
-      this.logger.log(`Email sent to ${to}: ${subject}`);
+      this.logger.log(`Email sent to ${to}: ${localizedSubject}`);
     } catch (error) {
       this.logger.error(`Email failed to ${to}`, error.message);
+    }
+  }
+
+  /**
+   * Posts a Slack Incoming Webhook payload for a notification event.
+   * Failures are logged and never throw — Slack must not break in-app/email.
+   */
+  async sendSlackMessage(
+    webhookUrl: string,
+    type: NotificationType,
+    title: string,
+    message: string,
+    data?: Record<string, any>,
+  ) {
+    try {
+      const shipmentId = data?.shipmentId ? String(data.shipmentId) : undefined;
+      const milestoneIndex =
+        data?.milestoneIndex !== undefined ? String(data.milestoneIndex) : undefined;
+
+      const fields = [
+        shipmentId ? { type: 'mrkdwn', text: `*Shipment:*\n\`${shipmentId}\`` } : null,
+        milestoneIndex !== undefined
+          ? { type: 'mrkdwn', text: `*Milestone:*\n${milestoneIndex}` }
+          : null,
+        { type: 'mrkdwn', text: `*Type:*\n${type}` },
+      ].filter(Boolean);
+
+      const payload = {
+        text: `ChainSettle — ${title}`,
+        blocks: [
+          {
+            type: 'header',
+            text: { type: 'plain_text', text: `ChainSettle — ${title}`, emoji: true },
+          },
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: message },
+          },
+          ...(fields.length
+            ? [{ type: 'section', fields }]
+            : []),
+        ],
+      };
+
+      const response = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        this.logger.error(
+          `Slack webhook failed (${response.status}): ${body || response.statusText}`,
+        );
+        return;
+      }
+
+      this.logger.log(`Slack notification sent for ${type}: ${title}`);
+    } catch (error) {
+      this.logger.error(`Slack notification failed for ${type}`, (error as Error).message);
     }
   }
 }

--- a/src/modules/notifications/templates/DISPUTE_RAISED.hbs
+++ b/src/modules/notifications/templates/DISPUTE_RAISED.hbs
@@ -1,14 +1,14 @@
 <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-  <h2 style="color: #1a1a2e;">ChainSettle — Dispute Raised</h2>
-  <p>A dispute has been raised for milestone <strong>{{milestoneIndex}}</strong> on shipment <strong>{{shipmentId}}</strong>.</p>
-  <p>Please submit your evidence promptly so the arbiter can review the case.</p>
+  <h2 style="color: #1a1a2e;">{{t.heading}}</h2>
+  <p>{{{t.body}}}</p>
+  <p>{{t.action}}</p>
   {{#if evidenceUrl}}
   <p>
     <a href="{{evidenceUrl}}" style="display:inline-block;background:#1a1a2e;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px;">
-      Submit Evidence
+      {{t.cta}}
     </a>
   </p>
   {{/if}}
   <hr />
-  <small style="color: #888;">You're receiving this because you're a participant on ChainSettle.</small>
+  <small style="color: #888;">{{t.footer}}</small>
 </div>

--- a/src/modules/notifications/templates/PAYMENT_RELEASED.hbs
+++ b/src/modules/notifications/templates/PAYMENT_RELEASED.hbs
@@ -1,14 +1,14 @@
 <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-  <h2 style="color: #1a1a2e;">ChainSettle — Payment Released</h2>
-  <p>A payment of <strong>{{amount}} {{tokenSymbol}}</strong> has been released for milestone <strong>{{milestoneIndex}}</strong> on shipment <strong>{{shipmentId}}</strong>.</p>
+  <h2 style="color: #1a1a2e;">{{t.heading}}</h2>
+  <p>{{{t.body}}}</p>
   {{#if txHash}}
   <p>Transaction: <code>{{txHash}}</code></p>
   {{/if}}
   <p>
     <a href="#" style="display:inline-block;background:#1a1a2e;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px;">
-      View Shipment
+      {{t.cta}}
     </a>
   </p>
   <hr />
-  <small style="color: #888;">You're receiving this because you're a participant on ChainSettle.</small>
+  <small style="color: #888;">{{t.footer}}</small>
 </div>

--- a/src/modules/notifications/templates/PROOF_SUBMITTED.hbs
+++ b/src/modules/notifications/templates/PROOF_SUBMITTED.hbs
@@ -1,14 +1,14 @@
 <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
-  <h2 style="color: #1a1a2e;">ChainSettle — Proof Submitted</h2>
-  <p>A proof has been submitted for milestone <strong>{{milestoneName}}</strong> on shipment <strong>{{shipmentId}}</strong>.</p>
+  <h2 style="color: #1a1a2e;">{{t.heading}}</h2>
+  <p>{{{t.body}}}</p>
   {{#if ipfsUrl}}
   <p>
     <a href="{{ipfsUrl}}" style="display:inline-block;background:#1a1a2e;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px;">
-      View Proof on IPFS
+      {{t.cta}}
     </a>
   </p>
   {{/if}}
-  <p>Please review and confirm or dispute the submitted proof.</p>
+  <p>{{t.footer_action}}</p>
   <hr />
-  <small style="color: #888;">You're receiving this because you're a participant on ChainSettle.</small>
+  <small style="color: #888;">{{t.footer}}</small>
 </div>


### PR DESCRIPTION
## Summary
Implements #230, #235, #237, and #246 for internationalization, batch milestone confirmation, Slack delivery, and SBOM generation in CI.

### #230 — i18n for API error messages
- Added a lightweight `I18nModule` with `en` + `es` locale catalogs under `src/i18n/locales/`
- Locale resolved from `Accept-Language` via `LocaleMiddleware` (falls back to English)
- `HttpExceptionFilter` / `ThrottlerExceptionFilter` translate known error strings
- Email template copy extracted into locale files; Handlebars templates consume `t.*`
- CORS allows `Accept-Language`
- Docs for adding a locale: `src/i18n/README.md`

### #235 — `POST /shipments/:id/milestones/bulk-confirm`
- New DTO + endpoint accepting up to 20 `{ milestoneIndex, txHash, paymentReleased }` items
- Reuses buyer / `PROOF_SUBMITTED` validation from confirm flow
- Valid confirms applied in one Prisma `$transaction`; invalid indexes reported per-item without rolling back successes
- Also wired single `POST .../milestones/:index/confirm` (DTO already existed)

### #237 — Slack notification integration
- Added `slackWebhookUrl` on `NotificationPreference` (+ migration)
- Per-type prefs now include `slack` (default `true`) alongside `inApp` / `email`
- `notifyUser` posts a Block Kit message when URL is set and type opts into Slack
- Clearing the webhook stops Slack only; in-app/email unchanged
- Configure via `PATCH /notifications/preferences` (`slackWebhookUrl`)

### #246 — SBOM in CI
- Added `.github/workflows/sbom.yml` (release / tag / manual) generating CycloneDX via `@cyclonedx/cyclonedx-npm`
- Uploads `sbom.cdx.json` as an artifact and attaches it to GitHub Releases
- Local regen: `npm run sbom` (documented in README)

## Test plan
- [ ] `Accept-Language: es` on a buyer-only confirm call returns Spanish for “Only the shipment buyer may confirm milestones”
- [ ] Missing/unsupported `Accept-Language` falls back to English
- [ ] Bulk-confirm 3 valid `PROOF_SUBMITTED` indexes → all succeed with per-index results
- [ ] Bulk-confirm mix of valid + invalid indexes → partial success; failed index has a clear `error`
- [ ] Set `slackWebhookUrl` on preferences → milestone event posts to Slack
- [ ] Clear `slackWebhookUrl` → Slack stops; in-app/email still work
- [ ] Run SBOM workflow (or `npm run sbom`) → valid `sbom.cdx.json` artifact
- [ ] Apply Prisma migration for `slackWebhookUrl`

closes #230
closes #235
closes #237
closes #246