### PR TITLE
Add admin arbiter endpoints and KYC requirements/withdrawal

### DIFF
--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -76,6 +76,10 @@ export const envValidationSchema = Joi.object({
   // both buyer and supplier to have a VERIFIED kycStatus.
   KYC_VALUE_THRESHOLD_STROOPS: Joi.string().default('1000000000000'), // 100,000 USDC at 7 decimals
 
+  // Shipments with totalAmount at or above this (higher) threshold require the
+  // "enhanced" KYC tier (additional documents) rather than the "basic" tier. See #285.
+  KYC_ENHANCED_VALUE_THRESHOLD_STROOPS: Joi.string().default('10000000000000'), // 1,000,000 USDC at 7 decimals
+
   // Signing key for calendar subscription tokens (#236). Rotating it revokes
   // every issued feed URL.
   CALENDAR_FEED_SECRET: Joi.string().allow('').default(''),

--- a/src/modules/arbiters/admin-arbiters.controller.ts
+++ b/src/modules/arbiters/admin-arbiters.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Get, Post, Param, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiParam, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { UserRole } from '@prisma/client';
+import { ArbitersService } from './arbiters.service';
+import { AddressParamDto } from './dto/address-param.dto';
+import { ListArbitersQueryDto } from './dto/list-arbiters-query.dto';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+
+/**
+ * Admin-only arbiter roster/reputation operations, kept separate from
+ * ArbitersController so routes live under /admin/arbiters/* rather than
+ * being nested under the participant-facing /arbiters/* prefix.
+ */
+@ApiTags('admin')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('admin/arbiters')
+export class AdminArbitersController {
+  constructor(private readonly arbitersService: ArbitersService) {}
+
+  /**
+   * GET /api/v1/admin/arbiters
+   * Registered before :address-style routes are ever added to this
+   * controller to avoid the literal segment being captured as a param.
+   */
+  @Get()
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: '[Admin] List every known arbiter with its cached reputation summary' })
+  @ApiResponse({ status: 200, description: 'Every distinct arbiter address ever assigned to a shipment, with reputation' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  async list(@Query() query: ListArbitersQueryDto) {
+    const addresses = await this.arbitersService.listKnownArbiterAddresses();
+    const arbiters = await Promise.all(
+      addresses.map((address) => this.arbitersService.getReputation(address)),
+    );
+
+    if (query.sortBy) {
+      const field = query.sortBy;
+      arbiters.sort((a, b) => (b[field] ?? 0) - (a[field] ?? 0));
+    }
+
+    return arbiters;
+  }
+
+  @Post(':address/reputation/recompute')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: "[Admin] Force an on-demand refresh of an arbiter's cached reputation" })
+  @ApiParam({ name: 'address', description: 'Stellar Ed25519 public key of the arbiter' })
+  @ApiResponse({ status: 200, description: 'Fresh reputation snapshot, now cached' })
+  @ApiResponse({ status: 403, description: 'Admin access required' })
+  recompute(@Param() params: AddressParamDto) {
+    return this.arbitersService.recompute(params.address);
+  }
+}

--- a/src/modules/arbiters/arbiters.module.ts
+++ b/src/modules/arbiters/arbiters.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ArbitersController } from './arbiters.controller';
+import { AdminArbitersController } from './admin-arbiters.controller';
 import { ArbitersService } from './arbiters.service';
 import { ArbiterReputationJob } from './arbiter-reputation.job';
 
 @Module({
-  controllers: [ArbitersController],
+  controllers: [ArbitersController, AdminArbitersController],
   providers: [ArbitersService, ArbiterReputationJob],
   exports: [ArbitersService],
 })

--- a/src/modules/arbiters/dto/list-arbiters-query.dto.ts
+++ b/src/modules/arbiters/dto/list-arbiters-query.dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional } from 'class-validator';
+
+const SORTABLE_FIELDS = ['disputesOpen', 'disputesHandled', 'averageResolutionTimeHours'] as const;
+export type ArbiterSortField = (typeof SORTABLE_FIELDS)[number];
+
+/** Query DTO for GET /admin/arbiters. */
+export class ListArbitersQueryDto {
+  @ApiPropertyOptional({
+    description: 'Sort arbiters by this reputation field, descending (default: no sorting)',
+    enum: SORTABLE_FIELDS,
+  })
+  @IsOptional()
+  @IsIn(SORTABLE_FIELDS)
+  sortBy?: ArbiterSortField;
+}

--- a/src/modules/kyc/dto/kyc-requirements-query.dto.ts
+++ b/src/modules/kyc/dto/kyc-requirements-query.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumberString, IsOptional } from 'class-validator';
+import { IsContractAddress } from '../../../common/decorators/is-contract-address.decorator';
+
+/** Query DTO for GET /kyc/requirements. */
+export class KycRequirementsQueryDto {
+  @ApiProperty({
+    description: 'Estimated shipment value, in the token\'s base units (stroops)',
+    example: '1000000000000',
+  })
+  @IsNumberString()
+  value: string;
+
+  @ApiPropertyOptional({
+    description: 'Soroban contract address of the settlement token (reserved for future per-token thresholds)',
+    example: 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA',
+  })
+  @IsOptional()
+  @IsContractAddress()
+  tokenAddress?: string;
+}

--- a/src/modules/kyc/kyc.controller.ts
+++ b/src/modules/kyc/kyc.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Get, Headers, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Delete, Get, Headers, HttpCode, HttpStatus, Param, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { KycService } from './kyc.service';
 import { KycWebhookDto } from './dto/kyc-webhook.dto';
+import { KycRequirementsQueryDto } from './dto/kyc-requirements-query.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { Public } from '../../common/decorators/public.decorator';
@@ -10,6 +11,14 @@ import { Public } from '../../common/decorators/public.decorator';
 @Controller('kyc')
 export class KycController {
   constructor(private readonly kycService: KycService) {}
+
+  @Get('requirements')
+  @Public()
+  @ApiOperation({ summary: 'Get the required KYC tier/documents for a given estimated shipment value' })
+  @ApiResponse({ status: 200, description: 'Required tier ("none" | "basic" | "enhanced") and document list' })
+  getRequirements(@Query() query: KycRequirementsQueryDto) {
+    return this.kycService.getRequirements(BigInt(query.value));
+  }
 
   @Post('initiate')
   @UseGuards(JwtAuthGuard)
@@ -42,5 +51,17 @@ export class KycController {
     @Headers('x-kyc-signature') signature?: string,
   ) {
     return this.kycService.handleWebhook(dto, signature);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Withdraw a still-pending KYC submission belonging to the authenticated user' })
+  @ApiParam({ name: 'id', description: 'The verification reference returned by POST /kyc/initiate' })
+  @ApiResponse({ status: 200, description: 'Submission withdrawn' })
+  @ApiResponse({ status: 404, description: 'No matching pending submission for this user' })
+  @ApiResponse({ status: 409, description: 'Submission has already been approved or rejected' })
+  withdraw(@Param('id') id: string, @CurrentUser('id') userId: string) {
+    return this.kycService.withdraw(userId, id);
   }
 }

--- a/src/modules/kyc/kyc.service.ts
+++ b/src/modules/kyc/kyc.service.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHmac, randomUUID } from 'crypto';
 import { KycStatus } from '@prisma/client';
@@ -6,10 +12,22 @@ import { PrismaService } from '../../common/prisma/prisma.service';
 import { AuditLogService } from '../audit-logs/audit-log.service';
 import { KycWebhookDto } from './dto/kyc-webhook.dto';
 
+export type KycTier = 'none' | 'basic' | 'enhanced';
+
+export interface KycRequirements {
+  tier: KycTier;
+  documents: string[];
+}
+
+const BASIC_TIER_DOCUMENTS = ['government_id', 'proof_of_address'];
+const ENHANCED_TIER_DOCUMENTS = [...BASIC_TIER_DOCUMENTS, 'proof_of_funds', 'enhanced_due_diligence'];
+
 @Injectable()
 export class KycService {
   private readonly logger = new Logger(KycService.name);
+  /** Source of truth for both `meetsThreshold()` and `getRequirements()` — see #285. */
   private readonly threshold: bigint;
+  private readonly enhancedThreshold: bigint;
   private readonly webhookSecret: string;
 
   constructor(
@@ -18,12 +36,29 @@ export class KycService {
     private readonly auditLog: AuditLogService,
   ) {
     this.threshold = BigInt(this.config.get<string>('KYC_VALUE_THRESHOLD_STROOPS', '1000000000000'));
+    this.enhancedThreshold = BigInt(
+      this.config.get<string>('KYC_ENHANCED_VALUE_THRESHOLD_STROOPS', '10000000000000'),
+    );
     this.webhookSecret = this.config.get<string>('KYC_WEBHOOK_SECRET', '');
   }
 
   /** Whether a shipment of this size requires both parties to be KYC-verified. */
   meetsThreshold(totalAmount: bigint): boolean {
-    return totalAmount >= this.threshold;
+    return this.getRequirements(totalAmount).tier !== 'none';
+  }
+
+  /**
+   * The KYC tier/documents required for a shipment of a given value, using
+   * the same thresholds `meetsThreshold()` gates shipment creation with.
+   */
+  getRequirements(value: bigint): KycRequirements {
+    if (value >= this.enhancedThreshold) {
+      return { tier: 'enhanced', documents: ENHANCED_TIER_DOCUMENTS };
+    }
+    if (value >= this.threshold) {
+      return { tier: 'basic', documents: BASIC_TIER_DOCUMENTS };
+    }
+    return { tier: 'none', documents: [] };
   }
 
   async isVerified(stellarAddress: string): Promise<boolean> {
@@ -115,5 +150,40 @@ export class KycService {
 
     this.logger.log(`KYC status for user ${user.id} updated to ${kycStatus} (reference ${dto.reference})`);
     return { message: 'KYC status updated' };
+  }
+
+  /**
+   * Withdraws a still-pending KYC submission, identified by the opaque
+   * `reference` handed back from `initiateVerification()`. Only the owning
+   * user may withdraw it, and only while it hasn't been decided yet. See #286.
+   */
+  async withdraw(userId: string, id: string): Promise<{ message: string }> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    if (!user.kycReference || user.kycReference !== id) {
+      throw new NotFoundException(`No KYC submission found with id "${id}"`);
+    }
+
+    if (user.kycStatus === KycStatus.VERIFIED || user.kycStatus === KycStatus.REJECTED) {
+      throw new ConflictException('This KYC submission has already been decided and can no longer be withdrawn');
+    }
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { kycStatus: KycStatus.UNVERIFIED, kycReference: null },
+    });
+
+    await this.auditLog.record({
+      actorId: userId,
+      actorAddress: user.stellarAddress,
+      action: 'KYC_VERIFICATION_WITHDRAWN',
+      resourceType: 'User',
+      resourceId: userId,
+      metadata: { reference: id },
+    });
+
+    this.logger.log(`KYC verification withdrawn for user ${userId} — reference ${id}`);
+    return { message: 'KYC submission withdrawn' };
   }
 }


### PR DESCRIPTION
## Summary
Implements four small, related API additions:

- **#283** `POST /admin/arbiters/:address/reputation/recompute` — on-demand reputation refresh for a single arbiter (admin-only), reusing `ArbitersService.recompute()`.
- **#284** `GET /admin/arbiters` — lists every arbiter ever assigned to a shipment with its cached reputation summary, with optional `sortBy` (`disputesOpen` | `disputesHandled` | `averageResolutionTimeHours`), descending.
- **#285** `GET /kyc/requirements?value=&tokenAddress=` — returns the required KYC tier (`none` | `basic` | `enhanced`) and document list for an estimated shipment value. Thresholds come from config (`KYC_VALUE_THRESHOLD_STROOPS`, new `KYC_ENHANCED_VALUE_THRESHOLD_STROOPS`) and `KycService.meetsThreshold()` now derives from the same `getRequirements()` logic, so both stay in sync.
- **#286** `DELETE /kyc/:id` — lets the owning user withdraw a still-pending KYC submission (`id` is the opaque reference from `POST /kyc/initiate`). Returns 409 if already decided, 404 if not found/not owned, and clears `kycStatus`/`kycReference` so a fresh `POST /kyc/initiate` can follow.

## Notes
- New admin routes live in a separate `AdminArbitersController` (`admin/arbiters/*`), mirroring the existing `AdminShipmentsController`/`AdminUsersController` pattern — admin-gated via the global `RolesGuard` + `@Roles(UserRole.ADMIN)`.
- No schema changes: KYC state continues to live on `User.kycStatus` / `User.kycReference` as it already did.
- Per instructions, tests were skipped for this change.

Closes #283
Closes #284
Closes #285
Closes #286