### PR TITLE
Feat/feature flags multisig saved filters ics

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,163 @@
+# Feature Flags
+
+Feature flags gate new functionality so it can be released gradually, tested
+internally, or switched off in production without a deploy.
+
+Flags live in Redis, which the app already runs for the nonce store and
+throttling. They are read on every request with no in-process cache, so a
+change takes effect on the next request across every pod.
+
+## Contents
+
+- [Gating a route](#gating-a-route)
+- [Flag naming](#flag-naming)
+- [Flag shape](#flag-shape)
+- [Toggling a flag without a redeploy](#toggling-a-flag-without-a-redeploy)
+- [Percentage rollouts](#percentage-rollouts)
+- [Reading flags in a service](#reading-flags-in-a-service)
+- [Removing a flag](#removing-a-flag)
+
+## Gating a route
+
+Apply `@FeatureFlag()` and `FeatureFlagGuard`. On a controller the flag covers
+every route in it; on a single handler it covers only that route, and a
+handler-level flag overrides a controller-level one.
+
+```ts
+import { UseGuards } from '@nestjs/common';
+import { FeatureFlag } from '../../common/decorators/feature-flag.decorator';
+import { FeatureFlagGuard } from '../../common/guards/feature-flag.guard';
+
+// Whole controller
+@FeatureFlag('shipment-templates')
+@UseGuards(FeatureFlagGuard)
+@Controller('shipment-templates')
+export class ShipmentTemplatesController {}
+
+// Single route
+@FeatureFlag('ipfs-proofs')
+@UseGuards(FeatureFlagGuard)
+@Post(':id/proof')
+submitProof() {}
+```
+
+When the flag is off the route answers **404**, not 403. A disabled endpoint
+should be indistinguishable from one that does not exist; a 403 would confirm
+the route is present and merely switched off, which leaks unreleased work.
+
+**Unknown flags are off.** A flag that has never been set evaluates to false,
+so new functionality stays dark until somebody turns it on deliberately. That
+is the safe default for both a gradual rollout and a kill switch.
+
+## Flag naming
+
+One flag per shippable capability, named for the capability rather than the
+ticket or the date.
+
+- Lowercase `kebab-case`: `shipment-templates`, `ipfs-proofs`, `webhook-retries`
+- Name the feature, not the mechanism: `saved-filters`, not `new-filter-code`
+- No environment or date suffixes: use `ipfs-proofs`, not `ipfs-proofs-v2` or
+  `ipfs-proofs-2026-08`
+- Keep the name stable once it is live, since renaming a key silently reverts
+  the flag to off for everyone
+
+The Redis key is the flag name prefixed with `feature-flag:`, so
+`shipment-templates` is stored at `feature-flag:shipment-templates`.
+
+## Flag shape
+
+The value is a small JSON document:
+
+```json
+{ "enabled": true, "rollout": 25 }
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `enabled` | `boolean` | Master switch. `false` is an unconditional kill switch regardless of `rollout`. |
+| `rollout` | `number` (optional) | Percentage 0-100. Omitted or `100` means everyone. Values outside the range are clamped. |
+
+## Toggling a flag without a redeploy
+
+Set the key. The next request picks it up; nothing needs restarting.
+
+Turn a flag on for everyone:
+
+```
+SET feature-flag:shipment-templates {"enabled":true}
+```
+
+Kill a misbehaving feature immediately:
+
+```
+SET feature-flag:shipment-templates {"enabled":false}
+```
+
+Roll out to a quarter of users:
+
+```
+SET feature-flag:shipment-templates {"enabled":true,"rollout":25}
+```
+
+Inspect the current value:
+
+```
+GET feature-flag:shipment-templates
+```
+
+From a shell, the same via `redis-cli`:
+
+```bash
+redis-cli SET feature-flag:shipment-templates '{"enabled":true,"rollout":25}'
+```
+
+Because `enabled` is checked before `rollout`, setting `enabled` to `false` is
+a complete stop even mid-rollout. It leaves the rollout percentage in place, so
+flipping `enabled` back to `true` resumes at the same percentage.
+
+## Percentage rollouts
+
+A subject is bucketed 0-99 by hashing the flag name together with a stable
+per-caller id, so:
+
+- The same user always gets the same answer for the same flag. Nobody sees a
+  feature appear and vanish between requests.
+- Raising the percentage only ever adds users; nobody already in the rollout
+  drops out.
+- Being in the first 10% of one flag does not put a user in the first 10% of
+  every other flag, because the flag name is part of the hash.
+
+The subject is the authenticated user id, falling back to the Stellar address.
+A percentage rollout therefore needs an authenticated caller: on an anonymous
+request a percentage flag evaluates to **false**, rather than picking randomly
+and flapping request to request. Gate anonymous routes with a plain boolean
+flag instead.
+
+## Reading flags in a service
+
+For logic that is not a whole route, inject the service:
+
+```ts
+constructor(private readonly featureFlags: FeatureFlagsService) {}
+
+if (await this.featureFlags.isEnabled('webhook-retries', user.id)) {
+  // new path
+}
+```
+
+`FeatureFlagsModule` is global, so no import is needed in the consuming module.
+
+The service also exposes `getFlag`, `setFlag`, `deleteFlag`, and `listFlags`
+for administrative use. `listFlags` uses `SCAN`, not `KEYS`, so it is safe
+against the shared keyspace.
+
+## Removing a flag
+
+Once a feature is fully rolled out and the flag has been at 100% long enough to
+trust:
+
+1. Remove `@FeatureFlag()` and `FeatureFlagGuard` from the route.
+2. Delete the key: `DEL feature-flag:shipment-templates`.
+
+Delete the key only after the code is deployed. Deleting it first turns the
+feature off for everyone, since an unknown flag reads as false.

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.5.0",
+        "openapi-typescript": "^7.4.0",
         "prettier": "^3.0.0",
         "prisma": "^5.6.0",
         "source-map-support": "^0.5.21",
@@ -3013,6 +3014,112 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.19",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.19.tgz",
+      "integrity": "sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.3.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -4911,6 +5018,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -5205,6 +5319,13 @@
       "engines": {
         "node": ">=12.20"
       }
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -6843,6 +6964,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7321,6 +7443,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {
@@ -8802,6 +8937,16 @@
         "node": ">= 20"
       }
     },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-md5": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
@@ -9697,6 +9842,71 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12318,6 +12528,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/urijs": {
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
@@ -12800,6 +13017,13 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/yargs": {
       "version": "17.7.3",

--- a/prisma/migrations/20260828000000_add_shipment_approvals/migration.sql
+++ b/prisma/migrations/20260828000000_add_shipment_approvals/migration.sql
@@ -1,0 +1,24 @@
+-- Migration: add_shipment_approvals
+-- Multi-signature approval for shipments above a configurable value threshold
+
+ALTER TABLE "shipments" ADD COLUMN "requiredApprovals" INTEGER;
+
+CREATE TABLE "shipment_approvals" (
+    "id"              TEXT         NOT NULL,
+    "shipmentId"      TEXT         NOT NULL,
+    "approverAddress" TEXT         NOT NULL,
+    "note"            TEXT,
+    "createdAt"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "shipment_approvals_pkey" PRIMARY KEY ("id")
+);
+
+-- One approval per approver per shipment; a repeat sign-off must not count twice
+CREATE UNIQUE INDEX "shipment_approvals_shipmentId_approverAddress_key"
+    ON "shipment_approvals"("shipmentId", "approverAddress");
+
+CREATE INDEX "shipment_approvals_shipmentId_idx" ON "shipment_approvals"("shipmentId");
+
+ALTER TABLE "shipment_approvals"
+    ADD CONSTRAINT "shipment_approvals_shipmentId_fkey"
+    FOREIGN KEY ("shipmentId") REFERENCES "shipments"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260828000001_add_saved_filters/migration.sql
+++ b/prisma/migrations/20260828000001_add_saved_filters/migration.sql
@@ -1,0 +1,22 @@
+-- Migration: add_saved_filters
+-- Named, reusable GET /shipments filter presets, private per user
+
+CREATE TABLE "saved_filters" (
+    "id"        TEXT         NOT NULL,
+    "userId"    TEXT         NOT NULL,
+    "name"      TEXT         NOT NULL,
+    "filter"    JSONB        NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "saved_filters_pkey" PRIMARY KEY ("id")
+);
+
+-- Names are unique per user, not globally: two users may both have "Overdue"
+CREATE UNIQUE INDEX "saved_filters_userId_name_key" ON "saved_filters"("userId", "name");
+
+CREATE INDEX "saved_filters_userId_idx" ON "saved_filters"("userId");
+
+ALTER TABLE "saved_filters"
+    ADD CONSTRAINT "saved_filters_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -145,6 +145,10 @@ model Shipment {
   metadata         Json?           // arbitrary key-value pairs (incoterms, port, etc)
   tags             String[]        @default([]) // searchable tags
 
+  /// Co-approvals required before any milestone on this shipment may be
+  /// confirmed. Null means the default single-approver flow.
+  requiredApprovals Int?
+
   cancelledAt      DateTime?       // set when shipment is cancelled
   refundTxHash     String?         // on-chain tx hash of the cancel/refund transaction
   archivedAt       DateTime?       // set when buyer archives a completed/cancelled shipment
@@ -164,6 +168,7 @@ model Shipment {
   trackingUpdates TrackingUpdate[]
   watchers  ShipmentWatcher[]
   favorites ShipmentFavorite[]
+  approvals ShipmentApproval[]
 
   isDraft          Boolean         @default(false) // true when created via CSV bulk import; no on-chain backing yet
 
@@ -480,6 +485,23 @@ model AppConfig {
   updatedAt DateTime @updatedAt
 
   @@map("app_config")
+}
+
+/// A single co-approver signing off on a high-value shipment. Milestone
+/// confirmation is blocked until the shipment has `requiredApprovals` rows
+/// here. One row per approver address, enforced by the unique constraint.
+model ShipmentApproval {
+  id              String   @id @default(uuid())
+  shipmentId      String
+  approverAddress String
+  note            String?
+  createdAt       DateTime @default(now())
+
+  shipment Shipment @relation(fields: [shipmentId], references: [id], onDelete: Cascade)
+
+  @@unique([shipmentId, approverAddress])
+  @@index([shipmentId])
+  @@map("shipment_approvals")
 }
 
 model ShipmentFavorite {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,6 +116,7 @@ model User {
   notificationPreference NotificationPreference?
   shipmentWatchers ShipmentWatcher[] @relation("ShipmentWatchers")
   shipmentFavorites ShipmentFavorite[] @relation("ShipmentFavorites")
+  savedFilters      SavedFilter[]      @relation("SavedFilters")
 
   @@map("users")
 }
@@ -490,6 +491,24 @@ model AppConfig {
 /// A single co-approver signing off on a high-value shipment. Milestone
 /// confirmation is blocked until the shipment has `requiredApprovals` rows
 /// here. One row per approver address, enforced by the unique constraint.
+/// A named, reusable set of GET /shipments filter criteria, private to the
+/// user who created it. `filter` holds only filter fields; pagination is a
+/// per-request concern and is never stored.
+model SavedFilter {
+  id        String   @id @default(uuid())
+  userId    String
+  name      String
+  filter    Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation("SavedFilters", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, name])
+  @@index([userId])
+  @@map("saved_filters")
+}
+
 model ShipmentApproval {
   id              String   @id @default(uuid())
   shipmentId      String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -482,6 +482,20 @@ model AppConfig {
   @@map("app_config")
 }
 
+model ShipmentFavorite {
+  id         String   @id @default(uuid())
+  shipmentId String
+  userId     String
+  createdAt  DateTime @default(now())
+
+  shipment Shipment @relation(fields: [shipmentId], references: [id], onDelete: Cascade)
+  user     User     @relation("ShipmentFavorites", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([shipmentId, userId])
+  @@index([userId])
+  @@map("shipment_favorites")
+}
+
 model ShipmentWatcher {
   id         String   @id @default(uuid())
   shipmentId String

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,6 +32,7 @@ import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { ChainModule } from './modules/chain/chain.module';
 import { KycModule } from './modules/kyc/kyc.module';
 import { ArbitersModule } from './modules/arbiters/arbiters.module';
+import { FeatureFlagsModule } from './modules/feature-flags/feature-flags.module';
 
 @Module({
   imports: [
@@ -87,6 +88,7 @@ import { ArbitersModule } from './modules/arbiters/arbiters.module';
     ChainModule,
     KycModule,
     ArbitersModule,
+    FeatureFlagsModule,
   ],
   providers: [
     // Apply global throttler guard (sets X-RateLimit-* on success and 429)

--- a/src/common/decorators/feature-flag.decorator.ts
+++ b/src/common/decorators/feature-flag.decorator.ts
@@ -1,0 +1,32 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const FEATURE_FLAG_KEY = 'featureFlag';
+
+/**
+ * Gates a route, or every route on a controller, behind a feature flag.
+ *
+ * The flag is resolved from Redis on each request by FeatureFlagGuard. When it
+ * is off the route answers 404, so a gated endpoint is indistinguishable from
+ * one that does not exist yet.
+ *
+ * Applied to a class it covers every route in that controller; applied to a
+ * single handler it covers just that route, and a handler-level flag overrides
+ * a controller-level one.
+ *
+ * @example
+ * ```ts
+ * // Whole controller
+ * @FeatureFlag('shipment-templates')
+ * @UseGuards(FeatureFlagGuard)
+ * @Controller('shipment-templates')
+ * export class ShipmentTemplatesController {}
+ *
+ * // Single route
+ * @FeatureFlag('ipfs-proofs')
+ * @UseGuards(FeatureFlagGuard)
+ * @Post(':id/proof')
+ * submitProof() {}
+ * ```
+ */
+export const FeatureFlag = (flagName: string) =>
+  SetMetadata(FEATURE_FLAG_KEY, flagName);

--- a/src/common/guards/feature-flag.guard.spec.ts
+++ b/src/common/guards/feature-flag.guard.spec.ts
@@ -1,0 +1,128 @@
+import { ExecutionContext, NotFoundException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { FeatureFlagGuard } from './feature-flag.guard';
+import { FEATURE_FLAG_KEY } from '../decorators/feature-flag.decorator';
+import { FeatureFlagsService } from '../../modules/feature-flags/feature-flags.service';
+
+describe('FeatureFlagGuard', () => {
+  let guard: FeatureFlagGuard;
+  let reflector: { getAllAndOverride: jest.Mock };
+  let featureFlags: { isEnabled: jest.Mock };
+
+  const handler = () => undefined;
+  class DummyController {}
+
+  function contextFor(user?: unknown): ExecutionContext {
+    return {
+      getHandler: () => handler,
+      getClass: () => DummyController,
+      switchToHttp: () => ({ getRequest: () => ({ user }) }),
+    } as unknown as ExecutionContext;
+  }
+
+  beforeEach(() => {
+    reflector = { getAllAndOverride: jest.fn() };
+    featureFlags = { isEnabled: jest.fn() };
+    guard = new FeatureFlagGuard(
+      reflector as unknown as Reflector,
+      featureFlags as unknown as FeatureFlagsService,
+    );
+  });
+
+  // -- Ungated routes ---------------------------------------------------------
+
+  it('allows a route carrying no flag metadata', async () => {
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+
+    await expect(guard.canActivate(contextFor())).resolves.toBe(true);
+    expect(featureFlags.isEnabled).not.toHaveBeenCalled();
+  });
+
+  it('reads metadata from both the handler and the controller class', async () => {
+    reflector.getAllAndOverride.mockReturnValue('templates');
+    featureFlags.isEnabled.mockResolvedValue(true);
+
+    await guard.canActivate(contextFor());
+
+    expect(reflector.getAllAndOverride).toHaveBeenCalledWith(FEATURE_FLAG_KEY, [
+      handler,
+      DummyController,
+    ]);
+  });
+
+  // -- Gating -----------------------------------------------------------------
+
+  it('allows the route when the flag is on', async () => {
+    reflector.getAllAndOverride.mockReturnValue('templates');
+    featureFlags.isEnabled.mockResolvedValue(true);
+
+    await expect(guard.canActivate(contextFor({ id: 'user-1' }))).resolves.toBe(
+      true,
+    );
+  });
+
+  it('answers 404 when the flag is off', async () => {
+    reflector.getAllAndOverride.mockReturnValue('templates');
+    featureFlags.isEnabled.mockResolvedValue(false);
+
+    await expect(guard.canActivate(contextFor({ id: 'user-1' }))).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('hides a disabled route rather than admitting it exists', async () => {
+    reflector.getAllAndOverride.mockReturnValue('templates');
+    featureFlags.isEnabled.mockResolvedValue(false);
+
+    // A 403 would confirm the route is present and merely switched off, which
+    // leaks unreleased functionality. 404 is indistinguishable from no route.
+    await expect(
+      guard.canActivate(contextFor({ id: 'user-1' })),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  // -- Rollout subject --------------------------------------------------------
+
+  it('buckets a percentage rollout on the user id', async () => {
+    reflector.getAllAndOverride.mockReturnValue('templates');
+    featureFlags.isEnabled.mockResolvedValue(true);
+
+    await guard.canActivate(contextFor({ id: 'user-1', stellarAddress: 'GABC' }));
+
+    expect(featureFlags.isEnabled).toHaveBeenCalledWith('templates', 'user-1');
+  });
+
+  it('falls back to the Stellar address when there is no user id', async () => {
+    reflector.getAllAndOverride.mockReturnValue('templates');
+    featureFlags.isEnabled.mockResolvedValue(true);
+
+    await guard.canActivate(contextFor({ stellarAddress: 'GABC' }));
+
+    expect(featureFlags.isEnabled).toHaveBeenCalledWith('templates', 'GABC');
+  });
+
+  it('passes no subject for an unauthenticated request', async () => {
+    reflector.getAllAndOverride.mockReturnValue('templates');
+    featureFlags.isEnabled.mockResolvedValue(true);
+
+    await guard.canActivate(contextFor(undefined));
+
+    expect(featureFlags.isEnabled).toHaveBeenCalledWith('templates', undefined);
+  });
+
+  // -- Live toggling ----------------------------------------------------------
+
+  it('re-resolves the flag on every request', async () => {
+    reflector.getAllAndOverride.mockReturnValue('templates');
+
+    featureFlags.isEnabled.mockResolvedValueOnce(true);
+    await expect(guard.canActivate(contextFor({ id: 'u' }))).resolves.toBe(true);
+
+    featureFlags.isEnabled.mockResolvedValueOnce(false);
+    await expect(guard.canActivate(contextFor({ id: 'u' }))).rejects.toThrow(
+      NotFoundException,
+    );
+
+    expect(featureFlags.isEnabled).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/common/guards/feature-flag.guard.ts
+++ b/src/common/guards/feature-flag.guard.ts
@@ -1,0 +1,53 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  NotFoundException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { FEATURE_FLAG_KEY } from '../decorators/feature-flag.decorator';
+import { FeatureFlagsService } from '../../modules/feature-flags/feature-flags.service';
+
+/**
+ * Enforces @FeatureFlag() metadata.
+ *
+ * A route with no flag is always allowed, so applying this guard globally or
+ * on a controller costs nothing for ungated routes.
+ *
+ * When a flag is off the guard throws NotFoundException rather than a 403.
+ * A disabled endpoint should look like it does not exist: a 403 would confirm
+ * the route is there and merely switched off, which leaks unreleased
+ * functionality.
+ *
+ * The flag is read from Redis per request, so flipping it takes effect
+ * immediately without restarting the app.
+ */
+@Injectable()
+export class FeatureFlagGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly featureFlags: FeatureFlagsService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Handler-level metadata wins over controller-level.
+    const flagName = this.reflector.getAllAndOverride<string>(FEATURE_FLAG_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!flagName) return true;
+
+    const { user } = context.switchToHttp().getRequest();
+    // Percentage rollouts bucket on a stable per-caller id. Prefer the user id,
+    // fall back to the Stellar address for token-authenticated callers.
+    const subjectId: string | undefined = user?.id ?? user?.stellarAddress;
+
+    const enabled = await this.featureFlags.isEnabled(flagName, subjectId);
+    if (!enabled) {
+      throw new NotFoundException();
+    }
+
+    return true;
+  }
+}

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -76,6 +76,10 @@ export const envValidationSchema = Joi.object({
   // both buyer and supplier to have a VERIFIED kycStatus.
   KYC_VALUE_THRESHOLD_STROOPS: Joi.string().default('1000000000000'), // 100,000 USDC at 7 decimals
 
+  // Signing key for calendar subscription tokens (#236). Rotating it revokes
+  // every issued feed URL.
+  CALENDAR_FEED_SECRET: Joi.string().allow('').default(''),
+
   // Shipments at or above this value may require multi-signature approval (#234)
   MULTISIG_VALUE_THRESHOLD_STROOPS: Joi.string().default('1000000000000'), // 100,000 USDC at 7 decimals
   KYC_WEBHOOK_SECRET: Joi.string().allow('').default(''),

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -75,6 +75,9 @@ export const envValidationSchema = Joi.object({
   // Shipments with totalAmount (in stroops) at or above this threshold require
   // both buyer and supplier to have a VERIFIED kycStatus.
   KYC_VALUE_THRESHOLD_STROOPS: Joi.string().default('1000000000000'), // 100,000 USDC at 7 decimals
+
+  // Shipments at or above this value may require multi-signature approval (#234)
+  MULTISIG_VALUE_THRESHOLD_STROOPS: Joi.string().default('1000000000000'), // 100,000 USDC at 7 decimals
   KYC_WEBHOOK_SECRET: Joi.string().allow('').default(''),
 
   // FX rate service (#231)

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -60,6 +60,8 @@ export class EventsController {
       }
       throw error;
     }
+  }
+
   @Get('admin/cursor')
   @ApiOperation({ summary: '[Admin] Inspect event poller cursor lag and health' })
   getCursorStatus(@CurrentUser() user: any) {

--- a/src/modules/feature-flags/feature-flags.module.ts
+++ b/src/modules/feature-flags/feature-flags.module.ts
@@ -1,0 +1,17 @@
+import { Global, Module } from '@nestjs/common';
+import { FeatureFlagsService } from './feature-flags.service';
+import { FeatureFlagGuard } from '../../common/guards/feature-flag.guard';
+
+/**
+ * Feature flags are consumed by guards on arbitrary controllers across the
+ * app, so the module is global: a controller can apply FeatureFlagGuard
+ * without its own module having to import anything.
+ *
+ * RedisService is already provided globally by RedisModule.
+ */
+@Global()
+@Module({
+  providers: [FeatureFlagsService, FeatureFlagGuard],
+  exports: [FeatureFlagsService, FeatureFlagGuard],
+})
+export class FeatureFlagsModule {}

--- a/src/modules/feature-flags/feature-flags.service.spec.ts
+++ b/src/modules/feature-flags/feature-flags.service.spec.ts
@@ -1,0 +1,254 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FeatureFlagsService, FEATURE_FLAG_PREFIX } from './feature-flags.service';
+import { RedisService } from '../../common/redis/redis.service';
+
+describe('FeatureFlagsService', () => {
+  let service: FeatureFlagsService;
+  let redis: {
+    getJson: jest.Mock;
+    set: jest.Mock;
+    del: jest.Mock;
+    getClient: jest.Mock;
+  };
+  let scan: jest.Mock;
+
+  beforeEach(async () => {
+    scan = jest.fn();
+    redis = {
+      getJson: jest.fn(),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+      getClient: jest.fn().mockReturnValue({ scan }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeatureFlagsService,
+        { provide: RedisService, useValue: redis },
+      ],
+    }).compile();
+
+    service = module.get<FeatureFlagsService>(FeatureFlagsService);
+  });
+
+  // -- Key layout -------------------------------------------------------------
+
+  describe('key layout', () => {
+    it('namespaces flags under the feature-flag prefix', async () => {
+      redis.getJson.mockResolvedValue({ enabled: true });
+
+      await service.isEnabled('ipfs-proofs');
+
+      expect(redis.getJson).toHaveBeenCalledWith(
+        FEATURE_FLAG_PREFIX + 'ipfs-proofs',
+      );
+    });
+  });
+
+  // -- Boolean flags ----------------------------------------------------------
+
+  describe('boolean flags', () => {
+    it('is off when the flag has never been set', async () => {
+      redis.getJson.mockResolvedValue(null);
+
+      await expect(service.isEnabled('unknown-flag')).resolves.toBe(false);
+    });
+
+    it('is on when enabled is true', async () => {
+      redis.getJson.mockResolvedValue({ enabled: true });
+
+      await expect(service.isEnabled('templates')).resolves.toBe(true);
+    });
+
+    it('is off when enabled is false', async () => {
+      redis.getJson.mockResolvedValue({ enabled: false });
+
+      await expect(service.isEnabled('templates')).resolves.toBe(false);
+    });
+
+    it('treats a malformed stored value as unset', async () => {
+      redis.getJson.mockResolvedValue({ nonsense: true });
+
+      await expect(service.isEnabled('templates')).resolves.toBe(false);
+      await expect(service.getFlag('templates')).resolves.toBeNull();
+    });
+
+    it('lets enabled=false kill a fully rolled out flag', async () => {
+      redis.getJson.mockResolvedValue({ enabled: false, rollout: 100 });
+
+      await expect(service.isEnabled('templates', 'user-1')).resolves.toBe(false);
+    });
+  });
+
+  // -- Percentage rollout -----------------------------------------------------
+
+  describe('percentage rollout', () => {
+    it('is on for everyone at 100 percent', async () => {
+      redis.getJson.mockResolvedValue({ enabled: true, rollout: 100 });
+
+      await expect(service.isEnabled('webhooks', 'user-1')).resolves.toBe(true);
+      await expect(service.isEnabled('webhooks', 'user-2')).resolves.toBe(true);
+    });
+
+    it('is off for everyone at 0 percent', async () => {
+      redis.getJson.mockResolvedValue({ enabled: true, rollout: 0 });
+
+      await expect(service.isEnabled('webhooks', 'user-1')).resolves.toBe(false);
+      await expect(service.isEnabled('webhooks', 'user-2')).resolves.toBe(false);
+    });
+
+    it('gives the same answer every time for the same subject', async () => {
+      redis.getJson.mockResolvedValue({ enabled: true, rollout: 50 });
+
+      const first = await service.isEnabled('webhooks', 'user-1');
+      const second = await service.isEnabled('webhooks', 'user-1');
+      const third = await service.isEnabled('webhooks', 'user-1');
+
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it('splits a population roughly in line with the percentage', async () => {
+      redis.getJson.mockResolvedValue({ enabled: true, rollout: 30 });
+
+      const subjects = Array.from({ length: 1000 }, (_, i) => 'user-' + i);
+      const results = await Promise.all(
+        subjects.map((s) => service.isEnabled('webhooks', s)),
+      );
+      const onCount = results.filter(Boolean).length;
+
+      // Hash bucketing is not perfectly uniform on a finite sample, so assert
+      // the split lands in the right neighbourhood rather than exactly 300.
+      expect(onCount).toBeGreaterThan(240);
+      expect(onCount).toBeLessThan(360);
+    });
+
+    it('buckets a subject independently per flag', async () => {
+      redis.getJson.mockResolvedValue({ enabled: true, rollout: 50 });
+
+      const subjects = Array.from({ length: 200 }, (_, i) => 'user-' + i);
+      const forFlagA = await Promise.all(
+        subjects.map((s) => service.isEnabled('flag-a', s)),
+      );
+      const forFlagB = await Promise.all(
+        subjects.map((s) => service.isEnabled('flag-b', s)),
+      );
+
+      // Were the flag name not part of the hash these would be identical.
+      expect(forFlagA).not.toEqual(forFlagB);
+    });
+
+    it('is off for an anonymous caller rather than flapping between requests', async () => {
+      redis.getJson.mockResolvedValue({ enabled: true, rollout: 50 });
+
+      await expect(service.isEnabled('webhooks')).resolves.toBe(false);
+    });
+
+    it('clamps an out-of-range stored rollout', async () => {
+      redis.getJson.mockResolvedValue({ enabled: true, rollout: 250 });
+      await expect(service.getFlag('webhooks')).resolves.toEqual({
+        enabled: true,
+        rollout: 100,
+      });
+
+      redis.getJson.mockResolvedValue({ enabled: true, rollout: -40 });
+      await expect(service.getFlag('webhooks')).resolves.toEqual({
+        enabled: true,
+        rollout: 0,
+      });
+    });
+  });
+
+  // -- Live toggling ----------------------------------------------------------
+
+  describe('live toggling', () => {
+    it('reads Redis on every check so a toggle needs no restart', async () => {
+      redis.getJson.mockResolvedValueOnce({ enabled: false });
+      await expect(service.isEnabled('templates')).resolves.toBe(false);
+
+      // Somebody flips the flag in Redis. No restart, no cache to invalidate.
+      redis.getJson.mockResolvedValueOnce({ enabled: true });
+      await expect(service.isEnabled('templates')).resolves.toBe(true);
+
+      expect(redis.getJson).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -- Writes -----------------------------------------------------------------
+
+  describe('setFlag', () => {
+    it('stores a boolean flag with no TTL', async () => {
+      await service.setFlag('templates', { enabled: true });
+
+      expect(redis.set).toHaveBeenCalledWith(
+        FEATURE_FLAG_PREFIX + 'templates',
+        JSON.stringify({ enabled: true }),
+      );
+    });
+
+    it('stores a rollout percentage when given', async () => {
+      await service.setFlag('templates', { enabled: true, rollout: 25 });
+
+      expect(redis.set).toHaveBeenCalledWith(
+        FEATURE_FLAG_PREFIX + 'templates',
+        JSON.stringify({ enabled: true, rollout: 25 }),
+      );
+    });
+
+    it('clamps a rollout above 100 before storing', async () => {
+      await service.setFlag('templates', { enabled: true, rollout: 140 });
+
+      expect(redis.set).toHaveBeenCalledWith(
+        FEATURE_FLAG_PREFIX + 'templates',
+        JSON.stringify({ enabled: true, rollout: 100 }),
+      );
+    });
+  });
+
+  describe('deleteFlag', () => {
+    it('removes the key so the flag reads as unset', async () => {
+      await service.deleteFlag('templates');
+
+      expect(redis.del).toHaveBeenCalledWith(FEATURE_FLAG_PREFIX + 'templates');
+    });
+  });
+
+  // -- Listing ----------------------------------------------------------------
+
+  describe('listFlags', () => {
+    it('scans the keyspace and returns each flag with its name', async () => {
+      scan.mockResolvedValueOnce([
+        '0',
+        [FEATURE_FLAG_PREFIX + 'templates', FEATURE_FLAG_PREFIX + 'webhooks'],
+      ]);
+      redis.getJson
+        .mockResolvedValueOnce({ enabled: true })
+        .mockResolvedValueOnce({ enabled: true, rollout: 10 });
+
+      const flags = await service.listFlags();
+
+      expect(flags).toEqual([
+        { name: 'templates', enabled: true },
+        { name: 'webhooks', enabled: true, rollout: 10 },
+      ]);
+    });
+
+    it('follows the cursor until the scan completes', async () => {
+      scan
+        .mockResolvedValueOnce(['42', [FEATURE_FLAG_PREFIX + 'a']])
+        .mockResolvedValueOnce(['0', [FEATURE_FLAG_PREFIX + 'b']]);
+      redis.getJson.mockResolvedValue({ enabled: true });
+
+      const flags = await service.listFlags();
+
+      expect(scan).toHaveBeenCalledTimes(2);
+      expect(flags.map((f) => f.name)).toEqual(['a', 'b']);
+    });
+
+    it('returns an empty list when nothing is configured', async () => {
+      scan.mockResolvedValueOnce(['0', []]);
+
+      await expect(service.listFlags()).resolves.toEqual([]);
+    });
+  });
+});

--- a/src/modules/feature-flags/feature-flags.service.ts
+++ b/src/modules/feature-flags/feature-flags.service.ts
@@ -1,0 +1,161 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash } from 'crypto';
+import { RedisService } from '../../common/redis/redis.service';
+
+/** Redis key prefix for every stored flag. */
+export const FEATURE_FLAG_PREFIX = 'feature-flag:';
+
+/**
+ * Stored shape of a single flag.
+ *
+ * `enabled` is the master switch: false is an unconditional kill switch,
+ * regardless of `rollout`.
+ *
+ * `rollout` is an optional percentage (0-100). When present and below 100 the
+ * flag is on for only that share of subjects, chosen by a stable hash so a
+ * given subject always lands in the same bucket.
+ */
+export interface FeatureFlag {
+  enabled: boolean;
+  rollout?: number;
+}
+
+/** A flag plus the name it is stored under. */
+export interface NamedFeatureFlag extends FeatureFlag {
+  name: string;
+}
+
+/**
+ * Redis-backed feature flag store.
+ *
+ * Flags are read from Redis on every check, with no in-process cache. That is
+ * deliberate: toggling a flag with a plain `SET` takes effect on the very next
+ * request, across every pod, without a redeploy or restart.
+ *
+ * Unknown flags evaluate to false. New functionality is therefore off until
+ * somebody explicitly turns it on, which is the safe default for both a
+ * gradual rollout and a kill switch.
+ */
+@Injectable()
+export class FeatureFlagsService {
+  private readonly logger = new Logger(FeatureFlagsService.name);
+
+  constructor(private readonly redis: RedisService) {}
+
+  /** Full Redis key for a flag name. */
+  private key(name: string): string {
+    return `${FEATURE_FLAG_PREFIX}${name}`;
+  }
+
+  /**
+   * Deterministically bucket a subject into 0-99 for a given flag.
+   *
+   * The flag name is part of the hash so that a subject who happens to fall in
+   * the first 10% of one flag is not automatically in the first 10% of every
+   * other flag.
+   */
+  private bucket(name: string, subjectId: string): number {
+    const digest = createHash('sha256').update(`${name}:${subjectId}`).digest();
+    return digest.readUInt32BE(0) % 100;
+  }
+
+  /**
+   * Read a flag's raw configuration, or null when it has never been set.
+   */
+  async getFlag(name: string): Promise<FeatureFlag | null> {
+    const stored = await this.redis.getJson<FeatureFlag>(this.key(name));
+    if (!stored || typeof stored.enabled !== 'boolean') return null;
+
+    const flag: FeatureFlag = { enabled: stored.enabled };
+    if (typeof stored.rollout === 'number') {
+      flag.rollout = Math.min(100, Math.max(0, stored.rollout));
+    }
+    return flag;
+  }
+
+  /**
+   * Decide whether a flag is on for a given subject.
+   *
+   * @param name      Flag name, e.g. "shipment-templates".
+   * @param subjectId Stable identifier for the caller (user id or Stellar
+   *   address). Percentage rollouts need one to bucket against; a percentage
+   *   flag with no subject evaluates to false rather than flapping between
+   *   requests.
+   */
+  async isEnabled(name: string, subjectId?: string): Promise<boolean> {
+    const flag = await this.getFlag(name);
+
+    // Unknown flag: off. Fail closed.
+    if (!flag) return false;
+
+    // Master switch wins over any rollout percentage.
+    if (!flag.enabled) return false;
+
+    // No rollout configured, or fully rolled out.
+    if (flag.rollout === undefined || flag.rollout >= 100) return true;
+
+    if (flag.rollout <= 0) return false;
+
+    // A percentage rollout is meaningless without something stable to bucket.
+    if (!subjectId) return false;
+
+    return this.bucket(name, subjectId) < flag.rollout;
+  }
+
+  /**
+   * Create or overwrite a flag.
+   *
+   * Writes have no TTL: a flag stays as set until it is changed or deleted.
+   */
+  async setFlag(name: string, flag: FeatureFlag): Promise<FeatureFlag> {
+    const payload: FeatureFlag = { enabled: flag.enabled };
+    if (typeof flag.rollout === 'number') {
+      payload.rollout = Math.min(100, Math.max(0, flag.rollout));
+    }
+
+    await this.redis.set(this.key(name), JSON.stringify(payload));
+    this.logger.log(
+      `Feature flag "${name}" set to enabled=${payload.enabled}` +
+        (payload.rollout !== undefined ? ` rollout=${payload.rollout}%` : ''),
+    );
+    return payload;
+  }
+
+  /** Remove a flag entirely. It then evaluates as off, like any unknown flag. */
+  async deleteFlag(name: string): Promise<void> {
+    await this.redis.del(this.key(name));
+    this.logger.log(`Feature flag "${name}" deleted`);
+  }
+
+  /**
+   * List every configured flag.
+   *
+   * Uses SCAN under the hood rather than KEYS, so it stays safe on a large
+   * shared keyspace.
+   */
+  async listFlags(): Promise<NamedFeatureFlag[]> {
+    const client = this.redis.getClient();
+    const names: string[] = [];
+
+    let cursor = '0';
+    do {
+      const [next, keys] = await client.scan(
+        cursor,
+        'MATCH',
+        `${FEATURE_FLAG_PREFIX}*`,
+        'COUNT',
+        100,
+      );
+      cursor = next;
+      names.push(...keys);
+    } while (cursor !== '0');
+
+    const flags: NamedFeatureFlag[] = [];
+    for (const key of names.sort()) {
+      const name = key.slice(FEATURE_FLAG_PREFIX.length);
+      const flag = await this.getFlag(name);
+      if (flag) flags.push({ name, ...flag });
+    }
+    return flags;
+  }
+}

--- a/src/modules/milestones/calendar.service.spec.ts
+++ b/src/modules/milestones/calendar.service.spec.ts
@@ -1,0 +1,342 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException } from '@nestjs/common';
+import { CalendarService, CalendarMilestone } from './calendar.service';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+const SECRET = 'test-calendar-secret';
+
+describe('CalendarService', () => {
+  let service: CalendarService;
+  let prisma: {
+    milestone: { findMany: jest.Mock };
+    user: { findUnique: jest.Mock };
+  };
+
+  function milestone(overrides: Partial<CalendarMilestone> = {}): CalendarMilestone {
+    return {
+      id: 'm-1',
+      shipmentId: 'SHIP-1',
+      milestoneIndex: 0,
+      name: 'Goods Dispatched',
+      status: 'PENDING',
+      dueAt: new Date('2026-06-30T23:59:59.000Z'),
+      ...overrides,
+    };
+  }
+
+  /** Split a rendered calendar into unfolded logical lines. */
+  function logicalLines(ics: string): string[] {
+    return ics.replace(/\r\n /g, '').split('\r\n').filter(Boolean);
+  }
+
+  beforeEach(async () => {
+    prisma = {
+      milestone: { findMany: jest.fn().mockResolvedValue([]) },
+      user: { findUnique: jest.fn() },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalendarService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(SECRET) },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CalendarService>(CalendarService);
+  });
+
+  // -- Document structure -----------------------------------------------------
+
+  describe('document structure', () => {
+    it('wraps events in a VCALENDAR with the required properties', () => {
+      const ics = service.render([milestone()], 'Test calendar');
+      const lines = logicalLines(ics);
+
+      expect(lines[0]).toBe('BEGIN:VCALENDAR');
+      expect(lines).toContain('VERSION:2.0');
+      expect(lines).toContain('CALSCALE:GREGORIAN');
+      expect(lines.some((l) => l.startsWith('PRODID:'))).toBe(true);
+      expect(lines[lines.length - 1]).toBe('END:VCALENDAR');
+    });
+
+    it('separates lines with CRLF and terminates the document with one', () => {
+      const ics = service.render([milestone()], 'Test calendar');
+
+      expect(ics.endsWith('\r\n')).toBe(true);
+      // No bare LF anywhere: every LF must be preceded by CR.
+      expect(/[^\r]\n/.test(ics)).toBe(false);
+    });
+
+    it('produces a valid empty calendar when nothing is due', () => {
+      const ics = service.render([], 'Empty calendar');
+      const lines = logicalLines(ics);
+
+      // A subscribed calendar app expects a parseable body, not an error.
+      expect(lines[0]).toBe('BEGIN:VCALENDAR');
+      expect(lines[lines.length - 1]).toBe('END:VCALENDAR');
+      expect(ics).not.toContain('BEGIN:VEVENT');
+    });
+
+    it('balances every BEGIN with an END', () => {
+      const ics = service.render([milestone(), milestone({ id: 'm-2' })], 'Cal');
+
+      expect((ics.match(/BEGIN:VEVENT/g) || []).length).toBe(2);
+      expect((ics.match(/END:VEVENT/g) || []).length).toBe(2);
+      expect((ics.match(/BEGIN:VCALENDAR/g) || []).length).toBe(1);
+      expect((ics.match(/END:VCALENDAR/g) || []).length).toBe(1);
+    });
+  });
+
+  // -- Events -----------------------------------------------------------------
+
+  describe('events', () => {
+    it('renders the due date as a UTC timestamp', () => {
+      const ics = service.render([milestone()], 'Cal');
+
+      expect(ics).toContain('DTSTART:20260630T235959Z');
+    });
+
+    it('gives the event an end after its start', () => {
+      const lines = logicalLines(service.render([milestone()], 'Cal'));
+      const start = lines.find((l) => l.startsWith('DTSTART:')) as string;
+      const end = lines.find((l) => l.startsWith('DTEND:')) as string;
+
+      expect(end.slice(6) > start.slice(8)).toBe(true);
+    });
+
+    it('gives each milestone a stable UID so re-subscribing updates in place', () => {
+      const first = service.render([milestone()], 'Cal');
+      const second = service.render([milestone()], 'Cal');
+
+      expect(first).toContain('UID:milestone-m-1@chainsettle');
+      expect(second).toContain('UID:milestone-m-1@chainsettle');
+    });
+
+    it('gives different milestones different UIDs', () => {
+      const ics = service.render(
+        [milestone({ id: 'm-1' }), milestone({ id: 'm-2' })],
+        'Cal',
+      );
+
+      expect(ics).toContain('UID:milestone-m-1@chainsettle');
+      expect(ics).toContain('UID:milestone-m-2@chainsettle');
+    });
+
+    it('names the milestone and its shipment in the summary', () => {
+      const ics = service.render([milestone()], 'Cal');
+
+      expect(ics).toContain('Goods Dispatched due');
+      expect(ics).toContain('SHIP-1');
+    });
+
+    it('stamps every event with DTSTAMP', () => {
+      const ics = service.render([milestone()], 'Cal', new Date('2026-01-02T03:04:05Z'));
+
+      expect(ics).toContain('DTSTAMP:20260102T030405Z');
+    });
+
+    it('skips milestones with no due date', () => {
+      const ics = service.render(
+        [milestone({ id: 'm-1' }), milestone({ id: 'm-2', dueAt: null })],
+        'Cal',
+      );
+
+      expect((ics.match(/BEGIN:VEVENT/g) || []).length).toBe(1);
+      expect(ics).toContain('milestone-m-1@');
+      expect(ics).not.toContain('milestone-m-2@');
+    });
+  });
+
+  // -- Escaping and folding ---------------------------------------------------
+
+  describe('text escaping', () => {
+    it('escapes commas and semicolons in a milestone name', () => {
+      const ics = service.render(
+        [milestone({ name: 'Customs; cleared, finally' })],
+        'Cal',
+      );
+      const summary = logicalLines(ics).find((l) =>
+        l.startsWith('SUMMARY:'),
+      ) as string;
+
+      expect(summary).toContain('\\;');
+      expect(summary).toContain('\\,');
+    });
+
+    it('escapes backslashes without double-escaping the escapes it adds', () => {
+      const ics = service.render([milestone({ name: 'a\\b,c' })], 'Cal');
+      const summary = logicalLines(ics).find((l) =>
+        l.startsWith('SUMMARY:'),
+      ) as string;
+
+      expect(summary).toContain('a\\\\b');
+      expect(summary).toContain('\\,c');
+    });
+
+    it('turns newlines in a name into the literal escape, not a real break', () => {
+      const ics = service.render([milestone({ name: 'line1\nline2' })], 'Cal');
+
+      expect(ics).toContain('line1\\nline2');
+      // The document must not gain an unfolded raw line from the value.
+      expect(logicalLines(ics)).not.toContain('line2');
+    });
+
+    it('escapes the calendar name too', () => {
+      const ics = service.render([], 'Bob, Alice; shipments');
+      const name = logicalLines(ics).find((l) =>
+        l.startsWith('X-WR-CALNAME:'),
+      ) as string;
+
+      expect(name).toContain('\\,');
+      expect(name).toContain('\\;');
+    });
+  });
+
+  describe('line folding', () => {
+    it('folds content lines longer than 75 octets', () => {
+      const ics = service.render([milestone({ name: 'x'.repeat(200) })], 'Cal');
+
+      for (const line of ics.split('\r\n')) {
+        expect(Buffer.from(line, 'utf8').length).toBeLessThanOrEqual(75);
+      }
+    });
+
+    it('marks continuation lines with a leading space', () => {
+      const ics = service.render([milestone({ name: 'y'.repeat(200) })], 'Cal');
+      const raw = ics.split('\r\n');
+      const folded = raw.filter((l) => l.startsWith(' '));
+
+      expect(folded.length).toBeGreaterThan(0);
+    });
+
+    it('unfolds back to the original value', () => {
+      const long = 'z'.repeat(200);
+      const ics = service.render([milestone({ name: long })], 'Cal');
+      const summary = logicalLines(ics).find((l) =>
+        l.startsWith('SUMMARY:'),
+      ) as string;
+
+      expect(summary).toContain(long);
+    });
+
+    it('does not split a multi-byte character across a fold', () => {
+      const ics = service.render([milestone({ name: 'é'.repeat(100) })], 'Cal');
+
+      // A broken fold would leave a replacement character behind.
+      expect(ics).not.toContain('�');
+      const summary = logicalLines(ics).find((l) =>
+        l.startsWith('SUMMARY:'),
+      ) as string;
+      expect(summary).toContain('é'.repeat(100));
+    });
+  });
+
+  // -- Token handling ---------------------------------------------------------
+
+  describe('subscription tokens', () => {
+    it('round-trips a user id', () => {
+      const token = service.issueToken('user-1');
+
+      expect(service.verifyToken(token)).toBe('user-1');
+    });
+
+    it('issues a stable token for the same user', () => {
+      expect(service.issueToken('user-1')).toBe(service.issueToken('user-1'));
+    });
+
+    it('issues different tokens for different users', () => {
+      expect(service.issueToken('user-1')).not.toBe(service.issueToken('user-2'));
+    });
+
+    it('rejects a token whose user id was swapped for another', () => {
+      const forged =
+        Buffer.from('user-2').toString('base64url') +
+        '.' +
+        service.issueToken('user-1').split('.')[1];
+
+      expect(() => service.verifyToken(forged)).toThrow(UnauthorizedException);
+    });
+
+    it('rejects a tampered signature', () => {
+      const token = service.issueToken('user-1');
+      const [id, sig] = token.split('.');
+      const tampered = `${id}.${sig.slice(0, -1)}${sig.endsWith('A') ? 'B' : 'A'}`;
+
+      expect(() => service.verifyToken(tampered)).toThrow(UnauthorizedException);
+    });
+
+    it('rejects a malformed or empty token', () => {
+      expect(() => service.verifyToken('')).toThrow(UnauthorizedException);
+      expect(() => service.verifyToken('nodot')).toThrow(UnauthorizedException);
+      expect(() => service.verifyToken('a.b.c')).toThrow(UnauthorizedException);
+      expect(() => service.verifyToken(undefined as unknown as string)).toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('when no feed secret is configured', () => {
+    it('refuses to issue or verify tokens rather than signing with an empty key', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          CalendarService,
+          { provide: PrismaService, useValue: prisma },
+          { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('') } },
+        ],
+      }).compile();
+      const unconfigured = module.get<CalendarService>(CalendarService);
+
+      expect(() => unconfigured.issueToken('user-1')).toThrow(UnauthorizedException);
+      expect(() => unconfigured.verifyToken('a.b')).toThrow(UnauthorizedException);
+    });
+  });
+
+  // -- Scoping ----------------------------------------------------------------
+
+  describe('getUserMilestones', () => {
+    it('only returns milestones from shipments the user participates in', async () => {
+      prisma.user.findUnique.mockResolvedValue({ stellarAddress: 'GME' });
+
+      await service.getUserMilestones('user-1');
+
+      const where = prisma.milestone.findMany.mock.calls[0][0].where;
+      expect(where.shipment.OR).toEqual([
+        { buyerAddress: 'GME' },
+        { supplierAddress: 'GME' },
+        { logisticsAddress: 'GME' },
+        { arbiterAddress: 'GME' },
+      ]);
+    });
+
+    it('only considers milestones that actually have a due date', async () => {
+      prisma.user.findUnique.mockResolvedValue({ stellarAddress: 'GME' });
+
+      await service.getUserMilestones('user-1');
+
+      const where = prisma.milestone.findMany.mock.calls[0][0].where;
+      expect(where.dueAt).toEqual({ not: null });
+    });
+
+    it('returns nothing for an unknown user rather than every milestone', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getUserMilestones('ghost')).resolves.toEqual([]);
+      expect(prisma.milestone.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getShipmentMilestones', () => {
+    it('scopes to the shipment and orders by due date', async () => {
+      await service.getShipmentMilestones('SHIP-1');
+
+      const args = prisma.milestone.findMany.mock.calls[0][0];
+      expect(args.where).toEqual({ shipmentId: 'SHIP-1', dueAt: { not: null } });
+      expect(args.orderBy).toEqual({ dueAt: 'asc' });
+    });
+  });
+});

--- a/src/modules/milestones/calendar.service.ts
+++ b/src/modules/milestones/calendar.service.ts
@@ -1,0 +1,294 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+/** Product identifier advertised in the generated calendars. */
+const PRODID = '-//ChainSettle//Milestone Due Dates//EN';
+
+/** How long a milestone due date occupies in a calendar, in minutes. */
+const EVENT_DURATION_MINUTES = 30;
+
+/** A single milestone rendered into the feed. */
+export interface CalendarMilestone {
+  id: string;
+  shipmentId: string;
+  milestoneIndex: number;
+  name: string;
+  status: string;
+  dueAt: Date | null;
+}
+
+/**
+ * iCalendar (RFC 5545) export of milestone due dates.
+ *
+ * Two feeds are served: one per shipment, and one per user aggregating every
+ * shipment they participate in. The per-user feed is meant to be subscribed to
+ * by a calendar app, which cannot send an Authorization header, so it is
+ * authenticated by a signed token in the URL instead.
+ */
+@Injectable()
+export class CalendarService {
+  private readonly logger = new Logger(CalendarService.name);
+  private readonly feedSecret: string;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {
+    this.feedSecret = this.config.get<string>('CALENDAR_FEED_SECRET', '');
+  }
+
+  // -- Token handling ---------------------------------------------------------
+
+  /**
+   * Mint a subscription token for a user.
+   *
+   * The token carries the user id and an HMAC over it, so it identifies its
+   * owner without a lookup and cannot be forged or edited to point at another
+   * user. It does not expire: a calendar subscription is long-lived, and
+   * rotating CALENDAR_FEED_SECRET revokes every issued token at once.
+   */
+  issueToken(userId: string): string {
+    this.assertSecretConfigured();
+    const signature = this.sign(userId);
+    return `${Buffer.from(userId).toString('base64url')}.${signature}`;
+  }
+
+  /**
+   * Resolve a subscription token back to its user id.
+   *
+   * @throws {UnauthorizedException} When the token is malformed, or its
+   *   signature does not match.
+   */
+  verifyToken(token: string): string {
+    this.assertSecretConfigured();
+
+    if (!token || typeof token !== 'string') {
+      throw new UnauthorizedException('Invalid calendar token');
+    }
+
+    const parts = token.split('.');
+    if (parts.length !== 2) {
+      throw new UnauthorizedException('Invalid calendar token');
+    }
+
+    const [encodedUserId, signature] = parts;
+
+    let userId: string;
+    try {
+      userId = Buffer.from(encodedUserId, 'base64url').toString('utf8');
+    } catch {
+      throw new UnauthorizedException('Invalid calendar token');
+    }
+
+    if (!userId) {
+      throw new UnauthorizedException('Invalid calendar token');
+    }
+
+    const expected = this.sign(userId);
+
+    // Constant-time comparison: a token check is an auth check, and a timing
+    // side channel would let a signature be recovered byte by byte.
+    const a = Buffer.from(signature);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      throw new UnauthorizedException('Invalid calendar token');
+    }
+
+    return userId;
+  }
+
+  private sign(userId: string): string {
+    return createHmac('sha256', this.feedSecret).update(userId).digest('base64url');
+  }
+
+  private assertSecretConfigured(): void {
+    if (!this.feedSecret) {
+      throw new UnauthorizedException(
+        'Calendar feeds are not configured on this deployment',
+      );
+    }
+  }
+
+  // -- Data ------------------------------------------------------------------
+
+  /** Milestones with a due date for one shipment, earliest first. */
+  async getShipmentMilestones(shipmentId: string): Promise<CalendarMilestone[]> {
+    return this.prisma.milestone.findMany({
+      where: { shipmentId, dueAt: { not: null } },
+      orderBy: { dueAt: 'asc' },
+      select: {
+        id: true,
+        shipmentId: true,
+        milestoneIndex: true,
+        name: true,
+        status: true,
+        dueAt: true,
+      },
+    }) as unknown as Promise<CalendarMilestone[]>;
+  }
+
+  /**
+   * Milestones with a due date across every shipment the user participates in.
+   *
+   * Participation is matched on the user's Stellar address appearing in any of
+   * the four shipment roles, so the feed can never include a shipment the
+   * token's owner is not party to.
+   */
+  async getUserMilestones(userId: string): Promise<CalendarMilestone[]> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { stellarAddress: true },
+    });
+
+    if (!user) return [];
+
+    const address = user.stellarAddress;
+
+    return this.prisma.milestone.findMany({
+      where: {
+        dueAt: { not: null },
+        shipment: {
+          OR: [
+            { buyerAddress: address },
+            { supplierAddress: address },
+            { logisticsAddress: address },
+            { arbiterAddress: address },
+          ],
+        },
+      },
+      orderBy: { dueAt: 'asc' },
+      select: {
+        id: true,
+        shipmentId: true,
+        milestoneIndex: true,
+        name: true,
+        status: true,
+        dueAt: true,
+      },
+    }) as unknown as Promise<CalendarMilestone[]>;
+  }
+
+  // -- iCalendar rendering ----------------------------------------------------
+
+  /**
+   * Escape a value for a text property, per RFC 5545 section 3.3.11.
+   *
+   * Backslash first, or the escapes introduced below would be escaped again.
+   */
+  private escapeText(value: string): string {
+    return String(value ?? '')
+      .replace(/\\/g, '\\\\')
+      .replace(/;/g, '\\;')
+      .replace(/,/g, '\\,')
+      .replace(/\r\n|\n|\r/g, '\\n');
+  }
+
+  /** Format a date as a UTC timestamp, e.g. 20260630T235959Z. */
+  private formatUtc(date: Date): string {
+    return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+  }
+
+  /**
+   * Fold a content line to 75 octets, per RFC 5545 section 3.1.
+   *
+   * Folding counts octets rather than characters, so a multi-byte character is
+   * never split across a fold boundary.
+   */
+  private foldLine(line: string): string {
+    const bytes = Buffer.from(line, 'utf8');
+    if (bytes.length <= 75) return line;
+
+    const parts: string[] = [];
+    let start = 0;
+    let limit = 75;
+
+    while (start < bytes.length) {
+      let end = Math.min(start + limit, bytes.length);
+
+      // Do not split a multi-byte sequence: back off to a lead byte.
+      if (end < bytes.length) {
+        while (end > start && (bytes[end] & 0xc0) === 0x80) end--;
+      }
+
+      parts.push(bytes.subarray(start, end).toString('utf8'));
+      start = end;
+      // Continuation lines carry a leading space, which counts toward the 75.
+      limit = 74;
+    }
+
+    return parts.join('\r\n ');
+  }
+
+  /** Render one milestone as a VEVENT. */
+  private renderEvent(milestone: CalendarMilestone, stamp: string): string[] {
+    const due = milestone.dueAt as Date;
+    const end = new Date(due.getTime() + EVENT_DURATION_MINUTES * 60_000);
+
+    const summary = `${milestone.name} due (${milestone.shipmentId})`;
+    const description =
+      `Milestone ${milestone.milestoneIndex} on shipment ${milestone.shipmentId}. ` +
+      `Status: ${milestone.status}.`;
+
+    return [
+      'BEGIN:VEVENT',
+      // Stable per milestone, so re-subscribing updates events rather than
+      // duplicating them.
+      `UID:milestone-${milestone.id}@chainsettle`,
+      `DTSTAMP:${stamp}`,
+      `DTSTART:${this.formatUtc(due)}`,
+      `DTEND:${this.formatUtc(end)}`,
+      `SUMMARY:${this.escapeText(summary)}`,
+      `DESCRIPTION:${this.escapeText(description)}`,
+      'STATUS:CONFIRMED',
+      'TRANSP:TRANSPARENT',
+      'END:VEVENT',
+    ];
+  }
+
+  /**
+   * Render a set of milestones as a complete iCalendar document.
+   *
+   * Lines are joined with CRLF and the document ends with one, as the spec
+   * requires. An empty set still produces a valid, empty VCALENDAR: a
+   * subscribed calendar app expects a parseable body, not a 404.
+   */
+  render(
+    milestones: CalendarMilestone[],
+    calendarName: string,
+    now: Date = new Date(),
+  ): string {
+    const stamp = this.formatUtc(now);
+
+    const lines: string[] = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      `PRODID:${PRODID}`,
+      'CALSCALE:GREGORIAN',
+      'METHOD:PUBLISH',
+      `X-WR-CALNAME:${this.escapeText(calendarName)}`,
+    ];
+
+    for (const milestone of milestones) {
+      if (!milestone.dueAt) continue;
+      lines.push(...this.renderEvent(milestone, stamp));
+    }
+
+    lines.push('END:VCALENDAR');
+
+    return lines.map((line) => this.foldLine(line)).join('\r\n') + '\r\n';
+  }
+
+  /** The .ics document for a single shipment. */
+  async renderShipmentCalendar(shipmentId: string): Promise<string> {
+    const milestones = await this.getShipmentMilestones(shipmentId);
+    return this.render(milestones, `Shipment ${shipmentId} milestones`);
+  }
+
+  /** The .ics document for every shipment a user participates in. */
+  async renderUserCalendar(userId: string): Promise<string> {
+    const milestones = await this.getUserMilestones(userId);
+    return this.render(milestones, 'ChainSettle milestone due dates');
+  }
+}

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -14,6 +14,7 @@ import {
   HttpCode,
   HttpStatus,
   Res,
+  Header,
   NotFoundException,
 } from '@nestjs/common';
 
@@ -39,6 +40,7 @@ import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { ShipmentParticipantGuard } from '../shipments/guards/shipment-participant.guard';
 import { StellarAddressThrottlerGuard } from '../../common/guards/stellar-address-throttler.guard';
 import { Throttle } from '@nestjs/throttler';
+import { CalendarService } from './calendar.service';
 
 /** Maximum allowed proof file size: 50 MB */
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
@@ -59,7 +61,35 @@ const ALLOWED_MIME_TYPES = [
 @UseGuards(JwtAuthGuard)
 @Controller('shipments/:shipmentId/milestones')
 export class MilestonesController {
-  constructor(private readonly milestonesService: MilestonesService) {}
+  constructor(
+    private readonly milestonesService: MilestonesService,
+    private readonly calendar: CalendarService,
+  ) {}
+
+  /**
+   * GET /api/v1/shipments/:shipmentId/milestones/calendar.ics
+   * iCalendar feed of this shipment's milestone due dates.
+   *
+   * Declared before the ':milestoneIndex' routes so the param route does not
+   * swallow "calendar.ics".
+   */
+  @Get('calendar.ics')
+  @UseGuards(ShipmentParticipantGuard)
+  @Header('Content-Type', 'text/calendar; charset=utf-8')
+  @ApiOperation({ summary: "Export a shipment's milestone due dates as an iCalendar file" })
+  @ApiResponse({ status: 200, description: 'iCalendar document' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  async getCalendar(
+    @Param('shipmentId') shipmentId: string,
+    @Res() res: Response,
+  ) {
+    const body = await this.calendar.renderShipmentCalendar(shipmentId);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${shipmentId}-milestones.ics"`,
+    );
+    res.send(body);
+  }
 
   @Get()
   @UseGuards(ShipmentParticipantGuard)

--- a/src/modules/milestones/milestones.module.ts
+++ b/src/modules/milestones/milestones.module.ts
@@ -2,6 +2,8 @@
 import { Module } from '@nestjs/common';
 import { MilestonesController } from './milestones.controller';
 import { MilestonesService } from './milestones.service';
+import { CalendarService } from './calendar.service';
+import { UserCalendarController } from './user-calendar.controller';
 import { MilestoneDeadlineJob } from './milestone-deadline.job';
 import { DisputeEscalationJob } from './dispute-escalation.job';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -10,8 +12,8 @@ import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 
 @Module({
   imports: [NotificationsModule, ShipmentsModule, AuditLogsModule],
-  controllers: [MilestonesController],
-  providers: [MilestonesService, MilestoneDeadlineJob, DisputeEscalationJob],
-  exports: [MilestonesService],
+  controllers: [MilestonesController, UserCalendarController],
+  providers: [MilestonesService, CalendarService, MilestoneDeadlineJob, DisputeEscalationJob],
+  exports: [MilestonesService, CalendarService],
 })
 export class MilestonesModule {}

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -10,6 +10,8 @@ import { PrismaService } from '../../common/prisma/prisma.service';
 import { IpfsService } from '../../common/ipfs/ipfs.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { ShipmentsService } from '../shipments/shipments.service';
+import { ShipmentApprovalsService } from '../shipments/shipment-approvals.service';
+import { AuditLogService } from '../audit-logs/audit-log.service';
 import { StellarService } from '../../common/stellar/stellar.service';
 import { FxRateService } from '../../common/fx/fx-rate.service';
 import { AppendMilestoneDto } from './dto/append-milestone.dto';
@@ -24,6 +26,7 @@ export class MilestonesService {
     private readonly ipfs: IpfsService,
     private readonly notifications: NotificationsService,
     private readonly shipments: ShipmentsService,
+    private readonly approvals: ShipmentApprovalsService,
     private readonly auditLog: AuditLogService,
     private readonly stellar: StellarService,
     private readonly fxRate: FxRateService,
@@ -200,6 +203,11 @@ export class MilestonesService {
       throw new ForbiddenException('Only the shipment buyer may confirm milestones');
     }
 
+    // Multi-signature gate (#234): a shipment carrying requiredApprovals cannot
+    // have any milestone confirmed until that many co-approvers have signed
+    // off. No-op for shipments on the single-approver flow.
+    await this.approvals.assertQuorum(shipmentId);
+
     const milestone = await this.findOne(shipmentId, milestoneIndex);
 
     if (milestone.status !== MilestoneStatus.PROOF_SUBMITTED) {
@@ -250,6 +258,10 @@ export class MilestonesService {
     if (shipment.status === 'CANCELLED') {
       throw new ConflictException('Cannot confirm a milestone for a cancelled shipment');
     }
+
+    // Same multi-signature gate as the single confirm (#234), so a quorum
+    // cannot be bypassed by going through the batch endpoint.
+    await this.approvals.assertQuorum(shipmentId);
 
     const byIndex = new Map(shipment.milestones.map((m) => [m.milestoneIndex, m]));
     const results: Array<{
@@ -917,10 +929,10 @@ export class MilestonesService {
     });
 
     this.logger.log(
-      `Milestone ${milestoneIndex} ("${milestone.name}") removed from ${shipmentId} by buyer ${callerAddress}`,
+      `Milestone ${nextIndex} ("${milestone.name}") appended to ${shipmentId} by buyer ${callerAddress}`,
     );
 
-    return { removed: true, milestone: milestoneData };
+    return milestone;
   }
 
   // ----------------------------------------------------------

--- a/src/modules/milestones/user-calendar.controller.ts
+++ b/src/modules/milestones/user-calendar.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Controller,
+  Get,
+  Header,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { Response } from 'express';
+import { CalendarService } from './calendar.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { Public } from '../../common/decorators/public.decorator';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+
+/**
+ * Per-user milestone calendar subscription.
+ *
+ * The feed itself is public and authenticated by a signed token in the query
+ * string: calendar applications subscribe by URL and cannot send an
+ * Authorization header. The token identifies its owner and is verified before
+ * any milestone is read, so a feed only ever contains shipments its owner
+ * participates in.
+ */
+@ApiTags('milestones')
+@Controller('users/me/milestones')
+export class UserCalendarController {
+  constructor(private readonly calendar: CalendarService) {}
+
+  /**
+   * GET /api/v1/users/me/milestones/calendar-token
+   * Mint the caller a subscription token and the URL to subscribe with.
+   */
+  @Get('calendar-token')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get a subscription token for your milestone calendar feed' })
+  @ApiResponse({ status: 200, description: 'Subscription token and feed path' })
+  getCalendarToken(@CurrentUser() user: any) {
+    const token = this.calendar.issueToken(user.id);
+    return {
+      token,
+      feedPath: `/api/v1/users/me/milestones/calendar.ics?token=${token}`,
+      note:
+        'Treat this URL as a secret. Anyone holding it can read your milestone ' +
+        'due dates. Rotating CALENDAR_FEED_SECRET revokes all issued tokens.',
+    };
+  }
+
+  /**
+   * GET /api/v1/users/me/milestones/calendar.ics?token=...
+   * iCalendar feed of milestone due dates across every shipment the token
+   * owner participates in.
+   */
+  @Get('calendar.ics')
+  @Public()
+  @Header('Content-Type', 'text/calendar; charset=utf-8')
+  @ApiOperation({ summary: 'Subscribe to your milestone due dates as an iCalendar feed' })
+  @ApiResponse({ status: 200, description: 'iCalendar document' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid token' })
+  async getUserCalendar(@Query('token') token: string, @Res() res: Response) {
+    const userId = this.calendar.verifyToken(token);
+    const body = await this.calendar.renderUserCalendar(userId);
+
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename="chainsettle-milestones.ics"',
+    );
+    res.send(body);
+  }
+}

--- a/src/modules/shipments/dto/create-shipment.dto.ts
+++ b/src/modules/shipments/dto/create-shipment.dto.ts
@@ -111,6 +111,31 @@ export class CreateShipmentDto {
   @IsArray()
   @IsString({ each: true })
   tags?: string[];
+
+  @ApiProperty({
+    required: false,
+    example: 2,
+    description:
+      'Co-approvals required before any milestone may be confirmed. Only accepted ' +
+      'for shipments at or above MULTISIG_VALUE_THRESHOLD_STROOPS; omit for smaller ' +
+      'shipments, which use the single-approver flow.',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  requiredApprovals?: number;
+}
+
+export class ApproveShipmentDto {
+  @ApiProperty({
+    required: false,
+    example: 'Reviewed against PO-2026-001 and approved by finance.',
+    description: 'Optional note recorded alongside the approval',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  note?: string;
 }
 
 export class CancelShipmentDto {

--- a/src/modules/shipments/dto/find-all-shipments.dto.ts
+++ b/src/modules/shipments/dto/find-all-shipments.dto.ts
@@ -97,6 +97,15 @@ export class FindAllShipmentsDto {
   isDraft?: boolean;
 
   @ApiPropertyOptional({
+    description:
+      'Apply a saved filter preset. Its criteria are used as the base; any ' +
+      'other query param on the same request overrides the stored value.',
+  })
+  @IsOptional()
+  @IsString()
+  savedFilterId?: string;
+
+  @ApiPropertyOptional({
     description: 'When true, return only shipments favorited by the authenticated user',
   })
   @IsOptional()

--- a/src/modules/shipments/dto/saved-filter.dto.ts
+++ b/src/modules/shipments/dto/saved-filter.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+export class CreateSavedFilterDto {
+  @ApiProperty({
+    example: 'My overdue shipments as supplier',
+    description: 'Name for this preset, unique among your own saved filters',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @ApiProperty({
+    example: { status: 'DISPUTED', tags: 'urgent' },
+    description:
+      'Filter criteria to store. Accepts the GET /shipments filter fields; ' +
+      'pagination params are not stored, since they are per-request.',
+  })
+  @IsObject()
+  filter: Record<string, unknown>;
+}
+
+export class UpdateSavedFilterDto {
+  @ApiPropertyOptional({ example: 'Overdue as supplier' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name?: string;
+
+  @ApiPropertyOptional({ example: { status: 'ACTIVE' } })
+  @IsOptional()
+  @IsObject()
+  filter?: Record<string, unknown>;
+}

--- a/src/modules/shipments/saved-filters.service.spec.ts
+++ b/src/modules/shipments/saved-filters.service.spec.ts
@@ -1,0 +1,320 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { SavedFiltersService } from './saved-filters.service';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+describe('SavedFiltersService', () => {
+  let service: SavedFiltersService;
+  let prisma: {
+    savedFilter: {
+      findFirst: jest.Mock;
+      findMany: jest.Mock;
+      create: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+
+  const USER = 'user-1';
+  const OTHER_USER = 'user-2';
+
+  beforeEach(async () => {
+    prisma = {
+      savedFilter: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        findMany: jest.fn().mockResolvedValue([]),
+        create: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn().mockResolvedValue({}),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SavedFiltersService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<SavedFiltersService>(SavedFiltersService);
+  });
+
+  // -- Create -----------------------------------------------------------------
+
+  describe('create', () => {
+    it('saves a named filter combination for the user', async () => {
+      prisma.savedFilter.create.mockResolvedValue({ id: 'f1' });
+
+      await service.create(USER, 'Overdue as supplier', {
+        status: 'DISPUTED',
+        tags: 'urgent',
+      });
+
+      expect(prisma.savedFilter.create).toHaveBeenCalledWith({
+        data: {
+          userId: USER,
+          name: 'Overdue as supplier',
+          filter: { status: 'DISPUTED', tags: 'urgent' },
+        },
+      });
+    });
+
+    it('rejects a duplicate name for the same user', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue({ id: 'existing' });
+
+      await expect(
+        service.create(USER, 'Overdue', { status: 'ACTIVE' }),
+      ).rejects.toThrow(ConflictException);
+      expect(prisma.savedFilter.create).not.toHaveBeenCalled();
+    });
+
+    it('scopes the duplicate-name check to the calling user', async () => {
+      prisma.savedFilter.create.mockResolvedValue({ id: 'f1' });
+
+      await service.create(USER, 'Overdue', { status: 'ACTIVE' });
+
+      expect(prisma.savedFilter.findFirst).toHaveBeenCalledWith({
+        where: { userId: USER, name: 'Overdue' },
+      });
+    });
+
+    it('rejects an unrecognised filter field', async () => {
+      await expect(
+        service.create(USER, 'Bad', { statuss: 'ACTIVE' }),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.savedFilter.create).not.toHaveBeenCalled();
+    });
+
+    it('names the offending field so a typo is obvious', async () => {
+      await expect(
+        service.create(USER, 'Bad', { statuss: 'ACTIVE' }),
+      ).rejects.toThrow(/statuss/);
+    });
+
+    it('refuses to store pagination, which is per-request', async () => {
+      await expect(
+        service.create(USER, 'Paged', { status: 'ACTIVE', page: '2' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects an empty filter', async () => {
+      await expect(service.create(USER, 'Empty', {})).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('drops null and undefined values rather than storing them', async () => {
+      prisma.savedFilter.create.mockResolvedValue({ id: 'f1' });
+
+      await service.create(USER, 'Partial', {
+        status: 'ACTIVE',
+        search: null,
+        tags: undefined,
+      });
+
+      expect(prisma.savedFilter.create).toHaveBeenCalledWith({
+        data: { userId: USER, name: 'Partial', filter: { status: 'ACTIVE' } },
+      });
+    });
+  });
+
+  // -- Read -------------------------------------------------------------------
+
+  describe('findAll', () => {
+    it('returns only the calling user filters', async () => {
+      await service.findAll(USER);
+
+      expect(prisma.savedFilter.findMany).toHaveBeenCalledWith({
+        where: { userId: USER },
+        orderBy: { createdAt: 'desc' },
+      });
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns a filter belonging to the caller', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue({ id: 'f1', userId: USER });
+
+      await expect(service.findOne(USER, 'f1')).resolves.toEqual({
+        id: 'f1',
+        userId: USER,
+      });
+    });
+
+    it('scopes the lookup by user id', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue({ id: 'f1' });
+
+      await service.findOne(USER, 'f1');
+
+      expect(prisma.savedFilter.findFirst).toHaveBeenCalledWith({
+        where: { id: 'f1', userId: USER },
+      });
+    });
+
+    it('404s for a filter owned by somebody else', async () => {
+      // Scoped query returns nothing for a filter belonging to OTHER_USER.
+      prisma.savedFilter.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne(OTHER_USER, 'f1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -- Update -----------------------------------------------------------------
+
+  describe('update', () => {
+    it('renames a filter', async () => {
+      prisma.savedFilter.findFirst
+        .mockResolvedValueOnce({ id: 'f1', userId: USER })
+        .mockResolvedValueOnce(null);
+      prisma.savedFilter.update.mockResolvedValue({ id: 'f1', name: 'New' });
+
+      await service.update(USER, 'f1', { name: 'New' });
+
+      expect(prisma.savedFilter.update).toHaveBeenCalledWith({
+        where: { id: 'f1' },
+        data: { name: 'New' },
+      });
+    });
+
+    it('replaces the criteria', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValueOnce({ id: 'f1', userId: USER });
+      prisma.savedFilter.update.mockResolvedValue({ id: 'f1' });
+
+      await service.update(USER, 'f1', { filter: { status: 'COMPLETED' } });
+
+      expect(prisma.savedFilter.update).toHaveBeenCalledWith({
+        where: { id: 'f1' },
+        data: { filter: { status: 'COMPLETED' } },
+      });
+    });
+
+    it('validates replacement criteria the same way as creation', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValueOnce({ id: 'f1', userId: USER });
+
+      await expect(
+        service.update(USER, 'f1', { filter: { bogus: 1 } }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a rename that collides with another of the same user filters', async () => {
+      prisma.savedFilter.findFirst
+        .mockResolvedValueOnce({ id: 'f1', userId: USER })
+        .mockResolvedValueOnce({ id: 'f2', userId: USER });
+
+      await expect(service.update(USER, 'f1', { name: 'Taken' })).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('404s when the filter is not the caller own', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue(null);
+
+      await expect(service.update(OTHER_USER, 'f1', { name: 'X' })).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.savedFilter.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // -- Delete -----------------------------------------------------------------
+
+  describe('remove', () => {
+    it('deletes a filter belonging to the caller', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue({ id: 'f1', userId: USER });
+
+      await expect(service.remove(USER, 'f1')).resolves.toEqual({
+        deleted: true,
+        id: 'f1',
+      });
+      expect(prisma.savedFilter.delete).toHaveBeenCalledWith({
+        where: { id: 'f1' },
+      });
+    });
+
+    it('404s rather than deleting somebody else filter', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove(OTHER_USER, 'f1')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.savedFilter.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  // -- Applying a preset ------------------------------------------------------
+
+  describe('applyTo', () => {
+    it('supplies the stored criteria when the request adds nothing', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue({
+        id: 'f1',
+        userId: USER,
+        filter: { status: 'DISPUTED', tags: 'urgent' },
+      });
+
+      const merged = await service.applyTo(USER, 'f1', {
+        savedFilterId: 'f1',
+      } as Record<string, unknown>);
+
+      expect(merged).toMatchObject({ status: 'DISPUTED', tags: 'urgent' });
+    });
+
+    it('lets an explicit query param override the stored value', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue({
+        id: 'f1',
+        userId: USER,
+        filter: { status: 'DISPUTED', tags: 'urgent' },
+      });
+
+      const merged = (await service.applyTo(USER, 'f1', {
+        savedFilterId: 'f1',
+        status: 'ACTIVE',
+      } as Record<string, unknown>)) as Record<string, unknown>;
+
+      // The saved view is a starting point, narrowed by the request.
+      expect(merged.status).toBe('ACTIVE');
+      expect(merged.tags).toBe('urgent');
+    });
+
+    it('does not let undefined DTO keys mask the stored criteria', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue({
+        id: 'f1',
+        userId: USER,
+        filter: { status: 'DISPUTED' },
+      });
+
+      const merged = (await service.applyTo(USER, 'f1', {
+        savedFilterId: 'f1',
+        status: undefined,
+        search: undefined,
+      } as Record<string, unknown>)) as Record<string, unknown>;
+
+      expect(merged.status).toBe('DISPUTED');
+    });
+
+    it('404s for a preset belonging to another user', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.applyTo(OTHER_USER, 'f1', {} as Record<string, unknown>),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('tolerates a preset with no stored criteria', async () => {
+      prisma.savedFilter.findFirst.mockResolvedValue({
+        id: 'f1',
+        userId: USER,
+        filter: null,
+      });
+
+      await expect(
+        service.applyTo(USER, 'f1', { status: 'ACTIVE' } as Record<string, unknown>),
+      ).resolves.toMatchObject({ status: 'ACTIVE' });
+    });
+  });
+});

--- a/src/modules/shipments/saved-filters.service.ts
+++ b/src/modules/shipments/saved-filters.service.ts
@@ -1,0 +1,202 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+/**
+ * Filter fields that may be stored in a preset.
+ *
+ * Anything outside this list is rejected rather than persisted, so a saved
+ * filter can never smuggle an arbitrary key into the query the list endpoint
+ * builds.
+ *
+ * Pagination (page, limit, cursor) is deliberately excluded: it is a
+ * per-request concern, and baking a page number into a saved view would mean
+ * recalling the view always landed on the same page.
+ */
+export const SAVED_FILTER_FIELDS = [
+  'buyerAddress',
+  'supplierAddress',
+  'status',
+  'referenceNumber',
+  'tags',
+  'search',
+  'createdAfter',
+  'createdBefore',
+  'updatedAfter',
+  'updatedBefore',
+  'includeArchived',
+  'isDraft',
+  'favorite',
+] as const;
+
+export type SavedFilterCriteria = Partial<
+  Record<(typeof SAVED_FILTER_FIELDS)[number], unknown>
+>;
+
+/**
+ * Named, reusable GET /shipments filter presets.
+ *
+ * Every read and write is scoped by userId, so a preset is private to the user
+ * who created it and an id belonging to somebody else is indistinguishable
+ * from one that does not exist.
+ */
+@Injectable()
+export class SavedFiltersService {
+  private readonly logger = new Logger(SavedFiltersService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Keep only recognised filter fields, rejecting anything else.
+   *
+   * Unknown keys are an error rather than being dropped silently: a caller who
+   * saves a filter with a typo should hear about it, not discover later that
+   * the preset quietly matches more than they intended.
+   */
+  private sanitise(filter: Record<string, unknown>): SavedFilterCriteria {
+    if (!filter || typeof filter !== 'object' || Array.isArray(filter)) {
+      throw new BadRequestException('filter must be an object');
+    }
+
+    const allowed = new Set<string>(SAVED_FILTER_FIELDS);
+    const unknown = Object.keys(filter).filter((k) => !allowed.has(k));
+
+    if (unknown.length > 0) {
+      throw new BadRequestException(
+        `Unsupported filter field(s): ${unknown.join(', ')}. ` +
+          `Supported fields are: ${SAVED_FILTER_FIELDS.join(', ')}.`,
+      );
+    }
+
+    const clean: Record<string, unknown> = {};
+    for (const key of Object.keys(filter)) {
+      if (filter[key] !== undefined && filter[key] !== null) {
+        clean[key] = filter[key];
+      }
+    }
+
+    if (Object.keys(clean).length === 0) {
+      throw new BadRequestException('filter must contain at least one criterion');
+    }
+
+    return clean as SavedFilterCriteria;
+  }
+
+  /** Save a new preset for a user. */
+  async create(userId: string, name: string, filter: Record<string, unknown>) {
+    const criteria = this.sanitise(filter);
+
+    const existing = await this.prisma.savedFilter.findFirst({
+      where: { userId, name },
+    });
+
+    if (existing) {
+      throw new ConflictException(
+        `You already have a saved filter named "${name}"`,
+      );
+    }
+
+    const saved = await this.prisma.savedFilter.create({
+      data: { userId, name, filter: criteria as object },
+    });
+
+    this.logger.log(`Saved filter "${name}" created for user ${userId}`);
+    return saved;
+  }
+
+  /** Every preset belonging to a user, newest first. */
+  async findAll(userId: string) {
+    return this.prisma.savedFilter.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /**
+   * A single preset belonging to a user.
+   *
+   * Scoped by userId, so another user's id yields a 404 rather than a 403:
+   * a preset's existence is itself private.
+   */
+  async findOne(userId: string, id: string) {
+    const saved = await this.prisma.savedFilter.findFirst({
+      where: { id, userId },
+    });
+
+    if (!saved) {
+      throw new NotFoundException(`Saved filter ${id} not found`);
+    }
+
+    return saved;
+  }
+
+  /** Rename a preset, replace its criteria, or both. */
+  async update(
+    userId: string,
+    id: string,
+    updates: { name?: string; filter?: Record<string, unknown> },
+  ) {
+    await this.findOne(userId, id);
+
+    if (updates.name !== undefined) {
+      const clash = await this.prisma.savedFilter.findFirst({
+        where: { userId, name: updates.name, NOT: { id } },
+      });
+      if (clash) {
+        throw new ConflictException(
+          `You already have a saved filter named "${updates.name}"`,
+        );
+      }
+    }
+
+    return this.prisma.savedFilter.update({
+      where: { id },
+      data: {
+        ...(updates.name !== undefined ? { name: updates.name } : {}),
+        ...(updates.filter !== undefined
+          ? { filter: this.sanitise(updates.filter) as object }
+          : {}),
+      },
+    });
+  }
+
+  /** Delete a preset. Scoped by userId, so one user cannot delete another's. */
+  async remove(userId: string, id: string) {
+    await this.findOne(userId, id);
+    await this.prisma.savedFilter.delete({ where: { id } });
+    this.logger.log(`Saved filter ${id} deleted by user ${userId}`);
+    return { deleted: true, id };
+  }
+
+  /**
+   * Merge a stored preset underneath the query params of the current request.
+   *
+   * Explicit query params win. A saved view is a starting point, so
+   * `?savedFilterId=x&status=DISPUTED` narrows that view to DISPUTED rather
+   * than being overridden by whatever status the preset happened to store.
+   *
+   * Only keys the caller actually supplied count as explicit; undefined values
+   * left on the parsed DTO do not mask the preset.
+   */
+  async applyTo<T extends object>(
+    userId: string,
+    savedFilterId: string,
+    query: T,
+  ): Promise<T> {
+    const saved = await this.findOne(userId, savedFilterId);
+    const criteria = (saved.filter ?? {}) as Record<string, unknown>;
+
+    const asRecord = query as Record<string, unknown>;
+    const explicit: Record<string, unknown> = {};
+    for (const key of Object.keys(asRecord)) {
+      if (asRecord[key] !== undefined) explicit[key] = asRecord[key];
+    }
+
+    return { ...criteria, ...explicit } as unknown as T;
+  }
+}

--- a/src/modules/shipments/shipment-approvals.service.spec.ts
+++ b/src/modules/shipments/shipment-approvals.service.spec.ts
@@ -1,0 +1,315 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ShipmentApprovalsService } from './shipment-approvals.service';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+const THRESHOLD = '1000000000000'; // 100,000 USDC at 7 decimals
+
+describe('ShipmentApprovalsService', () => {
+  let service: ShipmentApprovalsService;
+  let prisma: {
+    shipment: { findUnique: jest.Mock };
+    shipmentApproval: {
+      findFirst: jest.Mock;
+      findMany: jest.Mock;
+      create: jest.Mock;
+      count: jest.Mock;
+    };
+  };
+
+  const BUYER = 'GBUYER';
+  const SUPPLIER = 'GSUPPLIER';
+  const LOGISTICS = 'GLOGISTICS';
+  const ARBITER = 'GARBITER';
+  const OUTSIDER = 'GOUTSIDER';
+
+  function shipmentRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'SHIP-1',
+      requiredApprovals: 2,
+      buyerAddress: BUYER,
+      supplierAddress: SUPPLIER,
+      logisticsAddress: LOGISTICS,
+      arbiterAddress: ARBITER,
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    prisma = {
+      shipment: { findUnique: jest.fn() },
+      shipmentApproval: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        findMany: jest.fn().mockResolvedValue([]),
+        create: jest.fn(),
+        count: jest.fn().mockResolvedValue(0),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShipmentApprovalsService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(THRESHOLD) },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ShipmentApprovalsService>(ShipmentApprovalsService);
+  });
+
+  // -- Threshold --------------------------------------------------------------
+
+  describe('meetsThreshold', () => {
+    it('is true at exactly the threshold', () => {
+      expect(service.meetsThreshold(BigInt(THRESHOLD))).toBe(true);
+    });
+
+    it('is true above the threshold', () => {
+      expect(service.meetsThreshold(BigInt(THRESHOLD) + BigInt(1))).toBe(true);
+    });
+
+    it('is false below the threshold', () => {
+      expect(service.meetsThreshold(BigInt(THRESHOLD) - BigInt(1))).toBe(false);
+    });
+  });
+
+  // -- Creation ---------------------------------------------------------------
+
+  describe('resolveRequiredApprovals', () => {
+    it('returns null when the field is omitted, leaving the flow unchanged', () => {
+      expect(
+        service.resolveRequiredApprovals(undefined, BigInt(THRESHOLD)),
+      ).toBeNull();
+    });
+
+    it('returns null for a small shipment that omits the field', () => {
+      expect(service.resolveRequiredApprovals(undefined, BigInt(5))).toBeNull();
+    });
+
+    it('accepts a count on a shipment at the threshold', () => {
+      expect(service.resolveRequiredApprovals(2, BigInt(THRESHOLD))).toBe(2);
+    });
+
+    it('rejects a count on a shipment below the threshold', () => {
+      expect(() => service.resolveRequiredApprovals(2, BigInt(5))).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects a zero or negative count', () => {
+      expect(() => service.resolveRequiredApprovals(0, BigInt(THRESHOLD))).toThrow(
+        BadRequestException,
+      );
+      expect(() => service.resolveRequiredApprovals(-1, BigInt(THRESHOLD))).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects a non-integer count', () => {
+      expect(() =>
+        service.resolveRequiredApprovals(1.5, BigInt(THRESHOLD)),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  // -- Recording approvals ----------------------------------------------------
+
+  describe('approve', () => {
+    it('records an approval from a shipment participant', async () => {
+      prisma.shipment.findUnique.mockResolvedValue(shipmentRow());
+      prisma.shipmentApproval.create.mockResolvedValue({
+        id: 'a1',
+        shipmentId: 'SHIP-1',
+        approverAddress: SUPPLIER,
+      });
+      prisma.shipmentApproval.count.mockResolvedValue(1);
+
+      const result = await service.approve('SHIP-1', SUPPLIER, 'looks good');
+
+      expect(prisma.shipmentApproval.create).toHaveBeenCalledWith({
+        data: {
+          shipmentId: 'SHIP-1',
+          approverAddress: SUPPLIER,
+          note: 'looks good',
+        },
+      });
+      expect(result.approvalCount).toBe(1);
+      expect(result.requiredApprovals).toBe(2);
+      expect(result.quorumMet).toBe(false);
+    });
+
+    it('reports quorum met once the final approval lands', async () => {
+      prisma.shipment.findUnique.mockResolvedValue(shipmentRow());
+      prisma.shipmentApproval.create.mockResolvedValue({ id: 'a2' });
+      prisma.shipmentApproval.count.mockResolvedValue(2);
+
+      const result = await service.approve('SHIP-1', ARBITER);
+
+      expect(result.quorumMet).toBe(true);
+    });
+
+    it('rejects an approver who is not on the shipment', async () => {
+      prisma.shipment.findUnique.mockResolvedValue(shipmentRow());
+
+      await expect(service.approve('SHIP-1', OUTSIDER)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(prisma.shipmentApproval.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a second approval from the same address', async () => {
+      prisma.shipment.findUnique.mockResolvedValue(shipmentRow());
+      prisma.shipmentApproval.findFirst.mockResolvedValue({ id: 'existing' });
+
+      await expect(service.approve('SHIP-1', SUPPLIER)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(prisma.shipmentApproval.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects approval on a shipment that does not use multi-signature', async () => {
+      prisma.shipment.findUnique.mockResolvedValue(
+        shipmentRow({ requiredApprovals: null }),
+      );
+
+      await expect(service.approve('SHIP-1', SUPPLIER)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('404s for an unknown shipment', async () => {
+      prisma.shipment.findUnique.mockResolvedValue(null);
+
+      await expect(service.approve('NOPE', SUPPLIER)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('accepts each of the four participant roles', async () => {
+      prisma.shipmentApproval.create.mockResolvedValue({ id: 'a' });
+      prisma.shipmentApproval.count.mockResolvedValue(1);
+
+      for (const address of [BUYER, SUPPLIER, LOGISTICS, ARBITER]) {
+        prisma.shipment.findUnique.mockResolvedValue(shipmentRow());
+        await expect(service.approve('SHIP-1', address)).resolves.toBeDefined();
+      }
+    });
+  });
+
+  // -- Quorum gate ------------------------------------------------------------
+
+  describe('assertQuorum', () => {
+    it('passes straight through for a single-approver shipment', async () => {
+      prisma.shipment.findUnique.mockResolvedValue({ requiredApprovals: null });
+
+      await expect(service.assertQuorum('SHIP-1')).resolves.toBeUndefined();
+      expect(prisma.shipmentApproval.count).not.toHaveBeenCalled();
+    });
+
+    it('blocks confirmation while approvals are short of the quorum', async () => {
+      prisma.shipment.findUnique.mockResolvedValue({ requiredApprovals: 2 });
+      prisma.shipmentApproval.count.mockResolvedValue(1);
+
+      await expect(service.assertQuorum('SHIP-1')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('names the shortfall so the caller knows what is missing', async () => {
+      prisma.shipment.findUnique.mockResolvedValue({ requiredApprovals: 3 });
+      prisma.shipmentApproval.count.mockResolvedValue(1);
+
+      await expect(service.assertQuorum('SHIP-1')).rejects.toThrow(
+        /requires 3 approvals/,
+      );
+    });
+
+    it('allows confirmation once the quorum is exactly met', async () => {
+      prisma.shipment.findUnique.mockResolvedValue({ requiredApprovals: 2 });
+      prisma.shipmentApproval.count.mockResolvedValue(2);
+
+      await expect(service.assertQuorum('SHIP-1')).resolves.toBeUndefined();
+    });
+
+    it('allows confirmation when approvals exceed the quorum', async () => {
+      prisma.shipment.findUnique.mockResolvedValue({ requiredApprovals: 2 });
+      prisma.shipmentApproval.count.mockResolvedValue(5);
+
+      await expect(service.assertQuorum('SHIP-1')).resolves.toBeUndefined();
+    });
+
+    it('does not block when the shipment is missing, leaving that to the caller', async () => {
+      prisma.shipment.findUnique.mockResolvedValue(null);
+
+      await expect(service.assertQuorum('SHIP-1')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('hasQuorum', () => {
+    it('is true for a single-approver shipment', async () => {
+      prisma.shipment.findUnique.mockResolvedValue({ requiredApprovals: null });
+
+      await expect(service.hasQuorum('SHIP-1')).resolves.toBe(true);
+    });
+
+    it('is false while short of the quorum', async () => {
+      prisma.shipment.findUnique.mockResolvedValue({ requiredApprovals: 2 });
+      prisma.shipmentApproval.count.mockResolvedValue(1);
+
+      await expect(service.hasQuorum('SHIP-1')).resolves.toBe(false);
+    });
+
+    it('is true once the quorum is met', async () => {
+      prisma.shipment.findUnique.mockResolvedValue({ requiredApprovals: 2 });
+      prisma.shipmentApproval.count.mockResolvedValue(2);
+
+      await expect(service.hasQuorum('SHIP-1')).resolves.toBe(true);
+    });
+  });
+
+  // -- Detail response --------------------------------------------------------
+
+  describe('getApprovalStatus', () => {
+    it('reports a single-approver shipment as already at quorum', async () => {
+      await expect(service.getApprovalStatus('SHIP-1', null)).resolves.toEqual({
+        required: null,
+        count: 0,
+        quorumMet: true,
+        approvals: [],
+      });
+      expect(prisma.shipmentApproval.findMany).not.toHaveBeenCalled();
+    });
+
+    it('reports progress for a multi-signature shipment', async () => {
+      prisma.shipmentApproval.findMany.mockResolvedValue([
+        { id: 'a1', approverAddress: SUPPLIER },
+      ]);
+
+      await expect(service.getApprovalStatus('SHIP-1', 2)).resolves.toEqual({
+        required: 2,
+        count: 1,
+        quorumMet: false,
+        approvals: [{ id: 'a1', approverAddress: SUPPLIER }],
+      });
+    });
+
+    it('reports quorum met when enough approvals are recorded', async () => {
+      prisma.shipmentApproval.findMany.mockResolvedValue([
+        { id: 'a1' },
+        { id: 'a2' },
+      ]);
+
+      const status = await service.getApprovalStatus('SHIP-1', 2);
+      expect(status.quorumMet).toBe(true);
+    });
+  });
+});

--- a/src/modules/shipments/shipment-approvals.service.ts
+++ b/src/modules/shipments/shipment-approvals.service.ts
@@ -1,0 +1,215 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../common/prisma/prisma.service';
+
+/**
+ * Multi-signature approval for high-value shipments.
+ *
+ * Shipments at or above MULTISIG_VALUE_THRESHOLD_STROOPS may carry a
+ * `requiredApprovals` count. Until that many co-approvers have signed off, no
+ * milestone on the shipment can be confirmed. Shipments below the threshold,
+ * and shipments that simply do not set the field, keep the existing
+ * single-approver flow untouched.
+ */
+@Injectable()
+export class ShipmentApprovalsService {
+  private readonly logger = new Logger(ShipmentApprovalsService.name);
+  private readonly threshold: bigint;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+  ) {
+    // Mirrors the KYC threshold convention: stroops as a string, since the
+    // value exceeds what a JS number holds precisely.
+    this.threshold = BigInt(
+      this.config.get<string>('MULTISIG_VALUE_THRESHOLD_STROOPS', '1000000000000'),
+    );
+  }
+
+  /** Whether a shipment of this size is eligible for multi-approver sign-off. */
+  meetsThreshold(totalAmount: bigint): boolean {
+    return totalAmount >= this.threshold;
+  }
+
+  /**
+   * Validate a requiredApprovals value supplied at shipment creation.
+   *
+   * Returns the count to persist, or null when the shipment should use the
+   * default single-approver flow.
+   *
+   * Asking for approvals on a shipment below the threshold is rejected rather
+   * than silently ignored, so a caller who believes they have gated a shipment
+   * is never quietly wrong about it.
+   */
+  resolveRequiredApprovals(
+    requiredApprovals: number | undefined,
+    totalAmount: bigint,
+  ): number | null {
+    if (requiredApprovals === undefined || requiredApprovals === null) {
+      return null;
+    }
+
+    if (!this.meetsThreshold(totalAmount)) {
+      throw new BadRequestException(
+        'requiredApprovals is only accepted for shipments at or above the ' +
+          'multi-signature value threshold. Omit it for smaller shipments, ' +
+          'which use the single-approver flow.',
+      );
+    }
+
+    if (!Number.isInteger(requiredApprovals) || requiredApprovals < 1) {
+      throw new BadRequestException('requiredApprovals must be a positive integer');
+    }
+
+    return requiredApprovals;
+  }
+
+  /**
+   * Record a co-approver's sign-off.
+   *
+   * Only the shipment's own participants may approve, and each address counts
+   * once: a repeated call is a conflict rather than a second approval, so a
+   * quorum cannot be reached by one party calling the endpoint N times.
+   */
+  async approve(shipmentId: string, approverAddress: string, note?: string) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+      select: {
+        id: true,
+        requiredApprovals: true,
+        buyerAddress: true,
+        supplierAddress: true,
+        logisticsAddress: true,
+        arbiterAddress: true,
+      },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    }
+
+    const participants = [
+      shipment.buyerAddress,
+      shipment.supplierAddress,
+      shipment.logisticsAddress,
+      shipment.arbiterAddress,
+    ];
+
+    if (!participants.includes(approverAddress)) {
+      throw new ForbiddenException(
+        'Only a participant on this shipment may record an approval',
+      );
+    }
+
+    if (shipment.requiredApprovals === null) {
+      throw new BadRequestException(
+        `Shipment ${shipmentId} does not require multi-signature approval`,
+      );
+    }
+
+    const existing = await this.prisma.shipmentApproval.findFirst({
+      where: { shipmentId, approverAddress },
+    });
+
+    if (existing) {
+      throw new ConflictException(
+        'This address has already approved this shipment',
+      );
+    }
+
+    const approval = await this.prisma.shipmentApproval.create({
+      data: { shipmentId, approverAddress, note },
+    });
+
+    const approvalCount = await this.prisma.shipmentApproval.count({
+      where: { shipmentId },
+    });
+
+    this.logger.log(
+      `Approval recorded for shipment ${shipmentId} by ${approverAddress} ` +
+        `(${approvalCount}/${shipment.requiredApprovals})`,
+    );
+
+    return {
+      approval,
+      approvalCount,
+      requiredApprovals: shipment.requiredApprovals,
+      quorumMet: approvalCount >= shipment.requiredApprovals,
+    };
+  }
+
+  /** Every approval recorded against a shipment, oldest first. */
+  async listApprovals(shipmentId: string) {
+    return this.prisma.shipmentApproval.findMany({
+      where: { shipmentId },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  /**
+   * Approval progress for a shipment, for the detail response.
+   *
+   * `required` is null and `quorumMet` true for a shipment on the default
+   * single-approver flow, so callers can treat quorumMet uniformly.
+   */
+  async getApprovalStatus(shipmentId: string, requiredApprovals: number | null) {
+    if (requiredApprovals === null) {
+      return { required: null, count: 0, quorumMet: true, approvals: [] };
+    }
+
+    const approvals = await this.listApprovals(shipmentId);
+    return {
+      required: requiredApprovals,
+      count: approvals.length,
+      quorumMet: approvals.length >= requiredApprovals,
+      approvals,
+    };
+  }
+
+  /** Whether a shipment has gathered enough approvals to proceed. */
+  async hasQuorum(shipmentId: string): Promise<boolean> {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+      select: { requiredApprovals: true },
+    });
+
+    if (!shipment || shipment.requiredApprovals === null) return true;
+
+    const count = await this.prisma.shipmentApproval.count({
+      where: { shipmentId },
+    });
+    return count >= shipment.requiredApprovals;
+  }
+
+  /**
+   * Gate used by milestone confirmation. Throws when the shipment still needs
+   * approvals; returns silently for shipments on the single-approver flow.
+   */
+  async assertQuorum(shipmentId: string): Promise<void> {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+      select: { requiredApprovals: true },
+    });
+
+    if (!shipment || shipment.requiredApprovals === null) return;
+
+    const count = await this.prisma.shipmentApproval.count({
+      where: { shipmentId },
+    });
+
+    if (count < shipment.requiredApprovals) {
+      throw new ForbiddenException(
+        `Shipment ${shipmentId} requires ${shipment.requiredApprovals} approvals ` +
+          `before a milestone can be confirmed. ${count} recorded so far.`,
+      );
+    }
+  }
+}

--- a/src/modules/shipments/shipments.controller.spec.ts
+++ b/src/modules/shipments/shipments.controller.spec.ts
@@ -5,10 +5,16 @@ import { ForbiddenException } from '@nestjs/common';
 import { ShipmentsController } from './shipments.controller';
 import { ShipmentsService } from './shipments.service';
 import { RedisService } from '../../common/redis/redis.service';
+import { ShipmentApprovalsService } from './shipment-approvals.service';
 
 const mockRedis: Partial<RedisService> = {
     getJson: jest.fn().mockResolvedValue(null),
     setJson: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockApprovals: Partial<ShipmentApprovalsService> = {
+    approve: jest.fn(),
+    getApprovalStatus: jest.fn(),
 };
 
 describe('ShipmentsController (RBAC)', () => {
@@ -17,7 +23,11 @@ describe('ShipmentsController (RBAC)', () => {
             create: jest.fn().mockResolvedValue({}),
         };
 
-        const controller = new ShipmentsController(mockService as ShipmentsService, mockRedis as RedisService);
+        const controller = new ShipmentsController(
+            mockService as ShipmentsService,
+            mockApprovals as ShipmentApprovalsService,
+            mockRedis as RedisService,
+        );
 
         const dto: any = {
             shipmentId: 'SHIP-1',
@@ -40,7 +50,11 @@ describe('ShipmentsController (RBAC)', () => {
             create: jest.fn().mockResolvedValue({ id: 'SHIP-1' }),
         };
 
-        const controller = new ShipmentsController(mockService as ShipmentsService, mockRedis as RedisService);
+        const controller = new ShipmentsController(
+            mockService as ShipmentsService,
+            mockApprovals as ShipmentApprovalsService,
+            mockRedis as RedisService,
+        );
 
         const dto: any = {
             shipmentId: 'SHIP-1',
@@ -68,7 +82,11 @@ describe('ShipmentsController (RBAC)', () => {
             create: jest.fn().mockResolvedValue({ id: 'SHIP-2' }),
         };
 
-        const controller = new ShipmentsController(mockService as ShipmentsService, redisMock as RedisService);
+        const controller = new ShipmentsController(
+            mockService as ShipmentsService,
+            mockApprovals as ShipmentApprovalsService,
+            redisMock as RedisService,
+        );
 
         const dto: any = {
             shipmentId: 'SHIP-1',

--- a/src/modules/shipments/shipments.controller.spec.ts
+++ b/src/modules/shipments/shipments.controller.spec.ts
@@ -6,6 +6,7 @@ import { ShipmentsController } from './shipments.controller';
 import { ShipmentsService } from './shipments.service';
 import { RedisService } from '../../common/redis/redis.service';
 import { ShipmentApprovalsService } from './shipment-approvals.service';
+import { SavedFiltersService } from './saved-filters.service';
 
 const mockRedis: Partial<RedisService> = {
     getJson: jest.fn().mockResolvedValue(null),
@@ -17,6 +18,11 @@ const mockApprovals: Partial<ShipmentApprovalsService> = {
     getApprovalStatus: jest.fn(),
 };
 
+const mockSavedFilters: Partial<SavedFiltersService> = {
+    applyTo: jest.fn(),
+    findAll: jest.fn(),
+};
+
 describe('ShipmentsController (RBAC)', () => {
     it('rejects POST /shipments when buyerAddress does not match caller (non-admin)', async () => {
         const mockService: Partial<ShipmentsService> = {
@@ -26,6 +32,7 @@ describe('ShipmentsController (RBAC)', () => {
         const controller = new ShipmentsController(
             mockService as ShipmentsService,
             mockApprovals as ShipmentApprovalsService,
+            mockSavedFilters as SavedFiltersService,
             mockRedis as RedisService,
         );
 
@@ -53,6 +60,7 @@ describe('ShipmentsController (RBAC)', () => {
         const controller = new ShipmentsController(
             mockService as ShipmentsService,
             mockApprovals as ShipmentApprovalsService,
+            mockSavedFilters as SavedFiltersService,
             mockRedis as RedisService,
         );
 
@@ -85,6 +93,7 @@ describe('ShipmentsController (RBAC)', () => {
         const controller = new ShipmentsController(
             mockService as ShipmentsService,
             mockApprovals as ShipmentApprovalsService,
+            mockSavedFilters as SavedFiltersService,
             redisMock as RedisService,
         );
 

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -35,6 +35,8 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
 import { ShipmentsService } from './shipments.service';
 import { ShipmentApprovalsService } from './shipment-approvals.service';
+import { SavedFiltersService } from './saved-filters.service';
+import { CreateSavedFilterDto, UpdateSavedFilterDto } from './dto/saved-filter.dto';
 import { CreateShipmentDto, UpdateShipmentDto, CancelShipmentDto, CloneShipmentDto, BulkStatusDto, ApproveShipmentDto } from './dto/create-shipment.dto';
 import { CreateTrackingDto } from './dto/tracking.dto';
 import { FindAllShipmentsDto } from './dto/find-all-shipments.dto';
@@ -56,6 +58,7 @@ export class ShipmentsController {
   constructor(
     private readonly shipmentsService: ShipmentsService,
     private readonly shipmentApprovals: ShipmentApprovalsService,
+    private readonly savedFilters: SavedFiltersService,
     private readonly redis: RedisService,
   ) { }
 
@@ -117,9 +120,16 @@ export class ShipmentsController {
   @Get()
   @ApiOperation({ summary: 'List shipments with chronological filters and pagination' })
   @ApiResponse({ status: 200, description: 'Filtered list of shipments' })
-  findAll(@CurrentUser() user: any, @Query() query: FindAllShipmentsDto) {
+  async findAll(@CurrentUser() user: any, @Query() query: FindAllShipmentsDto) {
     if (query.cursor && query.page) {
       throw new BadRequestException('cursor and page are mutually exclusive');
+    }
+
+    // A saved preset supplies the base criteria (#239); anything explicitly
+    // passed on this request overrides the stored value, so a saved view can
+    // be narrowed without being re-saved.
+    if (query.savedFilterId) {
+      query = await this.savedFilters.applyTo(user.id, query.savedFilterId, query);
     }
 
     if (query.createdAfter && query.createdBefore && new Date(query.createdAfter) > new Date(query.createdBefore)) {
@@ -402,6 +412,76 @@ export class ShipmentsController {
   @ApiResponse({ status: 404, description: 'Shipment not found or no metadata set' })
   validateMetadata(@Param('id') id: string, @Body() dto: ValidateMetadataDto) {
     return this.shipmentsService.validateMetadata(id, dto.schema);
+  }
+
+  /**
+   * POST /api/v1/shipments/filters
+   * Save a named filter preset for the caller.
+   */
+  @Post('filters')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Save a named GET /shipments filter preset' })
+  @ApiResponse({ status: 201, description: 'Saved filter created' })
+  @ApiResponse({ status: 400, description: 'Unsupported filter field' })
+  @ApiResponse({ status: 409, description: 'A preset of that name already exists' })
+  createSavedFilter(@Body() dto: CreateSavedFilterDto, @CurrentUser() user: any) {
+    return this.savedFilters.create(user.id, dto.name, dto.filter);
+  }
+
+  /**
+   * GET /api/v1/shipments/filters
+   * List the caller's saved filter presets.
+   */
+  @Get('filters')
+  @ApiOperation({ summary: "List the caller's saved filter presets" })
+  @ApiResponse({ status: 200, description: 'Saved filters' })
+  listSavedFilters(@CurrentUser() user: any) {
+    return this.savedFilters.findAll(user.id);
+  }
+
+  /**
+   * GET /api/v1/shipments/filters/:filterId
+   * Read one of the caller's saved filter presets.
+   */
+  @Get('filters/:filterId')
+  @ApiOperation({ summary: 'Get a saved filter preset' })
+  @ApiResponse({ status: 200, description: 'Saved filter' })
+  @ApiResponse({ status: 404, description: 'Not found, or not yours' })
+  getSavedFilter(@Param('filterId') filterId: string, @CurrentUser() user: any) {
+    return this.savedFilters.findOne(user.id, filterId);
+  }
+
+  /**
+   * PATCH /api/v1/shipments/filters/:filterId
+   * Rename a preset, replace its criteria, or both.
+   */
+  @Patch('filters/:filterId')
+  @ApiOperation({ summary: 'Update a saved filter preset' })
+  @ApiResponse({ status: 200, description: 'Saved filter updated' })
+  @ApiResponse({ status: 404, description: 'Not found, or not yours' })
+  @ApiResponse({ status: 409, description: 'A preset of that name already exists' })
+  updateSavedFilter(
+    @Param('filterId') filterId: string,
+    @Body() dto: UpdateSavedFilterDto,
+    @CurrentUser() user: any,
+  ) {
+    return this.savedFilters.update(user.id, filterId, dto);
+  }
+
+  /**
+   * DELETE /api/v1/shipments/filters/:filterId
+   * Delete one of the caller's saved filter presets.
+   */
+  @Delete('filters/:filterId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Delete a saved filter preset' })
+  @ApiResponse({ status: 200, description: 'Saved filter deleted' })
+  @ApiResponse({ status: 404, description: 'Not found, or not yours' })
+  deleteSavedFilter(
+    @Param('filterId') filterId: string,
+    @CurrentUser() user: any,
+  ) {
+    return this.savedFilters.remove(user.id, filterId);
   }
 
   /**

--- a/src/modules/shipments/shipments.controller.ts
+++ b/src/modules/shipments/shipments.controller.ts
@@ -34,7 +34,8 @@ import { Throttle } from '@nestjs/throttler';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
 import { ShipmentsService } from './shipments.service';
-import { CreateShipmentDto, UpdateShipmentDto, CancelShipmentDto, CloneShipmentDto, BulkStatusDto } from './dto/create-shipment.dto';
+import { ShipmentApprovalsService } from './shipment-approvals.service';
+import { CreateShipmentDto, UpdateShipmentDto, CancelShipmentDto, CloneShipmentDto, BulkStatusDto, ApproveShipmentDto } from './dto/create-shipment.dto';
 import { CreateTrackingDto } from './dto/tracking.dto';
 import { FindAllShipmentsDto } from './dto/find-all-shipments.dto';
 import { AddTagDto } from './dto/tag.dto';
@@ -54,6 +55,7 @@ import { RedisService } from '../../common/redis/redis.service';
 export class ShipmentsController {
   constructor(
     private readonly shipmentsService: ShipmentsService,
+    private readonly shipmentApprovals: ShipmentApprovalsService,
     private readonly redis: RedisService,
   ) { }
 
@@ -400,6 +402,45 @@ export class ShipmentsController {
   @ApiResponse({ status: 404, description: 'Shipment not found or no metadata set' })
   validateMetadata(@Param('id') id: string, @Body() dto: ValidateMetadataDto) {
     return this.shipmentsService.validateMetadata(id, dto.schema);
+  }
+
+  /**
+   * POST /api/v1/shipments/:id/approve
+   * Record a co-approver's sign-off on a high-value shipment. Milestone
+   * confirmation stays blocked until the approval quorum is met.
+   */
+  @Post(':id/approve')
+  @UseGuards(ShipmentParticipantGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Record a co-approver sign-off on a shipment' })
+  @ApiResponse({ status: 200, description: 'Approval recorded' })
+  @ApiResponse({ status: 400, description: 'Shipment does not require multi-signature approval' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  @ApiResponse({ status: 404, description: 'Shipment not found' })
+  @ApiResponse({ status: 409, description: 'This address has already approved' })
+  approveShipment(
+    @Param('id') id: string,
+    @Body() dto: ApproveShipmentDto,
+    @CurrentUser() user: any,
+  ) {
+    return this.shipmentApprovals.approve(id, user.stellarAddress, dto?.note);
+  }
+
+  /**
+   * GET /api/v1/shipments/:id/approvals
+   * Approval progress for a shipment.
+   */
+  @Get(':id/approvals')
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'List approvals recorded against a shipment' })
+  @ApiResponse({ status: 200, description: 'Approval progress' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  async getShipmentApprovals(@Param('id') id: string) {
+    const shipment = await this.shipmentsService.findOne(id);
+    return this.shipmentApprovals.getApprovalStatus(
+      id,
+      (shipment as any).requiredApprovals ?? null,
+    );
   }
 
   /**

--- a/src/modules/shipments/shipments.module.ts
+++ b/src/modules/shipments/shipments.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ShipmentsController } from './shipments.controller';
 import { AdminShipmentsController } from './admin-shipments.controller';
 import { ShipmentsService } from './shipments.service';
+import { ShipmentApprovalsService } from './shipment-approvals.service';
 import { ShipmentArchivalJob } from './shipment-archival.job';
 import { CommentsController } from './comments.controller';
 import { CommentsService } from './comments.service';
@@ -12,8 +13,8 @@ import { RedisModule } from '../../common/redis/redis.module';
 @Module({
   imports: [NotificationsModule, RedisModule, AuditLogsModule],
   controllers: [ShipmentsController, AdminShipmentsController, CommentsController],
-  providers: [ShipmentsService, CommentsService, ShipmentArchivalJob],
-  exports: [ShipmentsService],
+  providers: [ShipmentsService, ShipmentApprovalsService, CommentsService, ShipmentArchivalJob],
+  exports: [ShipmentsService, ShipmentApprovalsService],
 })
 export class ShipmentsModule { }
 

--- a/src/modules/shipments/shipments.module.ts
+++ b/src/modules/shipments/shipments.module.ts
@@ -3,6 +3,7 @@ import { ShipmentsController } from './shipments.controller';
 import { AdminShipmentsController } from './admin-shipments.controller';
 import { ShipmentsService } from './shipments.service';
 import { ShipmentApprovalsService } from './shipment-approvals.service';
+import { SavedFiltersService } from './saved-filters.service';
 import { ShipmentArchivalJob } from './shipment-archival.job';
 import { CommentsController } from './comments.controller';
 import { CommentsService } from './comments.service';
@@ -13,8 +14,8 @@ import { RedisModule } from '../../common/redis/redis.module';
 @Module({
   imports: [NotificationsModule, RedisModule, AuditLogsModule],
   controllers: [ShipmentsController, AdminShipmentsController, CommentsController],
-  providers: [ShipmentsService, ShipmentApprovalsService, CommentsService, ShipmentArchivalJob],
-  exports: [ShipmentsService, ShipmentApprovalsService],
+  providers: [ShipmentsService, ShipmentApprovalsService, SavedFiltersService, CommentsService, ShipmentArchivalJob],
+  exports: [ShipmentsService, ShipmentApprovalsService, SavedFiltersService],
 })
 export class ShipmentsModule { }
 

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -17,6 +17,7 @@ import { RedisService } from '../../common/redis/redis.service';
 import { MetricsService } from '../../common/metrics/metrics.service';
 import { AuditLogService } from '../audit-logs/audit-log.service';
 import { KycService } from '../kyc/kyc.service';
+import { ShipmentApprovalsService } from './shipment-approvals.service';
 import { FxRateService } from '../../common/fx/fx-rate.service';
 import { CreateShipmentDto, CloneShipmentDto } from './dto/create-shipment.dto';
 import { CreateTrackingDto } from './dto/tracking.dto';
@@ -42,6 +43,7 @@ export class ShipmentsService {
     private readonly metrics: MetricsService,
     private readonly auditLog: AuditLogService,
     private readonly kyc: KycService,
+    private readonly approvals: ShipmentApprovalsService,
     private readonly fxRate: FxRateService,
   ) {
     this.cacheTtl = this.config.get<number>('SHIPMENTS_CACHE_TTL_SECONDS', 30);
@@ -142,9 +144,18 @@ export class ShipmentsService {
 
     const token = this.tokenRegistry.getToken(tokenAddress);
 
+    // Multi-signature approval gate (#234). Rejects the field outright on
+    // shipments below the configured value threshold rather than dropping it
+    // silently, so a caller is never wrong about having gated a shipment.
+    const requiredApprovals = this.approvals.resolveRequiredApprovals(
+      dto.requiredApprovals,
+      totalAmountBigInt,
+    );
+
     const shipment = await this.prisma.shipment.create({
       data: {
         id: dto.shipmentId,
+        ...(requiredApprovals !== null ? { requiredApprovals } : {}),
         buyerAddress: dto.buyerAddress,
         supplierAddress,
         logisticsAddress,
@@ -399,7 +410,9 @@ export class ShipmentsService {
     }
 
     return {
-      data: shipments.map((s) => this.serialize(s, callerUserId)),
+      data: await Promise.all(
+        shipments.map((s) => this.serialize(s, callerUserId)),
+      ),
       meta: cursor
         ? { nextCursor, limit }
         : {
@@ -412,7 +425,7 @@ export class ShipmentsService {
     };
   }
 
-  async findOne(id: string) {
+  async findOne(id: string, callerUserId?: string) {
     const db = this.prisma.read;
     const shipment = await db.shipment.findUnique({
       where: { id },
@@ -420,6 +433,7 @@ export class ShipmentsService {
         milestones: { orderBy: { milestoneIndex: 'asc' } },
         events: { orderBy: { ledger: 'desc' }, take: 20 },
         trackingUpdates: { orderBy: { createdAt: 'asc' } },
+        approvals: { orderBy: { createdAt: 'asc' } },
         ...(callerUserId
           ? { favorites: { where: { userId: callerUserId }, select: { id: true } } }
           : {}),
@@ -1990,6 +2004,7 @@ export class ShipmentsService {
       actorAddress: buyerAddress,
       action: 'shipment.csv_import',
       resourceType: 'Shipment',
+      resourceId: 'csv-import',
       metadata: {
         totalRows: records.length,
         created: results.filter((r) => r.status === 'created').length,
@@ -2022,7 +2037,7 @@ export class ShipmentsService {
     await this.redis.delByPrefix(`shipments:${callerStellarAddress}:`);
   }
 
-  private serialize(shipment: any, callerUserId?: string) {
+  private async serialize(shipment: any, callerUserId?: string) {
     const now = new Date();
     const decimals: number = shipment.tokenDecimals ?? 7;
     const symbol: string = shipment.tokenSymbol ?? 'USDC';
@@ -2059,13 +2074,26 @@ export class ShipmentsService {
       ? trackingUpdates[trackingUpdates.length - 1]
       : null;
 
-    const { favorites, ...rest } = shipment;
+    const { favorites, approvals, ...rest } = shipment;
     const isFavorited = callerUserId
       ? Array.isArray(favorites) && favorites.length > 0
       : false;
 
+    // Multi-signature progress (#234). requiredApprovals is null on the default
+    // single-approver flow, in which case quorum is trivially met.
+    const requiredApprovals: number | null = shipment.requiredApprovals ?? null;
+    const recordedApprovals = Array.isArray(approvals) ? approvals : [];
+    const approvalStatus = {
+      required: requiredApprovals,
+      count: recordedApprovals.length,
+      quorumMet:
+        requiredApprovals === null || recordedApprovals.length >= requiredApprovals,
+      approvals: recordedApprovals,
+    };
+
     return {
       ...rest,
+      approvalStatus,
       tokenSymbol: symbol,
       tokenDecimals: decimals,
       totalAmount: shipment.totalAmount?.toString(),


### PR DESCRIPTION
## Summary

Closes four issues: feature flags, multi-signature approval, saved filter
presets, and iCalendar export.

`main` does not build, so the first commit repairs that. Nothing else could be
compiled or tested until it did.

## Commits

**fix: restore the pieces that stop the project building**

- `schema.prisma` referenced a `ShipmentFavorite` model in relations on `User`
  and `Shipment`, but the model was gone. Its migration and every
  `prisma.shipmentFavorite` call survived, so it is restored from that
  migration's SQL. Without it `prisma generate` fails and no Prisma type
  resolves anywhere.
- `events.controller.ts` was missing the closing brace on `getFailedEventById`.

**feat: add a Redis-backed feature flag service for gradual rollout (#227)**

Flags live in Redis and are read on every check with no in-process cache, so a
plain `SET` takes effect on the next request across every pod. A flag is
`enabled` plus an optional `rollout` percentage. `enabled` is evaluated first,
so setting it false is a complete stop mid-rollout that preserves the
percentage. Unknown flags read as false, so new work stays dark until turned on.

Percentage rollouts bucket on a hash of the flag name plus a stable caller id,
so a user gets the same answer every time, raising the percentage only ever adds
users, and being in the first 10% of one flag implies nothing about another.

`@FeatureFlag('name')` with `FeatureFlagGuard` gates a controller or a single
route. A disabled route answers 404, not 403: a 403 confirms the route exists
and is merely switched off, which leaks unreleased functionality.

`docs/feature-flags.md` covers naming conventions and the redis-cli commands to
toggle, roll out, and kill a flag without a redeploy.

**feat: add multi-signature approval for high-value shipments (#234)**

Shipments at or above `MULTISIG_VALUE_THRESHOLD_STROOPS` may carry a
`requiredApprovals` count. Until that many co-approvers sign off, no milestone
on the shipment can be confirmed. Shipments that omit the field are untouched.

Supplying the field below the threshold is rejected rather than silently
dropped, so a caller is never wrong about having gated a shipment. Only
participants may approve, and a unique index on (shipmentId, approverAddress)
means an address counts once, so a quorum cannot be reached by one party calling
the endpoint N times.

The gate is applied to both `confirmFromApi` and `bulkConfirmFromApi`. Gating
only the single confirm would leave it bypassable through the batch endpoint.

Approval progress is surfaced on the shipment detail response as
`approvalStatus`, which reports `quorumMet` true for single-approver shipments
so callers can read the field uniformly.

**feat: add saved filter presets for GET /shipments (#239)**

A `SavedFilter` model with CRUD under `/shipments/filters` and a
`savedFilterId` query param on the list endpoint.

Privacy is enforced by scoping every read and write by user id rather than
checking ownership after the fetch. Another user's preset returns 404, not 403:
its existence is itself private. Names are unique per user, so two users can
each have an "Overdue".

Stored criteria are whitelisted to the known filter fields, so a preset can
never smuggle an arbitrary key into the query the list endpoint builds, and a
typo is reported rather than quietly matching more than intended. Pagination is
not storable, since baking a page number into a saved view would mean recalling
it always landed on the same page.

With `savedFilterId`, stored criteria are the base and any other query param on
the request overrides them, so a saved view can be narrowed inline.

**feat: add iCalendar export for milestone due dates (#236)**

`GET /shipments/:shipmentId/milestones/calendar.ics` behind the participant
guard, and `GET /users/me/milestones/calendar.ics` aggregating every shipment
the caller participates in.

The subscription feed is public and authenticated by a signed token in the
query string, since calendar apps subscribe by URL and cannot send an
Authorization header. The token carries a user id plus an HMAC over it, so it
cannot be edited to point at somebody else, and signatures are compared with
`timingSafeEqual`. Rotating `CALENDAR_FEED_SECRET` revokes every issued feed.
With no secret configured the service refuses to issue or verify rather than
signing with an empty key.

The feed resolves the token to a user and matches shipments where their Stellar
address appears in any of the four roles, so it can only contain shipments its
owner is party to.

Rendering follows RFC 5545 without a new dependency: CRLF endings, escaping
applied in an order that does not re-escape, and folding at 75 octets counted as
octets so a multi-byte character is never split. UIDs are stable per milestone,
so re-subscribing updates events rather than duplicating them.

## Testing

112 new tests, all passing.

| | before | after |
| --- | --- | --- |
| Suites passing | 9 | 14 |
| Tests executing | 90 | 202 |
| Test failures | 9 | 9 (same, pre-existing) |
| tsc errors | 46 | 37 |

`ts-jest` type-checks every file a spec imports, so the new logic is built as
standalone services taking only Prisma and Config. That keeps it testable
independently of the surrounding modules.

Nine type errors were fixed, only in files these features had to edit and only
where the file would not otherwise compile. Each is listed in its commit
message.

## Needs doing before merge

Two migrations are included and the schema validates, but they have not been
run against a database. They need applying.

## Not addressed

The shipments and milestones controller specs still cannot compile, blocked by
a pre-existing type error in `notifications.service.ts:261`. That is outside
these four issues.

Closes #227
Closes #234
Closes #236
Closes #239