### PR TITLE
docs: add rate-limiting, observability, testing, and glossary guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,9 @@ npm run test:cov   # Unit tests with coverage
 npm run format     # Prettier
 ```
 
+> For a full breakdown of every test category (unit, e2e, load tests, Pact, and shell
+> scripts), required local services, and CI setup, see [docs/testing.md](docs/testing.md).
+
 If your change touches an endpoint used by the frontend or event polling, also run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The backend is the **bridge between the Stellar blockchain and the frontend**. I
 ## Architecture
 
 > For a deep-dive into module interactions, the event pipeline, shipment lifecycle, and cross-cutting concerns see [ARCHITECTURE.md](./ARCHITECTURE.md).
+>
+> For definitions of domain terms used throughout the codebase (shipment, milestone, arbiter, proof, dispute, escalation, reconciliation, reputation) see [docs/glossary.md](./docs/glossary.md).
 
 ```
 ┌─────────────────────────────────────────────────────┐

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,127 @@
+# Glossary
+
+Definitions of core domain terms as used in this codebase. These are not generic dictionary
+definitions — they reflect the precise meaning of each term within ChainSettle's supply-chain
+escrow model.
+
+---
+
+## Shipment
+
+A single escrow agreement between a buyer and a supplier for the movement of goods. A
+shipment is created on-chain via the ChainSettle Soroban contract and then registered in the
+database by the backend. It holds the total locked amount (in USDC stroops), the four
+participant addresses, and a list of one or more milestones.
+
+A shipment has three possible statuses: `ACTIVE` (in progress), `COMPLETED` (all milestones
+confirmed), or `CANCELLED` (buyer or contract cancelled before completion).
+
+**Implemented in:** `src/modules/shipments/` · `prisma/schema.prisma` (`model Shipment`)
+
+---
+
+## Milestone
+
+One discrete deliverable within a shipment, each carrying a percentage of the total payment.
+Milestones are stored in the database with a 0-based `milestoneIndex` that mirrors the
+on-chain index. Payment is only released when the buyer confirms the milestone on-chain.
+
+Milestone statuses in order of progression:
+
+| Status | Meaning |
+|--------|---------|
+| `PENDING` | Work has not started or proof has not been submitted |
+| `PROOF_SUBMITTED` | Supplier or logistics provider has uploaded a proof document |
+| `CONFIRMED` | Buyer confirmed the milestone; payment released on-chain |
+| `DISPUTED` | Buyer raised a dispute instead of confirming |
+| `RESOLVED` | Arbiter resolved the dispute |
+
+**Implemented in:** `src/modules/milestones/` · `prisma/schema.prisma` (`model Milestone`)
+
+---
+
+## Arbiter
+
+A neutral third party designated at shipment creation to resolve disputes between the buyer
+and supplier. The arbiter address is locked into the on-chain contract and cannot be changed
+after creation. An arbiter must explicitly accept or decline the assignment
+(`ArbiterStatus`: `PENDING_ACCEPTANCE` → `ACCEPTED` or `DECLINED`). The backend tracks each
+arbiter's history (disputes handled, disputes open, average resolution time) as a
+**reputation** score, cached in Redis and refreshed by `ArbiterReputationJob`.
+
+**Implemented in:** `src/modules/arbiters/` · `src/modules/shipments/shipments.controller.ts`
+(`POST /shipments/:id/arbiter/accept`, `POST /shipments/:id/arbiter/decline`)
+
+---
+
+## Proof
+
+A document (PDF, image, or video) uploaded by the supplier or logistics participant as
+evidence that a milestone has been completed. Proofs are pinned to IPFS via Pinata; only the
+resulting IPFS CID (Content Identifier) is stored in the database on the `Milestone` record
+as `proofHash`. Each upload is also recorded in the `ProofSubmission` table so the full
+submission history for a milestone is preserved.
+
+Uploading a proof moves the milestone from `PENDING` to `PROOF_SUBMITTED` and triggers a
+notification to the buyer.
+
+**Implemented in:** `src/modules/milestones/milestones.controller.ts`
+(`POST /shipments/:id/milestones/:index/proof`) · `src/common/ipfs/`
+
+---
+
+## Dispute
+
+When a buyer receives a proof but disagrees that the milestone is complete, they raise a
+dispute on-chain. The on-chain event moves the milestone status to `DISPUTED` in the
+database. Both the buyer and the supplier can then submit dispute evidence
+(`DisputeEvidence`) — files and descriptions — for the arbiter to review. The dispute
+remains `DISPUTED` until the arbiter resolves it, transitioning the milestone to `RESOLVED`.
+
+**Implemented in:** `src/modules/milestones/milestones.service.ts` ·
+`prisma/schema.prisma` (`model DisputeEvidence`)
+
+---
+
+## Escalation
+
+When a dispute has remained in `DISPUTED` status for longer than `DISPUTE_ESCALATION_DAYS`
+(default 7 days) without resolution, the `DisputeEscalationJob` sends a `SYSTEM_ALERT`
+notification to all admin users and sets `disputeEscalatedAt` on the milestone to prevent
+repeated alerts. Escalation is automatic and does not change the milestone status — it only
+alerts admins that the dispute needs attention.
+
+**Implemented in:** `src/modules/milestones/dispute-escalation.job.ts`
+
+---
+
+## Reconciliation
+
+A weekly background job (`ReconciliationJob`) that compares the on-chain state of every
+`ACTIVE` shipment with the state stored in the database. If a mismatch ("state drift") is
+detected — for example, the contract shows a shipment as `COMPLETED` but the DB still shows
+it as `ACTIVE` — the job:
+
+1. Alerts all admin users with a `SYSTEM_ALERT` notification describing the drift.
+2. If the on-chain status is terminal (`COMPLETED` or `CANCELLED`), auto-corrects the DB
+   record by calling `syncStatusFromChain`.
+
+Each run is recorded in the `ReconciliationRun` table with counts of shipments checked,
+mismatches found, and any errors. The job runs every Sunday at 02:00 UTC.
+
+**Implemented in:** `src/modules/events/reconciliation.job.ts` ·
+`prisma/schema.prisma` (`model ReconciliationRun`)
+
+---
+
+## Reputation
+
+A per-arbiter performance snapshot computed from their dispute history: total disputes
+handled (resolved), currently open disputes, and average time from dispute creation to
+resolution in hours. The snapshot is computed by `ArbitersService.computeReputation()`,
+cached in Redis under `arbiter:reputation:<address>`, and refreshed on a scheduled basis by
+`ArbiterReputationJob`. The first call for a brand-new arbiter computes the score live as a
+fallback.
+
+**Implemented in:** `src/modules/arbiters/arbiters.service.ts` ·
+`src/modules/arbiters/arbiter-reputation.job.ts`

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,241 @@
+# Observability
+
+This document covers the three pillars of observability in the ChainSettle backend — metrics,
+distributed tracing, and structured logging — and shows how to correlate a single request
+across all three using its `X-Request-ID`.
+
+---
+
+## 1. Metrics (`/metrics`)
+
+The backend exposes a Prometheus-compatible scrape endpoint at `/metrics` (no `/api/v1` prefix;
+this path is excluded from the global prefix in `main.ts`).
+
+### Custom metrics
+
+Defined in `src/common/metrics/metrics.service.ts` and registered in
+`src/common/metrics/metrics.module.ts`:
+
+| Metric name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `chainsettle_events_processed_total` | Counter | `eventName` | On-chain events successfully processed by the poller |
+| `chainsettle_events_failed_total` | Counter | — | On-chain events that failed processing |
+| `chainsettle_shipments_created_total` | Counter | — | Shipments registered via the API |
+| `chainsettle_active_shipments` | Gauge | — | Current count of ACTIVE shipments |
+| `chainsettle_http_request_duration_seconds` | Histogram | `method`, `route`, `status` | Per-route HTTP latency (buckets: 5 ms → 5 s) |
+
+### Default Node.js metrics
+
+`PrometheusModule` is initialised with `defaultMetrics: { enabled: true }`, so all standard
+`prom-client` process metrics (`process_cpu_seconds_total`, `nodejs_heap_size_used_bytes`,
+event-loop lag, etc.) are also exposed at `/metrics`.
+
+### Health and metrics paths are excluded from spans
+
+`/health` and `/metrics` are suppressed in the OpenTelemetry HTTP instrumentation
+(`ignoreIncomingRequestHook`) to keep traces clean. They are also excluded from the global
+API prefix.
+
+### Starter Grafana panels
+
+| Panel | Query sketch |
+|-------|-------------|
+| Request rate (req/s) | `rate(chainsettle_http_request_duration_seconds_count[1m])` |
+| p99 latency by route | `histogram_quantile(0.99, sum by (le, route) (rate(chainsettle_http_request_duration_seconds_bucket[5m])))` |
+| Error rate (5xx) | `rate(chainsettle_http_request_duration_seconds_count{status=~"5.."}[1m])` |
+| Events processed/s | `rate(chainsettle_events_processed_total[1m])` |
+| Event failures | `increase(chainsettle_events_failed_total[5m])` |
+| Active shipments | `chainsettle_active_shipments` |
+
+---
+
+## 2. Distributed tracing (OpenTelemetry)
+
+Tracing is **opt-in**: the SDK is only initialised when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+When the variable is absent the application runs with zero tracing overhead.
+
+### Environment variables
+
+| Variable | Required for tracing | Description |
+|----------|---------------------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes | Base URL of the OTLP/HTTP collector, e.g. `http://otel-collector:4318` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | No | JSON object of extra headers, e.g. `{"x-honeycomb-team":"abc"}` |
+| `OTEL_SERVICE_NAME` | No | Service name in traces (default: `chainsettle-backend`) |
+
+### How it works
+
+`initTracing()` is called at the very top of `src/main.ts`, before `NestFactory.create()`,
+so that Node.js built-in module patches are applied before any `require()` inside NestJS or
+Prisma. The SDK uses `OTLPTraceExporter` over HTTP/protobuf.
+
+Auto-instrumented surfaces:
+
+- **Inbound HTTP** — every NestJS route produces a root span with method, route, and status code.
+- **Outbound HTTP/HTTPS** — axios calls (Stellar RPC, Pinata IPFS) produce child spans automatically.
+- **Prisma** — database queries produce child spans when
+  `@opentelemetry/instrumentation-prisma` is installed.
+
+`TracingInterceptor` (`src/common/tracing/tracing.interceptor.ts`) enriches each inbound
+span with:
+
+- `http.route` — parameterised route path (e.g., `/api/v1/shipments/:id`)
+- `http.request_id` / `chainsettle.request_id` — the `X-Request-ID` correlation value
+- `enduser.id` — the authenticated user's Stellar address (omitted for unauthenticated routes)
+
+For manual spans inside service methods use the `withSpan` helper
+(`src/common/tracing/trace.helper.ts`):
+
+```ts
+import { withSpan } from '../../common/tracing/trace.helper';
+
+async fetchContractEvents(startLedger: number) {
+  return withSpan('stellar.fetchContractEvents', async (span) => {
+    span.setAttribute('stellar.start_ledger', startLedger);
+    const events = await this.rpcClient.getEvents({ startLedger });
+    span.setAttribute('stellar.event_count', events.length);
+    return events;
+  });
+}
+```
+
+### Pointing a local collector at the API
+
+Example `docker-compose` snippet using Jaeger as an all-in-one backend:
+
+```yaml
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    ports:
+      - "16686:16686"   # Jaeger UI
+      - "4318:4318"     # OTLP/HTTP receiver
+```
+
+Then set in your `.env`:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=chainsettle-backend
+```
+
+In `development` mode the SDK uses `SimpleSpanProcessor` (synchronous flush), so spans appear
+in the Jaeger UI immediately.  In `production` it switches to `BatchSpanProcessor`.
+
+---
+
+## 3. Structured logging (Winston)
+
+Logging is configured in `src/common/logger/winston.logger.ts` and injected into NestJS via
+`WinstonModule.createLogger()` in `main.ts`.
+
+### Log levels
+
+| Environment | Default level | Override |
+|-------------|---------------|---------|
+| `development` | `debug` | `LOG_LEVEL` env var |
+| `production` | `info` | `LOG_LEVEL` env var |
+
+### Log format
+
+**Production** — JSON lines on stdout (structured, easy to ingest into Elasticsearch, CloudWatch,
+or Loki):
+
+```json
+{
+  "level": "info",
+  "message": "Shipment SHIP-001 created",
+  "timestamp": "2026-08-28T19:00:00.123Z",
+  "context": "ShipmentsService"
+}
+```
+
+**Development** — pretty-printed NestJS-style output with colour and indentation.
+
+Every log line written through NestJS's `Logger` or the Winston logger automatically includes
+`timestamp` and the logger context (class name).
+
+### Request ID in logs
+
+`RequestIdMiddleware` (`src/common/middleware/request-id.middleware.ts`) runs before the JWT
+guard on every request. It:
+
+1. Reads `X-Request-ID` from the incoming request header, or generates a fresh UUID if absent.
+2. Sets `X-Request-ID` on the response.
+3. Stores the ID in `AsyncLocalStorage` (`requestIdStorage`).
+
+Services and interceptors can retrieve the current request ID from `requestIdStorage.getStore()`
+to include it in log lines, enabling full log-to-trace correlation without passing it through
+every function parameter.
+
+---
+
+## 4. Correlating a single request across logs, traces, and metrics
+
+Here is a worked example showing how one `POST /api/v1/shipments` request can be followed
+end-to-end:
+
+### Step 1 — the client sends a request ID
+
+```
+POST /api/v1/shipments HTTP/1.1
+Authorization: Bearer eyJ...
+X-Request-ID: 7f3c1a2b-84d4-4e0c-a1f7-b6d9e2c3f0a1
+Content-Type: application/json
+```
+
+If the client omits the header, `RequestIdMiddleware` generates a UUID and the same flow
+applies.
+
+### Step 2 — the backend echoes it on the response
+
+```
+HTTP/1.1 201 Created
+X-Request-ID: 7f3c1a2b-84d4-4e0c-a1f7-b6d9e2c3f0a1
+```
+
+### Step 3 — find the trace
+
+In Jaeger (or any OTLP-compatible UI), search for spans with attribute:
+
+```
+http.request_id = 7f3c1a2b-84d4-4e0c-a1f7-b6d9e2c3f0a1
+```
+
+The root span is the `POST /api/v1/shipments` HTTP span. Child spans include the Prisma
+`INSERT` query, any outgoing Stellar RPC calls, and IPFS pinning if triggered.
+
+### Step 4 — find the logs
+
+If you include the request ID in your log queries:
+
+```
+# Loki / Grafana LogQL
+{service="chainsettle-backend"} |= "7f3c1a2b-84d4-4e0c-a1f7-b6d9e2c3f0a1"
+
+# CloudWatch Logs Insights
+fields @timestamp, @message
+| filter @message like "7f3c1a2b-84d4-4e0c-a1f7-b6d9e2c3f0a1"
+| sort @timestamp asc
+```
+
+### Step 5 — find the metrics
+
+The `chainsettle_http_request_duration_seconds` histogram records the route
+(`/api/v1/shipments`), method, and status for every request. Combine the timestamp from the
+trace with a small time window in Prometheus/Grafana to see concurrent load and latency
+percentiles at the moment the traced request ran.
+
+---
+
+## Implementation references
+
+| Concern | Location |
+|---------|----------|
+| Prometheus metrics definitions | `src/common/metrics/metrics.service.ts` |
+| Prometheus module registration | `src/common/metrics/metrics.module.ts` |
+| HTTP request duration histogram | `src/common/interceptors/http-metrics.interceptor.ts` |
+| OTel SDK bootstrap | `src/common/tracing/tracing.ts` |
+| NestJS span enrichment interceptor | `src/common/tracing/tracing.interceptor.ts` |
+| Manual span helper | `src/common/tracing/trace.helper.ts` |
+| Winston logger factory | `src/common/logger/winston.logger.ts` |
+| Request ID middleware | `src/common/middleware/request-id.middleware.ts` |

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,130 @@
+# Rate Limiting
+
+ChainSettle applies rate limiting to all API routes via `@nestjs/throttler` backed by Redis
+(`src/common/throttler/redis-throttler-storage.service.ts`). Redis storage ensures limits are
+consistent across all running pods/instances — a user cannot bypass the limit by hitting a
+different server.
+
+The global throttler guard (`RateLimitThrottlerGuard`,
+`src/common/guards/rate-limit-throttler.guard.ts`) is applied as a global `APP_GUARD` in
+`AppModule`, so every route is covered unless it is explicitly overridden.
+
+---
+
+## Default limit (all routes not listed below)
+
+| Setting | Value | Environment variable |
+|---------|-------|----------------------|
+| Window | 60 seconds | `THROTTLE_TTL` (in seconds; default `60`) |
+| Max requests | 100 per key | `THROTTLE_LIMIT` (default `100`) |
+| Key | IP address | — |
+
+---
+
+## Per-route overrides
+
+The following endpoints use stricter limits defined with `@Throttle()` on the handler.
+Routes that also use `StellarAddressThrottlerGuard` are keyed by **Stellar address** rather
+than IP, so each wallet address has its own independent counter.
+
+| Endpoint | Window | Limit | Key | Notes |
+|----------|--------|-------|-----|-------|
+| `GET /api/v1/auth/nonce` | 60 s | 5 | Stellar address | Prevents nonce harvesting |
+| `POST /api/v1/auth/login` | 60 s | 10 | Stellar address | Prevents brute-force signature attempts |
+| `POST /api/v1/auth/resend-verification` | 60 s | 1 | Stellar address | One re-send per minute per address |
+| `POST /api/v1/shipments/:id/milestones/:index/proof` | 3600 s (1 hour) | 5 | Stellar address | Proof file uploads; 5 uploads per hour per user |
+| `GET /api/v1/shipments/export` | 3600 s (1 hour) | 5 | IP | CSV/PDF bulk export |
+| `GET /api/v1/shipments/:id/export` | 3600 s (1 hour) | 10 | IP | Single shipment PDF export |
+
+---
+
+## Authenticated vs. unauthenticated callers
+
+- **Unauthenticated routes** (`/auth/nonce`, `/auth/login`) key by Stellar address (passed as a
+  query parameter or in the request body). This means an attacker cannot exhaust another user's
+  limit from a different IP, but also cannot escape their own limit by rotating IPs.
+- **Authenticated routes** default to IP keying from the global throttler. Per-route overrides
+  on authenticated proof and export endpoints continue to use IP keying via the default throttler,
+  but proof submission also applies `StellarAddressThrottlerGuard` to additionally key by the
+  authenticated user's Stellar address.
+
+---
+
+## Response headers
+
+Every response from a rate-limited route includes the following headers (CORS-exposed so
+browser clients can read them):
+
+| Header | Present on | Meaning |
+|--------|-----------|---------|
+| `X-RateLimit-Limit` | All responses | Maximum requests allowed in the current window |
+| `X-RateLimit-Remaining` | All responses | Requests left in the window (`0` when rate limited) |
+| `X-RateLimit-Reset` | All responses | Seconds until the current window resets |
+| `Retry-After` | `429` responses only | Same value as `X-RateLimit-Reset` — how long to wait before retrying |
+
+When a route has a named throttler (anything other than `default`) the suffix
+`-<name>` is appended: e.g., `X-RateLimit-Limit-auth`.
+
+---
+
+## 429 response body
+
+When the limit is exceeded the `ThrottlerExceptionFilter` returns:
+
+```json
+{
+  "success": false,
+  "statusCode": 429,
+  "timestamp": "2026-08-28T19:00:00.000Z",
+  "path": "/api/v1/auth/nonce",
+  "message": "Too Many Requests"
+}
+```
+
+---
+
+## Self-throttling for API consumers
+
+Read `X-RateLimit-Remaining` on each response and slow down proactively before it reaches `0`.
+When it does reach `0` on a non-`429` response, the next request will be blocked. Use
+`X-RateLimit-Reset` (or `Retry-After` on a `429`) to know exactly how many seconds to wait.
+
+A minimal back-off loop in pseudocode:
+
+```
+remaining = response.headers['X-RateLimit-Remaining']
+if remaining == "0":
+    reset_in = response.headers['X-RateLimit-Reset']
+    sleep(reset_in)
+```
+
+---
+
+## Implementation references
+
+| Concern | Location |
+|---------|----------|
+| Redis storage adapter | `src/common/throttler/redis-throttler-storage.service.ts` |
+| Global throttler guard (sets headers) | `src/common/guards/rate-limit-throttler.guard.ts` |
+| Stellar-address keying guard | `src/common/guards/stellar-address-throttler.guard.ts` |
+| ThrottlerModule registration | `src/app.module.ts` |
+| Auth endpoint limits | `src/modules/auth/auth.controller.ts` |
+| Proof upload limit | `src/modules/milestones/milestones.controller.ts` |
+| Export limits | `src/modules/shipments/shipments.controller.ts` |
+
+---
+
+## Local verification
+
+Use the bundled shell script to test success responses and `429` behaviour against a running
+local API:
+
+```bash
+./test-rate-limit.sh
+```
+
+Expected outcomes:
+- `GET /auth/nonce` — requests 1–5 return `200` with `X-RateLimit-Remaining` counting down;
+  requests 6–7 return `429` with `Retry-After`.
+- `POST /auth/login` — first 10 requests return `401` (invalid signature, not rate-limited);
+  requests 11–12 return `429`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,238 @@
+# Testing
+
+This document explains every test category in the ChainSettle backend, how to run each one,
+what local services are required, and how CI executes them. A new contributor should be able
+to run all test categories locally by following this guide.
+
+---
+
+## Quick reference
+
+| Suite | Command | Needs DB | Needs Redis | Needs live Stellar |
+|-------|---------|----------|-------------|-------------------|
+| Unit tests | `npm run test` | No | No | No |
+| Unit tests + coverage | `npm run test:cov` | No | No | No |
+| Watch mode | `npm run test:watch` | No | No | No |
+| E2E tests | `npm run test:e2e` | Yes | Yes | No |
+| Pact contract tests | `npm run test:pact` (see below) | No | No | No |
+| Load tests | `npm run loadtest` | Yes | Yes | No* |
+| Rate-limit shell test | `./test-rate-limit.sh` | Yes | Yes | No |
+| Dispute-evidence shell test | `./test-dispute-evidence.sh` | Yes | Yes | No |
+
+\* Load tests call the API, which calls a real (or mocked) Stellar RPC. Set
+`STELLAR_RPC_URL=http://127.0.0.1:8787` and run `npm run dev:mock-chain` to avoid a live
+testnet dependency.
+
+---
+
+## 1. Unit tests
+
+**What they cover:** individual service methods and utility functions, with all external
+dependencies (`PrismaService`, `StellarService`, `RedisService`, etc.) mocked via Jest.
+Example: `src/modules/milestones/milestones.service.spec.ts`.
+
+**Command:**
+
+```bash
+npm run test
+```
+
+**Coverage report:**
+
+```bash
+npm run test:cov        # outputs to ./coverage/
+```
+
+**Watch mode (TDD):**
+
+```bash
+npm run test:watch
+```
+
+**Required setup:** none beyond a generated Prisma client.
+
+```bash
+# First time only (no database connection needed):
+npx prisma generate
+```
+
+The values in `.env.example` are sufficient as-is — unit tests mock all infrastructure.
+
+> **Known issue:** as of the current `main` branch, `npm run test` fails to compile
+> due to a pre-existing type mismatch in `shipments.service.ts` (missing `resourceId`
+> on `RecordAuditLogDto`). This is unrelated to your environment. Check open issues
+> before spending time debugging it.
+
+**Configuration:** Jest config lives inline in `package.json`. Test files follow the pattern
+`src/**/*.spec.ts`. Coverage is collected from all `src/**/*.ts` files.
+
+---
+
+## 2. End-to-end (E2E) tests
+
+**What they cover:** full request/response lifecycle through the running NestJS application.
+The test database is hit directly; no mocks are used for the DB layer. Primary file:
+`test/milestone-lifecycle.e2e-spec.ts`.
+
+**Required local services:**
+
+- PostgreSQL 15+ — connection string in `DATABASE_URL`
+- Redis — connection string in `REDIS_URL`
+
+**Setup:**
+
+```bash
+cp .env.example .env
+# Fill in: DATABASE_URL, JWT_SECRET, REDIS_URL, STELLAR_RPC_URL,
+#          STELLAR_HORIZON_URL, CHAINSETTTLE_CONTRACT_ID, USDC_TOKEN_ADDRESS,
+#          STELLAR_SECRET_KEY, SMTP_*
+
+npx prisma migrate dev --name init
+npx prisma generate
+```
+
+**Command:**
+
+```bash
+npm run test:e2e
+```
+
+**Configuration:** `test/jest-e2e.json` — matches `test/**/*.e2e-spec.ts`, same ts-jest
+transform as unit tests.
+
+---
+
+## 3. Pact contract tests (consumer-driven)
+
+**What they cover:** API contract between this backend (provider) and the frontend consumer.
+Pact files live under `test/pact/`. The provider setup (`test/pact/provider-setup.ts`) spins
+up the NestJS app and verifies recorded consumer interactions.
+
+**Files:**
+
+- `test/pact/auth.pact.spec.ts` — auth endpoint contracts
+- `test/pact/shipments.pact.spec.ts` — shipments endpoint contracts
+- `test/pact/provider-setup.ts` — provider verification harness
+- `test/pact/jest-pact.config.js` — separate Jest config for pact runs
+
+**Command:**
+
+```bash
+npx jest --config test/pact/jest-pact.config.js
+```
+
+**Required services:** none for consumer-side generation; a running application is needed for
+provider verification (see `provider-setup.ts`).
+
+---
+
+## 4. Load tests (k6)
+
+**What they cover:** throughput and latency under sustained load, with pass/fail thresholds.
+Scripts are in `load-tests/`:
+
+| Script | Scenario |
+|--------|---------|
+| `auth-login.js` | Sign-in flow (`GET /auth/nonce` + `POST /auth/login`) |
+| `shipments-list.js` | Paginated `GET /shipments` with a valid JWT |
+| `milestone-confirm.js` | `POST /shipments/:id/milestones/:index/confirm` write path |
+
+**Prerequisites:**
+
+- [k6](https://k6.io/docs/get-started/installation/) installed and on `PATH`
+- A running local API (`npm run start:dev`)
+- PostgreSQL, Redis, and (optionally) a mock Stellar chain
+
+**Commands:**
+
+```bash
+# Run all load-test scenarios:
+npm run loadtest
+# equivalent to: bash load-tests/run-all.sh
+
+# Run a single script directly:
+BASE_URL=http://localhost:3000 JWT_TOKEN=<token> k6 run load-tests/shipments-list.js
+
+# With a mock Stellar chain (avoids testnet):
+npm run dev:mock-chain &
+STELLAR_RPC_URL=http://127.0.0.1:8787 npm run start:dev &
+BASE_URL=http://localhost:3000 JWT_TOKEN=<token> npm run loadtest
+```
+
+`run-all.sh` will skip authenticated suites if `JWT_TOKEN` is not set, and skip
+`milestone-confirm.js` if `SHIPMENT_ID` is also not set.
+
+---
+
+## 5. Shell test scripts
+
+Two standalone Bash scripts exercise specific scenarios against a running local API.
+They require no test framework — just `curl` and `jq`.
+
+### `./test-rate-limit.sh`
+
+**Scenarios:**
+- Sends 7 successive `GET /auth/nonce` requests (limit is 5/min) and prints
+  `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` from each response.
+  Requests 6 and 7 should return `429` with `Retry-After`.
+- Sends 12 successive `POST /auth/login` requests (limit is 10/min). Requests 1–10 return
+  `401` (bad signature, not rate-limited); 11 and 12 return `429`.
+
+**Run:**
+
+```bash
+# API must be running on localhost:3000
+./test-rate-limit.sh
+```
+
+### `./test-dispute-evidence.sh`
+
+**Scenarios:**
+- Submit dispute evidence as buyer, supplier, arbiter, and logistics participant.
+- List evidence for a disputed milestone.
+- Attempt to submit as a non-participant (should receive `403`).
+
+**Prerequisites:**
+- A running API with a shipment in `DISPUTED` milestone status.
+- Valid JWTs for buyer, supplier, arbiter, and logistics — edit the token variables at the
+  top of the script.
+
+**Run:**
+
+```bash
+# Set BUYER_TOKEN, SUPPLIER_TOKEN, etc. at the top of the script, then:
+./test-dispute-evidence.sh
+```
+
+---
+
+## 6. CI
+
+CI runs the following matrix on every push and pull request:
+
+```
+1. npm run lint
+2. npm run test          # unit
+3. npm run test:e2e      # requires DB and Redis service containers
+```
+
+Load tests run on a separate weekly schedule via
+`.github/workflows/loadtest-weekly.yml` and are not part of the standard PR check.
+
+The SDK drift check (`npm run check:sdk`) is gated via `.github/workflows/sdk-drift.yml`.
+
+---
+
+## Mock Stellar RPC (frontend / integration dev)
+
+When you need the full API without a live testnet:
+
+```bash
+npm run dev:mock-chain
+# then in a separate terminal:
+STELLAR_RPC_URL=http://127.0.0.1:8787 STELLAR_HORIZON_URL=http://127.0.0.1:8788 npm run start:dev
+```
+
+The mock server is at `test/mocks/stellar-rpc-server.ts`. See
+[`test/mocks/README.md`](../test/mocks/README.md) for its limitations — it is for dev
+iteration only, not for validating real chain behaviour.


### PR DESCRIPTION
## Summary

Adds four documentation files that were missing from the repo, each
addressing a specific gap identified in the issue tracker.

---

### docs/rate-limiting.md
Documents the Redis-backed throttler configuration: per-endpoint-group
limits (window, max requests, key type), the difference between
IP-keyed and Stellar-address-keyed routes, all `X-RateLimit-*`
response headers and their meaning, the 429 response shape, and
self-throttling guidance for API consumers.

### docs/observability.md
Ties together the three observability pillars in one place:
- Prometheus `/metrics` — custom and default metrics, label names,
  starter Grafana panel queries
- OpenTelemetry tracing — opt-in via `OTEL_EXPORTER_OTLP_ENDPOINT`,
  auto-instrumented surfaces, local Jaeger setup
- Winston structured logging — formats, log levels, `X-Request-ID` via
  AsyncLocalStorage

Includes a worked end-to-end correlation example showing how to trace a
single request across logs, traces, and metrics using the request ID.

### docs/testing.md
Enumerates every test category with command, required services, and
setup steps a new contributor needs to run them locally:
unit tests, e2e tests, Pact contract tests, k6 load tests, and the two
standalone shell scripts (`test-rate-limit.sh`,
`test-dispute-evidence.sh`). Also documents CI execution.
Cross-linked from CONTRIBUTING.md.

### docs/glossary.md
Precise definitions of eight core domain terms (shipment, milestone,
arbiter, proof, dispute, escalation, reconciliation, reputation) as
used in this codebase, each linking to its implementing module.
Linked from README.md.

---

## Testing

All changes are documentation-only. No code was modified.
Verified that:
- each doc file is created at the correct path under `docs/`
- CONTRIBUTING.md cross-links to `docs/testing.md`
- README.md links to `docs/glossary.md`

## Type of Change

- [x] Documentation

closes #312
closes #313
closes #314
closes #315