### PR TITLE
Audit log by ID, arbiter history, bulk-reject milestones, automated DB backups

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,53 @@
+name: Database backup
+
+# Scheduled encrypted pg_dump of the production database to S3-compatible
+# object storage, with automatic pruning per the retention policy documented
+# in docs/deployment.md. See scripts/db-backup.sh / db-prune-backups.sh.
+
+on:
+  schedule:
+    # Daily at 03:30 UTC (after the shipment-archival job at 03:00, see
+    # ShipmentArchivalJob), so the backup captures the post-archival state.
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        if: ${{ secrets.BACKUP_S3_BUCKET != '' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.BACKUP_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BACKUP_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.BACKUP_AWS_REGION || 'us-east-1' }}
+
+      - name: Install postgresql-client and gnupg
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client gnupg
+
+      - name: Run backup
+        if: ${{ secrets.BACKUP_S3_BUCKET != '' }}
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          BACKUP_S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET }}
+          BACKUP_S3_ENDPOINT_URL: ${{ secrets.BACKUP_S3_ENDPOINT_URL }}
+          BACKUP_GPG_PASSPHRASE: ${{ secrets.BACKUP_GPG_PASSPHRASE }}
+        run: ./scripts/db-backup.sh
+
+      - name: Prune old backups
+        if: ${{ secrets.BACKUP_S3_BUCKET != '' }}
+        env:
+          BACKUP_S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET }}
+          BACKUP_S3_ENDPOINT_URL: ${{ secrets.BACKUP_S3_ENDPOINT_URL }}
+          BACKUP_RETENTION_DAILY_DAYS: ${{ vars.BACKUP_RETENTION_DAILY_DAYS }}
+          BACKUP_RETENTION_WEEKLY_DAYS: ${{ vars.BACKUP_RETENTION_WEEKLY_DAYS }}
+        run: ./scripts/db-prune-backups.sh
+
+      - name: Skip (secrets not configured)
+        if: ${{ secrets.BACKUP_S3_BUCKET == '' }}
+        run: echo "BACKUP_S3_BUCKET secret not set — skipping backup"

--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ npm run sbom
 - [ ] Persist `lastProcessedLedger` in DB (not memory) for crash recovery
 - [ ] Enable HTTPS (reverse proxy — nginx or Caddy)
 - [ ] Set up Prisma connection pooling (PgBouncer)
+- [ ] Configure `BACKUP_S3_BUCKET` + related secrets for automated encrypted DB backups (`.github/workflows/db-backup.yml` — see `docs/deployment.md`)
 - [ ] Optionally set `DATABASE_REPLICA_URL` for read-heavy GET offload (see `docs/deployment.md`)
 - [ ] Wire up real Stellar `Keypair.verify()` in `auth.service.ts`
 - [ ] Set `CORS_ORIGIN` to your production frontend URL

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,6 +66,45 @@ shipments older than `SHIPMENT_ARCHIVAL_DAYS` (default 90) into
 - Cold archive retrieval: `GET /api/v1/shipments/archived` and
   `GET /api/v1/shipments/archived/:id` (full history snapshot in `payload`)
 
+## Automated database backups
+
+`.github/workflows/db-backup.yml` runs daily at 03:30 UTC (after the shipment
+archival job) via `scripts/db-backup.sh`:
+
+1. `pg_dump` the database (`DATABASE_URL`), gzip it.
+2. Encrypt the dump with GPG (AES256 symmetric, `BACKUP_GPG_PASSPHRASE`).
+3. Upload to `s3://<BACKUP_S3_BUCKET>/backups/daily/chainsettle-<UTC timestamp>.sql.gz.gpg`.
+4. On Sundays, also upload the same file under `backups/weekly/`.
+
+**Retention policy** (enforced by `scripts/db-prune-backups.sh`, run right
+after the backup step):
+
+| Prefix | Retention | Env var |
+|--------|-----------|---------|
+| `backups/daily/` | 30 days (default) | `BACKUP_RETENTION_DAILY_DAYS` |
+| `backups/weekly/` | 182 days / ~6 months (default) | `BACKUP_RETENTION_WEEKLY_DAYS` |
+
+Objects older than their prefix's retention window are deleted based on the
+timestamp encoded in the object key.
+
+### Restoring from a backup
+
+```bash
+# 1. Download the encrypted dump
+aws s3 cp s3://<BACKUP_S3_BUCKET>/backups/daily/chainsettle-<timestamp>.sql.gz.gpg .
+
+# 2. Decrypt
+gpg --batch --yes --passphrase "$BACKUP_GPG_PASSPHRASE" \
+  --output chainsettle-<timestamp>.sql.gz \
+  --decrypt chainsettle-<timestamp>.sql.gz.gpg
+
+# 3. Decompress and restore into a target database
+gunzip -c chainsettle-<timestamp>.sql.gz | psql "$TARGET_DATABASE_URL"
+```
+
+Restore into a scratch database first and verify row counts / spot-check
+recent rows before pointing production traffic at it.
+
 ## Required secrets / variables
 
 | Name | Purpose |
@@ -76,6 +115,10 @@ shipments older than `SHIPMENT_ARCHIVAL_DAYS` (default 90) into
 | `DEPLOY_PATH` | App root on the host (contains `docker-compose.yml` or process manager config) |
 | `HEALTHCHECK_URL` | e.g. `https://staging.example.com/api/v1/health/ready` |
 | `ACTIVE_SLOT_URL` / `PREVIEW_SLOT_URL` | Optional per-slot health URLs during cutover |
+| `BACKUP_S3_BUCKET` | Destination bucket for `db-backup.yml`, e.g. `s3://my-backups` (unset = job skips) |
+| `BACKUP_S3_ENDPOINT_URL` | Optional, for S3-compatible providers (R2, MinIO, Spaces) |
+| `BACKUP_AWS_ACCESS_KEY_ID` / `BACKUP_AWS_SECRET_ACCESS_KEY` / `BACKUP_AWS_REGION` | Credentials for the backup bucket |
+| `BACKUP_GPG_PASSPHRASE` | Symmetric encryption passphrase for backup dumps |
 
 ## Manual cutover checklist
 

--- a/scripts/db-backup.sh
+++ b/scripts/db-backup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Dumps the ChainSettle PostgreSQL database, encrypts it with GPG (symmetric,
+# AES256), and uploads it to an S3-compatible bucket for disaster recovery.
+#
+# Every run uploads to backups/daily/. On Sundays (UTC) it additionally
+# uploads the same encrypted dump to backups/weekly/, so the prune script
+# (db-prune-backups.sh) can apply a longer retention window to weekly copies.
+#
+# Required env vars:
+#   DATABASE_URL        - source Postgres connection string (pg_dump reads this)
+#   BACKUP_S3_BUCKET     - destination bucket, e.g. s3://my-backups
+#   BACKUP_GPG_PASSPHRASE - symmetric encryption passphrase
+# Optional:
+#   BACKUP_S3_ENDPOINT_URL - set for S3-compatible providers (R2, MinIO, Spaces)
+#
+# Usage: ./scripts/db-backup.sh
+set -euo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL is required}"
+: "${BACKUP_S3_BUCKET:?BACKUP_S3_BUCKET is required}"
+: "${BACKUP_GPG_PASSPHRASE:?BACKUP_GPG_PASSPHRASE is required}"
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+DAY_OF_WEEK="$(date -u +%u)" # 1=Monday .. 7=Sunday
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+DUMP_FILE="$WORKDIR/chainsettle-${TIMESTAMP}.sql.gz"
+ENCRYPTED_FILE="${DUMP_FILE}.gpg"
+
+echo "==> Dumping database..."
+pg_dump --format=plain --no-owner --no-privileges "$DATABASE_URL" | gzip -9 > "$DUMP_FILE"
+
+echo "==> Encrypting dump..."
+gpg --batch --yes --symmetric --cipher-algo AES256 \
+  --passphrase "$BACKUP_GPG_PASSPHRASE" \
+  --output "$ENCRYPTED_FILE" "$DUMP_FILE"
+
+S3_ARGS=()
+if [ -n "${BACKUP_S3_ENDPOINT_URL:-}" ]; then
+  S3_ARGS+=(--endpoint-url "$BACKUP_S3_ENDPOINT_URL")
+fi
+
+DEST_KEY="chainsettle-${TIMESTAMP}.sql.gz.gpg"
+
+echo "==> Uploading to ${BACKUP_S3_BUCKET}/backups/daily/${DEST_KEY}"
+aws s3 cp "${S3_ARGS[@]}" "$ENCRYPTED_FILE" "${BACKUP_S3_BUCKET}/backups/daily/${DEST_KEY}"
+
+if [ "$DAY_OF_WEEK" = "7" ]; then
+  echo "==> Sunday — also uploading to ${BACKUP_S3_BUCKET}/backups/weekly/${DEST_KEY}"
+  aws s3 cp "${S3_ARGS[@]}" "$ENCRYPTED_FILE" "${BACKUP_S3_BUCKET}/backups/weekly/${DEST_KEY}"
+fi
+
+echo "==> Backup complete: ${DEST_KEY}"

--- a/scripts/db-prune-backups.sh
+++ b/scripts/db-prune-backups.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Prunes database backups older than the configured retention policy:
+#   - backups/daily/  : keep BACKUP_RETENTION_DAILY_DAYS days   (default 30)
+#   - backups/weekly/ : keep BACKUP_RETENTION_WEEKLY_DAYS days  (default 182, ~6 months)
+#
+# Backup object keys are named chainsettle-<ISO8601 UTC timestamp>.sql.gz.gpg
+# (see db-backup.sh), so the cutoff is applied by parsing that timestamp out
+# of each key rather than relying on S3 object metadata.
+#
+# Required env vars:
+#   BACKUP_S3_BUCKET - bucket the backups live in, e.g. s3://my-backups
+# Optional:
+#   BACKUP_S3_ENDPOINT_URL     - set for S3-compatible providers (R2, MinIO, Spaces)
+#   BACKUP_RETENTION_DAILY_DAYS
+#   BACKUP_RETENTION_WEEKLY_DAYS
+#
+# Usage: ./scripts/db-prune-backups.sh
+set -euo pipefail
+
+: "${BACKUP_S3_BUCKET:?BACKUP_S3_BUCKET is required}"
+DAILY_RETENTION_DAYS="${BACKUP_RETENTION_DAILY_DAYS:-30}"
+WEEKLY_RETENTION_DAYS="${BACKUP_RETENTION_WEEKLY_DAYS:-182}"
+
+S3_ARGS=()
+if [ -n "${BACKUP_S3_ENDPOINT_URL:-}" ]; then
+  S3_ARGS+=(--endpoint-url "$BACKUP_S3_ENDPOINT_URL")
+fi
+
+# prune_prefix <prefix> <retention_days>
+prune_prefix() {
+  local prefix="$1"
+  local retention_days="$2"
+  local cutoff_epoch
+  cutoff_epoch="$(date -u -d "-${retention_days} days" +%s)"
+
+  echo "==> Pruning ${BACKUP_S3_BUCKET}/${prefix} older than ${retention_days} days"
+
+  aws s3 ls "${S3_ARGS[@]}" "${BACKUP_S3_BUCKET}/${prefix}" | awk '{print $NF}' | while read -r key; do
+    [ -z "$key" ] && continue
+    # key: chainsettle-2026-08-01T03-00-00Z.sql.gz.gpg
+    ts_part="${key#chainsettle-}"
+    ts_part="${ts_part%%.sql.gz.gpg}"
+    iso_ts="$(echo "$ts_part" | sed -E 's/^([0-9-]+)T([0-9]{2})-([0-9]{2})-([0-9]{2})Z$/\1T\2:\3:\4Z/')"
+    key_epoch="$(date -u -d "$iso_ts" +%s 2>/dev/null || echo "")"
+
+    if [ -z "$key_epoch" ]; then
+      echo "    skip (unparseable key): $key"
+      continue
+    fi
+
+    if [ "$key_epoch" -lt "$cutoff_epoch" ]; then
+      echo "    delete: $key"
+      aws s3 rm "${S3_ARGS[@]}" "${BACKUP_S3_BUCKET}/${prefix}${key}"
+    fi
+  done
+}
+
+prune_prefix "backups/daily/" "$DAILY_RETENTION_DAYS"
+prune_prefix "backups/weekly/" "$WEEKLY_RETENTION_DAYS"
+
+echo "==> Prune complete"

--- a/src/modules/arbiters/arbiters.controller.ts
+++ b/src/modules/arbiters/arbiters.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ArbitersService } from './arbiters.service';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { AddressParamDto } from './dto/address-param.dto';
@@ -17,5 +17,19 @@ export class ArbitersController {
   @ApiResponse({ status: 200, description: 'Reputation summary (neutral/empty when the arbiter has no history)' })
   getReputation(@Param() params: AddressParamDto) {
     return this.arbitersService.getReputation(params.address);
+  }
+
+  @Get(':address/history')
+  @ApiOperation({ summary: "Get an arbiter's paginated dispute-resolution history" })
+  @ApiParam({ name: 'address', description: 'Stellar Ed25519 public key of the arbiter' })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (default 1)' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page (default 20)' })
+  @ApiResponse({ status: 200, description: 'Paginated dispute history (empty page when the arbiter has no history)' })
+  getHistory(
+    @Param() params: AddressParamDto,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+  ) {
+    return this.arbitersService.getHistory(params.address, page, limit);
   }
 }

--- a/src/modules/arbiters/arbiters.service.ts
+++ b/src/modules/arbiters/arbiters.service.ts
@@ -43,6 +43,52 @@ export class ArbitersService {
     return reputation;
   }
 
+  /**
+   * Paginated list of the individual disputes underlying an arbiter's
+   * reputation summary (see computeReputation) — no aggregation, sorted by
+   * most recently resolved/escalated first. An arbiter with no history
+   * returns an empty page rather than an error.
+   */
+  async getHistory(arbiterAddress: string, page = 1, limit = 20) {
+    const where = {
+      shipment: { arbiterAddress },
+      status: { in: [MilestoneStatus.DISPUTED, MilestoneStatus.RESOLVED] },
+    };
+
+    const [milestones, total] = await this.prisma.$transaction([
+      this.prisma.milestone.findMany({
+        where,
+        select: {
+          shipmentId: true,
+          milestoneIndex: true,
+          status: true,
+          disputeEscalatedAt: true,
+          confirmedAt: true,
+        },
+        orderBy: { updatedAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      this.prisma.milestone.count({ where }),
+    ]);
+
+    return {
+      data: milestones.map((m) => ({
+        shipmentId: m.shipmentId,
+        milestoneIndex: m.milestoneIndex,
+        status: m.status,
+        escalatedAt: m.disputeEscalatedAt,
+        resolvedAt: m.status === MilestoneStatus.RESOLVED ? m.confirmedAt : null,
+      })),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
   /** All distinct arbiter addresses that have ever been assigned to a shipment. */
   async listKnownArbiterAddresses(): Promise<string[]> {
     const rows = await this.prisma.shipment.findMany({

--- a/src/modules/audit-logs/audit-log.service.ts
+++ b/src/modules/audit-logs/audit-log.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../common/prisma/prisma.service';
 import { buildCsvFromRows } from '../../common/utils/csv.util';
 
@@ -190,6 +190,32 @@ export class AuditLogService {
         createdAt: row.createdAt?.toISOString?.() ?? '',
       })),
     );
+  }
+
+  /**
+   * Fetch a single audit log entry by its own ID.
+   * Throws NotFoundException when the ID does not exist.
+   */
+  async findOne(id: string) {
+    const entry = await this.prisma.auditLog.findUnique({
+      where: { id },
+      include: {
+        user: {
+          select: {
+            id: true,
+            stellarAddress: true,
+            name: true,
+            role: true,
+          },
+        },
+      },
+    });
+
+    if (!entry) {
+      throw new NotFoundException(`Audit log entry ${id} not found`);
+    }
+
+    return entry;
   }
 
   /**

--- a/src/modules/audit-logs/audit-logs.controller.ts
+++ b/src/modules/audit-logs/audit-logs.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Param,
   Query,
   Res,
   UseGuards,
@@ -11,6 +12,7 @@ import {
   ApiResponse,
   ApiBearerAuth,
   ApiQuery,
+  ApiParam,
 } from '@nestjs/swagger';
 import { Response } from 'express';
 import { UserRole } from '@prisma/client';
@@ -106,5 +108,22 @@ export class AuditLogsController {
   @ApiResponse({ status: 403, description: 'Not authorized (admin only)' })
   async findByResource() {
     return { message: 'Use GET /admin/audit-logs with filters instead' };
+  }
+
+  /**
+   * GET /api/v1/admin/audit-logs/:id
+   * Fetch a single audit log entry by its own ID.
+   * Declared last so it doesn't swallow the more specific 'export' and
+   * 'resource/:resourceType/:resourceId' routes above.
+   */
+  @Get(':id')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Get a single audit log entry by ID (admin only)' })
+  @ApiParam({ name: 'id', description: 'Audit log entry ID' })
+  @ApiResponse({ status: 200, description: 'Audit log entry retrieved' })
+  @ApiResponse({ status: 403, description: 'Not authorized (admin only)' })
+  @ApiResponse({ status: 404, description: 'Audit log entry not found' })
+  async findOne(@Param('id') id: string) {
+    return this.auditLogService.findOne(id);
   }
 }

--- a/src/modules/milestones/dto/bulk-reject-milestones.dto.ts
+++ b/src/modules/milestones/dto/bulk-reject-milestones.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class BulkRejectMilestonesDto {
+  @ApiProperty({
+    type: [Number],
+    description: 'Zero-based milestone indices to reject (1–20, no duplicates)',
+    example: [0, 1],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(20)
+  @ArrayUnique()
+  @IsInt({ each: true })
+  @Min(0, { each: true })
+  indices: number[];
+
+  @ApiProperty({ description: 'Reason sent to each affected supplier explaining the rejection' })
+  @IsString()
+  @IsNotEmpty()
+  reason: string;
+}

--- a/src/modules/milestones/milestones.controller.ts
+++ b/src/modules/milestones/milestones.controller.ts
@@ -34,6 +34,7 @@ import { MilestonesService } from './milestones.service';
 import { AppendMilestoneDto } from './dto/append-milestone.dto';
 import { ConfirmMilestoneDto } from './dto/confirm-milestone.dto';
 import { BulkConfirmMilestonesDto } from './dto/bulk-confirm-milestones.dto';
+import { BulkRejectMilestonesDto } from './dto/bulk-reject-milestones.dto';
 import { RebalanceMilestonesDto } from './dto/rebalance-milestones.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
@@ -303,6 +304,29 @@ export class MilestonesController {
       dto.txHash,
       dto.paymentReleased,
     );
+  }
+
+  /**
+   * POST /api/v1/shipments/:shipmentId/milestones/bulk-reject
+   * Batch-reject multiple submitted proofs in one request (buyer only).
+   * Validates each index independently and returns a per-index result so
+   * partial failures (e.g. one milestone not in PROOF_SUBMITTED) don't fail
+   * the whole batch.
+   */
+  @Post('bulk-reject')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(ShipmentParticipantGuard)
+  @ApiOperation({ summary: 'Batch-reject multiple submitted proofs (buyer only)' })
+  @ApiResponse({ status: 200, description: 'Per-index results for the batch' })
+  @ApiResponse({ status: 403, description: 'Only the buyer may reject proofs' })
+  @ApiResponse({ status: 404, description: 'Shipment not found' })
+  bulkReject(
+    @Param('shipmentId') shipmentId: string,
+    @Body() dto: BulkRejectMilestonesDto,
+    @CurrentUser() user: any,
+  ) {
+    const callerAddress: string = user?.stellarAddress ?? user?.sub;
+    return this.milestonesService.bulkRejectFromApi(shipmentId, callerAddress, dto.indices, dto.reason);
   }
 
   /**

--- a/src/modules/milestones/milestones.service.ts
+++ b/src/modules/milestones/milestones.service.ts
@@ -820,6 +820,118 @@ export class MilestonesService {
     return updated;
   }
 
+  /**
+   * Batch-reject multiple submitted proofs in one request.
+   * Validates each index independently (same rule as rejectProof: must be
+   * PROOF_SUBMITTED) and returns per-index success/failure so partial
+   * failures are visible instead of failing the whole batch.
+   */
+  async bulkRejectFromApi(
+    shipmentId: string,
+    buyerAddress: string,
+    indices: number[],
+    reason: string,
+  ) {
+    const shipment = await this.prisma.shipment.findUnique({
+      where: { id: shipmentId },
+      include: { milestones: true },
+    });
+
+    if (!shipment) {
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    }
+
+    if (shipment.buyerAddress !== buyerAddress) {
+      throw new ForbiddenException('Only the shipment buyer may reject a proof');
+    }
+
+    const byIndex = new Map(shipment.milestones.map((m) => [m.milestoneIndex, m]));
+    const results: Array<{
+      milestoneIndex: number;
+      success: boolean;
+      milestone?: unknown;
+      error?: string;
+    }> = [];
+    const toReject: number[] = [];
+
+    for (const milestoneIndex of indices) {
+      const milestone = byIndex.get(milestoneIndex);
+      if (!milestone) {
+        results.push({
+          milestoneIndex,
+          success: false,
+          error: `Milestone ${milestoneIndex} not found on shipment ${shipmentId}`,
+        });
+        continue;
+      }
+      if (milestone.status !== MilestoneStatus.PROOF_SUBMITTED) {
+        results.push({
+          milestoneIndex,
+          success: false,
+          error: `Milestone ${milestoneIndex} must be in PROOF_SUBMITTED status to reject (currently ${milestone.status})`,
+        });
+        continue;
+      }
+      toReject.push(milestoneIndex);
+    }
+
+    const updatedByIndex = new Map<number, unknown>();
+
+    if (toReject.length > 0) {
+      const updated = await this.prisma.$transaction(
+        toReject.map((milestoneIndex) =>
+          this.prisma.milestone.update({
+            where: { shipmentId_milestoneIndex: { shipmentId, milestoneIndex } },
+            data: { status: MilestoneStatus.PENDING, proofHash: null },
+          }),
+        ),
+      );
+
+      updated.forEach((m, i) => {
+        updatedByIndex.set(toReject[i], m);
+      });
+
+      for (const milestoneIndex of toReject) {
+        const milestone = byIndex.get(milestoneIndex)!;
+        await this.notifications.notifyUser(
+          shipment.supplierAddress,
+          NotificationType.PROOF_REJECTED,
+          'Proof rejected — resubmission requested',
+          `Your proof for milestone ${milestoneIndex} ("${milestone.name}") on shipment ${shipmentId} was rejected. Reason: ${reason}`,
+          { shipmentId, milestoneIndex, reason },
+        );
+        results.push({
+          milestoneIndex,
+          success: true,
+          milestone: updatedByIndex.get(milestoneIndex),
+        });
+      }
+
+      this.logger.log(
+        `Bulk proof rejection on ${shipmentId} by buyer ${buyerAddress}: indices [${toReject.join(', ')}]`,
+      );
+    }
+
+    // Preserve request order in the response
+    const resultByIndex = new Map(results.map((r) => [r.milestoneIndex, r]));
+    return {
+      shipmentId,
+      results: indices.map(
+        (milestoneIndex) =>
+          resultByIndex.get(milestoneIndex) ?? {
+            milestoneIndex,
+            success: false,
+            error: 'Unknown error',
+          },
+      ),
+      summary: {
+        total: indices.length,
+        succeeded: toReject.length,
+        failed: indices.length - toReject.length,
+      },
+    };
+  }
+
   // ----------------------------------------------------------
   // PROOF HISTORY — immutable audit trail of all proof submissions
   // ----------------------------------------------------------


### PR DESCRIPTION
Closes #241, closes #280, closes #281, closes #282

## Summary

- **#280** — `GET /admin/audit-logs/:id`: fetch a single audit log entry by ID, admin-only, 404 when missing.
- **#282** — `GET /arbiters/:address/history?page=&limit=`: paginated list of the individual disputes underlying `computeReputation()`, sorted by most recently updated (resolved/escalated) first, empty page when no history.
- **#281** — `POST /shipments/:id/milestones/bulk-reject` (`{ indices, reason }`): batch-rejects submitted proofs, reusing the same per-milestone validation as the single-reject path (must be `PROOF_SUBMITTED`, buyer only), returns per-index success/error results, notifies each affected supplier.
- **#241** — Scheduled GitHub Actions workflow (`.github/workflows/db-backup.yml`, daily 03:30 UTC) runs `scripts/db-backup.sh` to `pg_dump`, gzip, GPG-encrypt, and upload to S3-compatible storage (`backups/daily/`, plus `backups/weekly/` on Sundays); `scripts/db-prune-backups.sh` prunes past the configured retention (30d daily / 182d weekly by default). Restore steps and required secrets documented in `docs/deployment.md`.

## Notes

- Tests were intentionally skipped for this batch per request.
- `npx tsc --noEmit` shows no new errors introduced by this change (verified against a pre-existing baseline of unrelated compile errors already on `main`, mostly stale generated types/spec files).