### PR TITLE
Fix overdue reminders, token registry, and health endpoints

### DIFF
--- a/docs/multi-token-support.md
+++ b/docs/multi-token-support.md
@@ -1,0 +1,71 @@
+# Multi-token support and onboarding a new payment token
+
+This project supports multiple payment tokens through the token registry, but the registry is only usable when the token is configured correctly and the token entry matches the on-chain decimals used by the asset.
+
+## 1. Register the token through the admin API
+
+Use the admin route to register a supported token before it is available for new shipments:
+
+```bash
+curl -X POST "$API_BASE/admin/tokens" \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "address": "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
+    "symbol": "USDC",
+    "displayName": "USD Coin",
+    "decimals": 7
+  }'
+```
+
+The route verifies that the contract exists on-chain, then stores the token in the in-memory registry used by shipment creation.
+
+## 2. Decimal precision gotcha
+
+This is the most common onboarding mistake: decimals must match the token's real contract precision.
+
+On Stellar, many Soroban tokens use 7 decimal places even when the UI or a human expects a simpler value. If a token is registered with the wrong decimals, the backend will store the wrong raw amount and any downstream value calculations (USD conversion, milestone amounts, and settlement math) will be wrong.
+
+The safe rule is:
+
+- verify the token's native contract decimals on-chain
+- register that exact value in the registry
+- never change decimals after the token has already been used by a shipment
+
+If a token is registered incorrectly, use the administrative update route to correct the entry before any shipments reference it.
+
+## 3. Contract-side allowlisting / deployment requirements
+
+Before the backend can use a token for shipment creation, the token must be properly deployed and recognized by the chain settlement contract. In practice that means:
+
+- the token contract must exist at the contract address being registered
+- the token must be one the settlement contract accepts for escrow flow
+- any allowlist or vendor configuration in the chain contract must include the token as a supported payment asset
+
+If this is being done in the companion `chainsetttle-contract` repo, make sure the contract configuration and metadata are updated there as part of the same rollout.
+
+## 4. Use the token in shipment creation
+
+Once the token is registered and enabled, a shipment can be created with it through the normal shipment request flow. The backend reads the token metadata from the registry, stores the token decimals and symbol on the shipment, and uses those values for all amount conversions and milestone calculations.
+
+A token that has been disabled via the admin patch endpoint will be rejected for new shipment creation, but historical shipments already using it remain unaffected.
+
+## 5. Admin maintenance
+
+If a token needs to be corrected or disabled, use the admin update route:
+
+```bash
+curl -X PATCH "$API_BASE/admin/tokens/CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA" \
+  -H "Authorization: Bearer $JWT" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": false,
+    "displayName": "USD Coin"
+  }'
+```
+
+The update endpoint accepts partial updates, but it rejects decimal changes once shipments already reference that token.
+
+## Result
+
+Following this sequence end-to-end ensures the new payment token is valid, correctly configured, and usable for shipment creation without corrupting historical amount calculations.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -496,6 +496,20 @@ model ShipmentWatcher {
   @@map("shipment_watchers")
 }
 
+model ShipmentFavorite {
+  id         String   @id @default(uuid())
+  shipmentId String
+  userId     String
+  createdAt  DateTime @default(now())
+
+  shipment Shipment @relation(fields: [shipmentId], references: [id], onDelete: Cascade)
+  user     User     @relation("ShipmentFavorites", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([shipmentId, userId])
+  @@index([userId])
+  @@map("shipment_favorites")
+}
+
 /// Cold-storage copy of a COMPLETED/CANCELLED shipment moved out of the hot
 /// `shipments` table by the scheduled archival job. `payload` retains the full
 /// relational snapshot (milestones, events, comments, tracking, notes, evidence).

--- a/src/common/token-registry/dto/register-token.dto.ts
+++ b/src/common/token-registry/dto/register-token.dto.ts
@@ -16,6 +16,9 @@ export class RegisterTokenDto {
   })
   symbol: string;
 
+  @ApiProperty({ description: 'Friendly display label for the token', example: 'Tether USD', required: false })
+  displayName?: string;
+
   @ApiProperty({ description: 'Token decimal places (0-18)', example: 7 })
   @IsInt()
   @Min(0)

--- a/src/common/token-registry/dto/update-token.dto.ts
+++ b/src/common/token-registry/dto/update-token.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsOptional, IsString, Max, Min, Matches } from 'class-validator';
+
+export class UpdateTokenDto {
+  @ApiProperty({ description: 'Friendly display name for the token', required: false, example: 'USD Coin' })
+  @IsOptional()
+  @IsString()
+  displayName?: string;
+
+  @ApiProperty({ description: 'Human-readable token symbol', required: false, example: 'USDC' })
+  @IsOptional()
+  @Matches(/^[A-Z0-9]{1,12}$/, {
+    message: 'symbol must be 1-12 uppercase alphanumeric characters',
+  })
+  symbol?: string;
+
+  @ApiProperty({ description: 'Token decimal places', required: false, example: 7 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(18)
+  decimals?: number;
+
+  @ApiProperty({ description: 'Whether this token can be used for new shipments', required: false, example: false })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/src/common/token-registry/token-registry.controller.ts
+++ b/src/common/token-registry/token-registry.controller.ts
@@ -1,12 +1,12 @@
-import { Controller, Get, Param, NotFoundException, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, NotFoundException, UseGuards, Patch, Body, Post } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import { TokenRegistryService } from './token-registry.service';
 import { RedisService } from '../redis/redis.service';
-import { Post, Body, ConflictException } from '@nestjs/common';
 import { UserRole } from '@prisma/client';
 import { Roles } from '../decorators/roles.decorator';
 import { RegisterTokenDto } from './dto/register-token.dto';
+import { UpdateTokenDto } from './dto/update-token.dto';
 
 const CACHE_KEY = 'token_registry:list';
 const CACHE_TTL = 300; // 5 minutes
@@ -66,5 +66,16 @@ export class AdminTokenRegistryController {
   @ApiResponse({ status: 409, description: 'Address already registered' })
   async registerToken(@Body() dto: RegisterTokenDto) {
     return this.tokenRegistry.registerToken(dto);
+  }
+
+  @Patch(':address')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: '[Admin] Update an existing supported payment token' })
+  @ApiResponse({ status: 200, description: 'Token updated' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  @ApiResponse({ status: 404, description: 'Token not found' })
+  @ApiResponse({ status: 409, description: 'Decimls cannot change after shipment usage' })
+  async updateToken(@Param('address') address: string, @Body() dto: UpdateTokenDto) {
+    return this.tokenRegistry.updateToken(address, dto);
   }
 }

--- a/src/common/token-registry/token-registry.module.ts
+++ b/src/common/token-registry/token-registry.module.ts
@@ -1,10 +1,12 @@
 import { Global, Module } from '@nestjs/common';
 import { TokenRegistryService } from './token-registry.service';
 import { AdminTokenRegistryController, TokenRegistryController } from './token-registry.controller';
+import { AuditLogsModule } from '../../modules/audit-logs/audit-logs.module';
 
 @Global()
 @Module({
-  controllers: [TokenRegistryController,  AdminTokenRegistryController],
+  imports: [AuditLogsModule],
+  controllers: [TokenRegistryController, AdminTokenRegistryController],
   providers: [TokenRegistryService],
   exports: [TokenRegistryService],
 })

--- a/src/common/token-registry/token-registry.service.spec.ts
+++ b/src/common/token-registry/token-registry.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TokenRegistryService } from './token-registry.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { StellarService } from '../stellar/stellar.service';
+import { RedisService } from '../redis/redis.service';
+import { AuditLogService } from '../../modules/audit-logs/audit-log.service';
+
+describe('TokenRegistryService', () => {
+  let service: TokenRegistryService;
+  let prisma: { shipment: { count: jest.Mock } };
+
+  beforeEach(async () => {
+    prisma = {
+      shipment: {
+        count: jest.fn().mockResolvedValue(0),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TokenRegistryService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn((key: string, fallback?: any) => fallback ?? undefined) },
+        },
+        {
+          provide: StellarService,
+          useValue: { contractExists: jest.fn().mockResolvedValue(true) },
+        },
+        {
+          provide: RedisService,
+          useValue: { del: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: PrismaService,
+          useValue: prisma,
+        },
+        {
+          provide: AuditLogService,
+          useValue: { record: jest.fn().mockResolvedValue(undefined) },
+        },
+      ],
+    }).compile();
+
+    service = module.get<TokenRegistryService>(TokenRegistryService);
+  });
+
+  it('disables a token without deleting it from the registry', async () => {
+    const address = 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA';
+
+    const result = await service.updateToken(address, { enabled: false });
+
+    expect(result.enabled).toBe(false);
+    expect(service.isEnabled(address)).toBe(false);
+    expect(service.findByAddress(address)).toMatchObject({ address, symbol: 'USDC' });
+  });
+
+  it('rejects decimals changes once shipments already reference the token', async () => {
+    const address = 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA';
+    prisma.shipment.count.mockResolvedValue(1);
+
+    await expect(service.updateToken(address, { decimals: 9 })).rejects.toBeInstanceOf(ConflictException);
+  });
+});

--- a/src/common/token-registry/token-registry.service.ts
+++ b/src/common/token-registry/token-registry.service.ts
@@ -1,20 +1,25 @@
-import { Injectable, Logger, ConflictException, BadRequestException } from '@nestjs/common';
+import { Injectable, Logger, ConflictException, BadRequestException, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as fs from 'fs';
 import * as path from 'path';
 import { StellarService } from '../stellar/stellar.service';
 import { RedisService } from '../redis/redis.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditLogService } from '../../modules/audit-logs/audit-log.service';
 import { RegisterTokenDto } from './dto/register-token.dto';
+
 export interface TokenInfo {
   symbol: string;
   decimals: number;
+  enabled?: boolean;
+  displayName?: string;
 }
 
 // Tokens pre-populated at compile time. Both USDC and EURC use 7 decimal
 // places on Stellar (the Soroban token standard normalises to 7).
 const BUILT_IN_TOKENS: Array<{ address: string } & TokenInfo> = [
-  { address: 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA', symbol: 'USDC', decimals: 7 },
-  { address: 'GB3Q6QDZYTHWT7E5PVS3W7FUT5GVAFC5KSZFFLPU25GO7VTC3NM2ZTVO', symbol: 'EURC', decimals: 7 },
+  { address: 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA', symbol: 'USDC', decimals: 7, enabled: true, displayName: 'USD Coin' },
+  { address: 'GB3Q6QDZYTHWT7E5PVS3W7FUT5GVAFC5KSZFFLPU25GO7VTC3NM2ZTVO', symbol: 'EURC', decimals: 7, enabled: true, displayName: 'Euro Coin' },
 ];
 
 @Injectable()
@@ -26,6 +31,8 @@ export class TokenRegistryService {
     private readonly config: ConfigService,
     private readonly stellar: StellarService,
     private readonly redis: RedisService,
+    private readonly prisma: PrismaService,
+    private readonly auditLog: AuditLogService,
   ) {
     this.initRegistry();
   }
@@ -57,9 +64,14 @@ export class TokenRegistryService {
 
   private loadFromJson(json: string, source: string) {
     try {
-      const tokens: Array<{ address: string; symbol: string; decimals: number }> = JSON.parse(json);
+      const tokens: Array<{ address: string; symbol: string; decimals: number; enabled?: boolean; displayName?: string }> = JSON.parse(json);
       for (const token of tokens) {
-        this.registry.set(token.address, { symbol: token.symbol, decimals: token.decimals });
+        this.registry.set(token.address.toUpperCase(), {
+          symbol: token.symbol,
+          decimals: token.decimals,
+          enabled: token.enabled ?? true,
+          displayName: token.displayName ?? token.symbol,
+        });
       }
       this.logger.log(`Loaded ${tokens.length} token(s) from ${source}`);
     } catch (err) {
@@ -74,15 +86,22 @@ export class TokenRegistryService {
    * correctly (7 decimals is the Stellar default).
    */
   getToken(contractAddress: string): TokenInfo {
-    return this.registry.get(contractAddress) ?? { symbol: 'UNKNOWN', decimals: 7 };
+    const normalized = contractAddress?.toUpperCase();
+    const token = this.registry.get(normalized);
+    return token ?? { symbol: 'UNKNOWN', decimals: 7, enabled: true, displayName: 'Unknown token' };
+  }
+
+  isEnabled(contractAddress: string): boolean {
+    const normalized = contractAddress?.toUpperCase();
+    return this.registry.get(normalized)?.enabled ?? true;
   }
 
   /**
    * Returns all registered tokens sorted alphabetically by symbol.
    */
-  listTokens(): Array<{ address: string; symbol: string; decimals: number }> {
+  listTokens(): Array<{ address: string; symbol: string; decimals: number; enabled: boolean; displayName: string }> {
     return Array.from(this.registry.entries())
-      .map(([address, { symbol, decimals }]) => ({ address, symbol, decimals }))
+      .map(([address, { symbol, decimals, enabled = true, displayName = symbol }]) => ({ address, symbol, decimals, enabled, displayName }))
       .sort((a, b) => a.symbol.localeCompare(b.symbol));
   }
 
@@ -93,10 +112,10 @@ export class TokenRegistryService {
    * in the app (see StellarService/Keypair, which always produce upper-case
    * StrKey-encoded addresses).
    */
-  findByAddress(address: string): { address: string; symbol: string; decimals: number } | undefined {
+  findByAddress(address: string): { address: string; symbol: string; decimals: number; enabled: boolean; displayName: string } | undefined {
     const normalized = address?.toUpperCase();
     const token = this.registry.get(normalized);
-    return token ? { address: normalized, symbol: token.symbol, decimals: token.decimals } : undefined;
+    return token ? { address: normalized, symbol: token.symbol, decimals: token.decimals, enabled: token.enabled ?? true, displayName: token.displayName ?? token.symbol } : undefined;
   }
 
   /**
@@ -109,7 +128,7 @@ export class TokenRegistryService {
    * table in the schema, so a token registered here won't survive a
    * restart unless it's also added to TOKEN_REGISTRY_JSON/PATH.
    */
-  async registerToken(dto: RegisterTokenDto): Promise<{ address: string; symbol: string; decimals: number }> {
+  async registerToken(dto: RegisterTokenDto): Promise<{ address: string; symbol: string; decimals: number; enabled: boolean; displayName: string }> {
     const normalized = dto.address.toUpperCase();
 
     if (this.registry.has(normalized)) {
@@ -127,11 +146,60 @@ export class TokenRegistryService {
       throw new BadRequestException(`No contract found at address ${normalized}`);
     }
 
-    this.registry.set(normalized, { symbol: dto.symbol, decimals: dto.decimals });
+    const token = {
+      symbol: dto.symbol,
+      decimals: dto.decimals,
+      enabled: true,
+      displayName: dto.displayName ?? dto.symbol,
+    };
+
+    this.registry.set(normalized, token);
     await this.redis.del('token_registry:list');
 
     this.logger.log(`Registered new token ${dto.symbol} at ${normalized}`);
 
-    return { address: normalized, symbol: dto.symbol, decimals: dto.decimals };
+    return { address: normalized, symbol: token.symbol, decimals: token.decimals, enabled: token.enabled, displayName: token.displayName };
+  }
+
+  async updateToken(address: string, updates: Partial<{ symbol: string; decimals: number; enabled: boolean; displayName: string }>) {
+    const normalized = address?.toUpperCase();
+    const existing = this.registry.get(normalized);
+    if (!existing) {
+      throw new NotFoundException(`Token address ${normalized} not found in registry`);
+    }
+
+    if (updates.decimals !== undefined && updates.decimals !== existing.decimals) {
+      const shipmentCount = await this.prisma.shipment.count({
+        where: { tokenAddress: normalized },
+      });
+
+      if (shipmentCount > 0) {
+        throw new ConflictException(
+          `Cannot change decimals for token ${normalized} because shipments already reference it`,
+        );
+      }
+    }
+
+    const next = {
+      ...existing,
+      ...(updates.symbol ? { symbol: updates.symbol } : {}),
+      ...(updates.decimals !== undefined ? { decimals: updates.decimals } : {}),
+      ...(updates.enabled !== undefined ? { enabled: updates.enabled } : {}),
+      ...(updates.displayName !== undefined ? { displayName: updates.displayName } : {}),
+    };
+
+    this.registry.set(normalized, next);
+    await this.redis.del('token_registry:list');
+
+    await this.auditLog.record({
+      actorAddress: 'system',
+      action: 'TOKEN_REGISTRY_UPDATED',
+      resourceType: 'TokenRegistry',
+      resourceId: normalized,
+      metadata: { before: existing, after: next },
+    });
+
+    this.logger.log(`Updated token registry entry ${normalized}`);
+    return { address: normalized, ...next };
   }
 }

--- a/src/modules/health/health.controller.spec.ts
+++ b/src/modules/health/health.controller.spec.ts
@@ -1,0 +1,57 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminHealthController, HealthController } from './health.controller';
+import { HealthCheckService } from '@nestjs/terminus';
+import { PrismaService } from '../../common/prisma/prisma.service';
+import { IpfsService } from '../../common/ipfs/ipfs.service';
+import { RedisService } from '../../common/redis/redis.service';
+import { StellarService } from '../../common/stellar/stellar.service';
+import { ConfigService } from '@nestjs/config';
+
+describe('HealthController', () => {
+  let controller: AdminHealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminHealthController],
+      providers: [
+        {
+          provide: HealthCheckService,
+          useValue: { check: jest.fn().mockResolvedValue({ status: 'ok' }) },
+        },
+        {
+          provide: PrismaService,
+          useValue: { $queryRaw: jest.fn().mockResolvedValue([{ ok: true }]) },
+        },
+        {
+          provide: IpfsService,
+          useValue: { isHealthy: true },
+        },
+        {
+          provide: RedisService,
+          useValue: { getClient: jest.fn(() => ({ ping: jest.fn().mockResolvedValue('PONG') })) },
+        },
+        {
+          provide: StellarService,
+          useValue: { getClient: jest.fn(() => ({ getHealth: jest.fn().mockResolvedValue({ status: 'healthy' }) })) },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn((key: string, defaultValue?: any) => defaultValue) },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AdminHealthController>(AdminHealthController);
+  });
+
+  it('returns a per-dependency admin summary without failing the whole endpoint', async () => {
+    const result = await controller.dependenciesSummary();
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      dependencies: expect.any(Array),
+    });
+    expect(result.dependencies.some((dep: any) => dep.name === 'stellar-rpc')).toBe(true);
+    expect(result.dependencies.some((dep: any) => dep.name === 'database')).toBe(true);
+  });
+});

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,13 +1,21 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import {
   HealthCheck,
   HealthCheckService,
   HealthIndicatorResult,
   PrismaHealthIndicator,
 } from '@nestjs/terminus';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { IpfsService } from '../../common/ipfs/ipfs.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { RedisService } from '../../common/redis/redis.service';
+import { StellarService } from '../../common/stellar/stellar.service';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import * as nodemailer from 'nodemailer';
 
 @ApiTags('health')
 @Controller('health')
@@ -70,5 +78,140 @@ export class HealthController {
   private ipfsHealthCheck(): HealthIndicatorResult {
     const status = this.ipfsService.isHealthy ? 'up' : 'down';
     return { ipfs: { status } };
+  }
+}
+
+@ApiTags('admin')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('admin/health')
+export class AdminHealthController {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly ipfsService: IpfsService,
+    private readonly redis: RedisService,
+    private readonly stellar: StellarService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Get('dependencies')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: '[Admin] Get status of all external dependencies' })
+  async dependenciesSummary() {
+    const dependencies = await Promise.all([
+      this.databaseHealthCheck(),
+      this.redisHealthCheck(),
+      this.stellarHealthCheck(),
+      this.ipfsHealthCheck(),
+      this.smtpHealthCheck(),
+      this.fxHealthCheck(),
+      this.kycHealthCheck(),
+    ]);
+
+    const failing = dependencies.filter((dep) => dep.status !== 'up' && dep.status !== 'unknown');
+    return {
+      status: failing.length === 0 ? 'ok' : 'degraded',
+      checkedAt: new Date().toISOString(),
+      dependencies,
+    };
+  }
+
+  private async databaseHealthCheck() {
+    const startedAt = Date.now();
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return { name: 'database', status: 'up', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString() };
+    } catch (error) {
+      return { name: 'database', status: 'down', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: error.message };
+    }
+  }
+
+  private async redisHealthCheck() {
+    const startedAt = Date.now();
+    try {
+      const result = await this.redis.getClient().ping();
+      return { name: 'redis', status: result === 'PONG' ? 'up' : 'down', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString() };
+    } catch (error) {
+      return { name: 'redis', status: 'down', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: error.message };
+    }
+  }
+
+  private async stellarHealthCheck() {
+    const startedAt = Date.now();
+    try {
+      const client: any = this.stellar.getClient();
+      if (typeof client.getHealth === 'function') {
+        await client.getHealth();
+      } else if (typeof client.getLatestLedger === 'function') {
+        await client.getLatestLedger();
+      }
+      return { name: 'stellar-rpc', status: 'up', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString() };
+    } catch (error) {
+      return { name: 'stellar-rpc', status: 'down', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: error.message };
+    }
+  }
+
+  private async ipfsHealthCheck() {
+    const startedAt = Date.now();
+    try {
+      const status = this.ipfsService.isHealthy ? 'up' : 'down';
+      return { name: 'ipfs', status, latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString() };
+    } catch (error) {
+      return { name: 'ipfs', status: 'down', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: error.message };
+    }
+  }
+
+  private async smtpHealthCheck() {
+    const startedAt = Date.now();
+    try {
+      const host = this.config.get<string>('SMTP_HOST');
+      if (!host) {
+        return { name: 'smtp', status: 'unknown', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: 'SMTP is not configured' };
+      }
+
+      const transporter = nodemailer.createTransport({
+        host,
+        port: this.config.get<number>('SMTP_PORT', 587),
+        secure: false,
+        auth: {
+          user: this.config.get<string>('SMTP_USER'),
+          pass: this.config.get<string>('SMTP_PASS'),
+        },
+      });
+      await transporter.verify();
+      return { name: 'smtp', status: 'up', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString() };
+    } catch (error) {
+      return { name: 'smtp', status: 'down', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: error.message };
+    }
+  }
+
+  private async fxHealthCheck() {
+    const startedAt = Date.now();
+    const apiUrl = this.config.get<string>('FX_RATE_API_URL');
+    if (!apiUrl) {
+      return { name: 'fx-rate-source', status: 'unknown', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: 'FX rate source is not configured' };
+    }
+
+    try {
+      await axios.get(apiUrl, { timeout: 5000, params: { symbol: 'USDC' } });
+      return { name: 'fx-rate-source', status: 'up', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString() };
+    } catch (error) {
+      return { name: 'fx-rate-source', status: 'down', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: error.message };
+    }
+  }
+
+  private async kycHealthCheck() {
+    const startedAt = Date.now();
+    const provider = this.config.get<string>('KYC_PROVIDER_URL');
+    if (!provider) {
+      return { name: 'kyc-provider', status: 'unknown', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: 'KYC provider endpoint is not configured in this backend' };
+    }
+
+    try {
+      await axios.get(provider, { timeout: 5000 });
+      return { name: 'kyc-provider', status: 'up', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString() };
+    } catch (error) {
+      return { name: 'kyc-provider', status: 'down', latencyMs: Date.now() - startedAt, lastCheckedAt: new Date().toISOString(), message: error.message };
+    }
   }
 }

--- a/src/modules/health/health.module.ts
+++ b/src/modules/health/health.module.ts
@@ -1,10 +1,10 @@
 // health.module.ts
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
-import { HealthController } from './health.controller';
+import { AdminHealthController, HealthController } from './health.controller';
 
 @Module({
   imports: [TerminusModule],
-  controllers: [HealthController],
+  controllers: [HealthController, AdminHealthController],
 })
 export class HealthModule {}

--- a/src/modules/milestones/milestone-deadline.job.spec.ts
+++ b/src/modules/milestones/milestone-deadline.job.spec.ts
@@ -87,7 +87,9 @@ describe('MilestoneDeadlineJob', () => {
 
       const prismaMock = prisma.milestone.findMany as jest.Mock;
       const prismaUpdateMock = prisma.milestone.update as jest.Mock;
-      prismaMock.mockResolvedValue([overdueMilestone]);
+      prismaMock
+        .mockResolvedValueOnce([overdueMilestone])
+        .mockResolvedValueOnce([]);
       prismaUpdateMock.mockResolvedValue(overdueMilestone);
 
       const notificationsSpy = jest.spyOn(notifications, 'notifyUser');
@@ -133,7 +135,9 @@ describe('MilestoneDeadlineJob', () => {
 
       const prismaMock = prisma.milestone.findMany as jest.Mock;
       const prismaUpdateMock = prisma.milestone.update as jest.Mock;
-      prismaMock.mockResolvedValue([overdueMilestone]);
+      prismaMock
+        .mockResolvedValueOnce([overdueMilestone])
+        .mockResolvedValueOnce([]);
       prismaUpdateMock.mockResolvedValue({
         ...overdueMilestone,
         overdueNotifiedAt: new Date(),
@@ -197,7 +201,9 @@ describe('MilestoneDeadlineJob', () => {
 
       const prismaMock = prisma.milestone.findMany as jest.Mock;
       const prismaUpdateMock = prisma.milestone.update as jest.Mock;
-      prismaMock.mockResolvedValue([milestone1, milestone2]);
+      prismaMock
+        .mockResolvedValueOnce([milestone1, milestone2])
+        .mockResolvedValueOnce([]);
       prismaUpdateMock.mockResolvedValue({ overdueNotifiedAt: new Date() });
 
       const notificationsSpy = jest.spyOn(notifications, 'notifyUser');
@@ -271,6 +277,8 @@ describe('MilestoneDeadlineJob', () => {
           shipmentId: 'shipment-abc',
           milestoneIndex: 2,
           dueAt: expect.any(String),
+          threshold: expect.any(Number),
+          recipient: expect.any(String),
         }),
       );
     });

--- a/src/modules/milestones/milestone-deadline.job.ts
+++ b/src/modules/milestones/milestone-deadline.job.ts
@@ -133,7 +133,14 @@ export class MilestoneDeadlineJob {
         NotificationType.MILESTONE_OVERDUE,
         title,
         message,
-        { shipmentId, milestoneIndex, dueAt: dueAt.toISOString() },
+        {
+          shipmentId,
+          milestoneIndex,
+          dueAt: dueAt.toISOString(),
+          threshold: this.reminder1Days,
+          recipient: shipment.buyerAddress,
+          escalation: false,
+        },
       );
 
       await this.notifications.notifyUser(
@@ -141,7 +148,14 @@ export class MilestoneDeadlineJob {
         NotificationType.MILESTONE_OVERDUE,
         title,
         message,
-        { shipmentId, milestoneIndex, dueAt: dueAt.toISOString() },
+        {
+          shipmentId,
+          milestoneIndex,
+          dueAt: dueAt.toISOString(),
+          threshold: this.reminder1Days,
+          recipient: shipment.supplierAddress,
+          escalation: false,
+        },
       );
 
       await this.prisma.milestone.update({
@@ -176,7 +190,14 @@ export class MilestoneDeadlineJob {
         NotificationType.MILESTONE_OVERDUE,
         title,
         message,
-        { shipmentId, milestoneIndex, dueAt: dueAt.toISOString(), escalation: true },
+        {
+          shipmentId,
+          milestoneIndex,
+          dueAt: dueAt.toISOString(),
+          threshold: this.reminder3Days,
+          recipient: shipment.buyerAddress,
+          escalation: true,
+        },
       );
 
       await this.notifications.notifyUser(
@@ -184,7 +205,14 @@ export class MilestoneDeadlineJob {
         NotificationType.MILESTONE_OVERDUE,
         title,
         message,
-        { shipmentId, milestoneIndex, dueAt: dueAt.toISOString(), escalation: true },
+        {
+          shipmentId,
+          milestoneIndex,
+          dueAt: dueAt.toISOString(),
+          threshold: this.reminder3Days,
+          recipient: shipment.supplierAddress,
+          escalation: true,
+        },
       );
 
       await this.prisma.milestone.update({

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -126,6 +126,19 @@ export class MilestonesController {
     return this.milestonesService.findOne(shipmentId, index);
   }
 
+  @Get(':index/reminders')
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'Get reminder history for a milestone' })
+  @ApiResponse({ status: 200, description: 'Reminder history records for this milestone' })
+  @ApiResponse({ status: 403, description: 'Not a shipment participant' })
+  @ApiResponse({ status: 404, description: 'Milestone or shipment not found' })
+  getReminderHistory(
+    @Param('shipmentId') shipmentId: string,
+    @Param('index', ParseIntPipe) index: number,
+  ) {
+    return this.milestonesService.getReminderHistory(shipmentId, index);
+  }
+
   /**
    * POST /api/v1/shipments/:shipmentId/milestones/:index/proof
    *

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -6,6 +6,7 @@ import {
   ConflictException,
   BadRequestException
 } from '@nestjs/common';
+import { AuditLogService } from '../audit-logs/audit-log.service';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { IpfsService } from '../../common/ipfs/ipfs.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -87,6 +88,45 @@ export class MilestonesService {
       );
     }
     return milestone;
+  }
+
+  async getReminderHistory(shipmentId: string, milestoneIndex: number) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+      select: { id: true },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    }
+
+    const milestone = await this.prisma.milestone.findUnique({
+      where: { shipmentId_milestoneIndex: { shipmentId, milestoneIndex } },
+      select: { id: true },
+    });
+
+    if (!milestone) {
+      throw new NotFoundException(`Milestone ${milestoneIndex} not found on shipment ${shipmentId}`);
+    }
+
+    const rows = await this.prisma.$queryRaw<any[]>(`
+      SELECT id, type, title, message, data, "createdAt"
+      FROM notifications
+      WHERE type = 'MILESTONE_OVERDUE'
+        AND data->>'shipmentId' = ${shipmentId}
+        AND CAST(data->>'milestoneIndex' AS integer) = ${milestoneIndex}
+      ORDER BY "createdAt" ASC
+    `);
+
+    return rows.map((row) => ({
+      id: row.id,
+      threshold: row.data?.threshold ?? null,
+      recipient: row.data?.recipient ?? null,
+      sentAt: row.createdAt,
+      title: row.title,
+      message: row.message,
+      escalation: row.data?.escalation ?? false,
+    }));
   }
 
   // ----------------------------------------------------------

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -11,7 +11,7 @@ import { WebhooksService } from '../webhooks/webhooks.service';
 import { UpdatePreferencesDto } from './dto/update-preferences.dto';
 import { DEFAULT_LOCALE, I18nService } from '../../i18n/i18n.service';
 
-type ChannelPrefs = { inApp: boolean; email: boolean; slack: boolean };
+type ChannelPrefs = { inApp: boolean; email: boolean; slack?: boolean };
 type PreferenceMap = Record<NotificationType, ChannelPrefs>;
 export type DigestFrequency = 'instant' | 'daily' | 'weekly';
 type StoredPreferences = PreferenceMap & {

--- a/src/modules/shipments/shipments.service.ts
+++ b/src/modules/shipments/shipments.service.ts
@@ -141,6 +141,9 @@ export class ShipmentsService {
     }
 
     const token = this.tokenRegistry.getToken(tokenAddress);
+    if (!token.enabled) {
+      throw new BadRequestException(`Token ${tokenAddress} is disabled and cannot be used for new shipments`);
+    }
 
     const shipment = await this.prisma.shipment.create({
       data: {

--- a/src/modules/webhooks/webhooks.service.ts
+++ b/src/modules/webhooks/webhooks.service.ts
@@ -9,7 +9,7 @@ import * as crypto from 'crypto';
 import axios, { AxiosError } from 'axios';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { AuditLogService } from '../audit-logs/audit-log.service';
-import { NotificationType } from '@prisma/client';
+import { NotificationType, Prisma } from '@prisma/client';
 import { CreateWebhookDto } from './dto/create-webhook.dto';
 
 // ─── Retry policy ────────────────────────────────────────────────────────────
@@ -303,7 +303,12 @@ export class WebhooksService {
     const signature = signBody(ep.secret, body);
 
     const delivery = await this.prisma.webhookDelivery.create({
-      data: { endpointId: ep.id, eventType, payload, attemptCount: 1 },
+      data: {
+        endpointId: ep.id,
+        eventType,
+        payload: payload as Prisma.InputJsonValue,
+        attemptCount: 1,
+      },
     });
 
     try {


### PR DESCRIPTION
## Summary
- Add multi-token onboarding docs and registration guidance.
- Expose reminder history and include reminder metadata in overdue notification payloads.
- Add admin token update endpoint with validation that prevents unsafe decimal changes after token usage.
- Add admin dependency health summary endpoint.

## Related issues
- Closes #316
- Closes #317
- Closes #318
- Closes #319

## Verification
- 