### PR TITLE
feat: template mine/visibility endpoints, webhook failed-deliveries/bulk-test

### DIFF
--- a/src/modules/shipment-templates/dto/create-shipment-template.dto.ts
+++ b/src/modules/shipment-templates/dto/create-shipment-template.dto.ts
@@ -118,3 +118,9 @@ export class UpdateShipmentTemplateDto {
   @IsBoolean()
   isPublic?: boolean;
 }
+
+export class UpdateTemplateVisibilityDto {
+  @ApiProperty({ example: true, description: 'Whether the template should be visible to all users' })
+  @IsBoolean()
+  isPublic: boolean;
+}

--- a/src/modules/shipment-templates/shipment-templates.controller.ts
+++ b/src/modules/shipment-templates/shipment-templates.controller.ts
@@ -19,7 +19,11 @@ import {
   ApiQuery,
 } from '@nestjs/swagger';
 import { ShipmentTemplatesService } from './shipment-templates.service';
-import { CreateShipmentTemplateDto, UpdateShipmentTemplateDto } from './dto/create-shipment-template.dto';
+import {
+  CreateShipmentTemplateDto,
+  UpdateShipmentTemplateDto,
+  UpdateTemplateVisibilityDto,
+} from './dto/create-shipment-template.dto';
 import { CreateTemplateFromShipmentDto } from './dto/create-template-from-shipment.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
@@ -70,6 +74,18 @@ export class ShipmentTemplatesController {
     return this.templatesService.findAll(user.id, page, limit);
   }
 
+  @Get('mine')
+  @ApiOperation({ summary: "List the authenticated user's own templates (public + private)" })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  findMine(
+    @CurrentUser() user: any,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+  ) {
+    return this.templatesService.findMine(user.id, page, limit);
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get a template by ID' })
   @ApiResponse({ status: 200, description: 'Template found' })
@@ -99,6 +115,20 @@ export class ShipmentTemplatesController {
     @CurrentUser() user: any,
   ) {
     return this.templatesService.update(id, user.id, dto);
+  }
+
+  @Patch(':id/visibility')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Toggle a template public/private (owner only)' })
+  @ApiResponse({ status: 200, description: 'Visibility updated successfully' })
+  @ApiResponse({ status: 403, description: 'Only owner can change visibility' })
+  @ApiResponse({ status: 404, description: 'Template not found' })
+  updateVisibility(
+    @Param('id') id: string,
+    @Body() dto: UpdateTemplateVisibilityDto,
+    @CurrentUser() user: any,
+  ) {
+    return this.templatesService.updateVisibility(id, user.id, user.stellarAddress, dto);
   }
 
   @Delete(':id')

--- a/src/modules/shipment-templates/shipment-templates.module.ts
+++ b/src/modules/shipment-templates/shipment-templates.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ShipmentTemplatesController } from './shipment-templates.controller';
 import { ShipmentTemplatesService } from './shipment-templates.service';
+import { AuditLogsModule } from '../audit-logs/audit-logs.module';
 
 @Module({
+  imports: [AuditLogsModule],
   controllers: [ShipmentTemplatesController],
   providers: [ShipmentTemplatesService],
   exports: [ShipmentTemplatesService],

--- a/src/modules/shipment-templates/shipment-templates.service.ts
+++ b/src/modules/shipment-templates/shipment-templates.service.ts
@@ -5,12 +5,20 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from '../../common/prisma/prisma.service';
-import { CreateShipmentTemplateDto, UpdateShipmentTemplateDto } from './dto/create-shipment-template.dto';
+import { AuditLogService } from '../audit-logs/audit-log.service';
+import {
+  CreateShipmentTemplateDto,
+  UpdateShipmentTemplateDto,
+  UpdateTemplateVisibilityDto,
+} from './dto/create-shipment-template.dto';
 import { CreateTemplateFromShipmentDto } from './dto/create-template-from-shipment.dto';
 
 @Injectable()
 export class ShipmentTemplatesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditLog: AuditLogService,
+  ) {}
 
   async create(dto: CreateShipmentTemplateDto, ownerId: string) {
     this.validateMilestonePercentages(dto.milestoneTemplates);
@@ -57,6 +65,34 @@ export class ShipmentTemplatesService {
           ],
         },
       }),
+    ]);
+
+    return {
+      data: templates,
+      pagination: {
+        page,
+        limit,
+        total,
+        pages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async findMine(
+    ownerId: string,
+    page: number = 1,
+    limit: number = 20,
+  ) {
+    const skip = (page - 1) * limit;
+
+    const [templates, total] = await Promise.all([
+      this.prisma.shipmentTemplate.findMany({
+        where: { ownerId },
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.shipmentTemplate.count({ where: { ownerId } }),
     ]);
 
     return {
@@ -190,6 +226,35 @@ export class ShipmentTemplatesService {
         isPublic: dto.isPublic,
       },
     });
+  }
+
+  async updateVisibility(
+    id: string,
+    ownerId: string,
+    actorAddress: string,
+    dto: UpdateTemplateVisibilityDto,
+  ) {
+    const template = await this.findOne(id);
+
+    if (template.ownerId !== ownerId) {
+      throw new ForbiddenException('Only the template owner can change its visibility');
+    }
+
+    const updated = await this.prisma.shipmentTemplate.update({
+      where: { id },
+      data: { isPublic: dto.isPublic },
+    });
+
+    await this.auditLog.record({
+      actorId: ownerId,
+      actorAddress: actorAddress ?? 'unknown',
+      action: 'SHIPMENT_TEMPLATE_VISIBILITY_CHANGED',
+      resourceType: 'ShipmentTemplate',
+      resourceId: id,
+      metadata: { isPublic: dto.isPublic },
+    });
+
+    return updated;
   }
 
   async delete(id: string, ownerId: string) {

--- a/src/modules/webhooks/webhooks.controller.ts
+++ b/src/modules/webhooks/webhooks.controller.ts
@@ -5,6 +5,7 @@ import {
   Delete,
   Body,
   Param,
+  Query,
   UseGuards,
   HttpCode,
   HttpStatus,
@@ -15,6 +16,7 @@ import {
   ApiBearerAuth,
   ApiResponse,
   ApiProperty,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { NotificationType } from '@prisma/client';
 import { WebhooksService } from './webhooks.service';
@@ -107,6 +109,20 @@ export class WebhooksController {
     return this.webhooksService.findForUser(userId);
   }
 
+  @Post('bulk-test')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: "Send a test ping to every active webhook owned by the caller",
+    description:
+      'Fans out a test ping to all active endpoints. Returns a per-endpoint ' +
+      'result (success/failure + latency) — an unreachable endpoint does not ' +
+      'prevent the others from being tested. Inactive endpoints are skipped.',
+  })
+  @ApiResponse({ status: 200, description: 'Per-endpoint test results' })
+  bulkTest(@CurrentUser('id') userId: string) {
+    return this.webhooksService.bulkTest(userId);
+  }
+
   @Get('event-types')
   @ApiOperation({ summary: 'List all subscribable webhook event types' })
   @ApiResponse({ status: 200, type: [String] })
@@ -128,6 +144,21 @@ export class WebhooksController {
   @ApiResponse({ status: 404, description: 'Webhook endpoint not found' })
   remove(@Param('id') id: string, @CurrentUser('id') userId: string) {
     return this.webhooksService.remove(id, userId);
+  }
+
+  @Get(':id/deliveries/failed')
+  @ApiOperation({ summary: 'List only the failed deliveries for a webhook endpoint' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated list of failed deliveries' })
+  @ApiResponse({ status: 404, description: 'Webhook endpoint not found' })
+  getFailedDeliveries(
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+  ) {
+    return this.webhooksService.getFailedDeliveries(userId, id, page, limit);
   }
 
   @Get(':id/deliveries/:deliveryId')

--- a/src/modules/webhooks/webhooks.service.ts
+++ b/src/modules/webhooks/webhooks.service.ts
@@ -204,6 +204,49 @@ export class WebhooksService {
     };
   }
 
+  /**
+   * Paginated list of deliveries for an endpoint whose last attempt did not
+   * succeed (still pending retry, permanently failed, or in-flight).
+   */
+  async getFailedDeliveries(
+    userId: string,
+    endpointId: string,
+    page: number = 1,
+    limit: number = 20,
+  ) {
+    const endpoint = await this.prisma.webhookEndpoint.findFirst({
+      where: { id: endpointId, userId },
+    });
+    if (!endpoint) throw new NotFoundException('Webhook endpoint not found');
+
+    const skip = (page - 1) * limit;
+    const where = { endpointId, deliveredAt: null } as const;
+
+    const [deliveries, total] = await Promise.all([
+      this.prisma.webhookDelivery.findMany({
+        where,
+        orderBy: { id: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.webhookDelivery.count({ where }),
+    ]);
+
+    return {
+      data: deliveries.map((delivery) => ({
+        ...delivery,
+        responseBody: delivery.responseBody?.slice(0, DELIVERY_RESPONSE_BODY_MAX) ?? null,
+        retryStatus: this.describeRetryStatus(delivery),
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        pages: Math.ceil(total / limit),
+      },
+    };
+  }
+
   /** Manual retry — resets permanentlyFailedAt so the delivery gets another chance. */
   async retryDelivery(endpointId: string, deliveryId: string, userId: string) {
     const endpoint = await this.prisma.webhookEndpoint.findFirst({
@@ -260,6 +303,56 @@ export class WebhooksService {
     }
 
     return { message: 'Webhook delivery retried' };
+  }
+
+  /** Sends a test ping to a single endpoint. Not persisted as a delivery record. */
+  private async sendTestPing(endpoint: { id: string; url: string; secret: string }) {
+    const body = buildBody('WEBHOOK_TEST', { message: 'This is a test ping from ChainSettle' });
+    const signature = signBody(endpoint.secret, body);
+    const startedAt = Date.now();
+
+    try {
+      const res = await axios.post(endpoint.url, body, {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-ChainSettle-Signature': signature,
+        },
+        timeout: 10_000,
+      });
+
+      return {
+        endpointId: endpoint.id,
+        success: true,
+        statusCode: res.status,
+        latencyMs: Date.now() - startedAt,
+      };
+    } catch (err) {
+      const statusCode: number | null = (err as AxiosError).response?.status ?? null;
+      const errorMessage = String(
+        (err as AxiosError).response?.data ?? (err as Error).message ?? 'Unknown error',
+      ).slice(0, 1_000);
+
+      return {
+        endpointId: endpoint.id,
+        success: false,
+        statusCode,
+        latencyMs: Date.now() - startedAt,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /** Fans a test ping out to every active webhook owned by the caller. */
+  async bulkTest(userId: string) {
+    const endpoints = await this.prisma.webhookEndpoint.findMany({
+      where: { userId, active: true },
+    });
+
+    const results = await Promise.all(
+      endpoints.map((ep) => this.sendTestPing(ep)),
+    );
+
+    return { tested: results.length, results };
   }
 
   // ── Auto-retry scheduler ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Implements four small, related enhancements to the shipment-templates and webhooks modules.

- `GET /shipment-templates/mine` — lists only the caller's own templates (public + private), with the same pagination as the general list.
- `PATCH /shipment-templates/:id/visibility` — toggles a template's `isPublic` flag, owner-only, records an audit log entry.
- `GET /webhooks/:id/deliveries/failed` — paginated list of deliveries whose last attempt did not succeed (failure reason/status code + attempt count included), same ownership check as the existing delivery-detail endpoint.
- `POST /webhooks/bulk-test` — fans a test ping out to every active webhook owned by the caller and returns a per-endpoint success/failure + latency result; one unreachable endpoint doesn't block the others.

Closes #287
Closes #288
Closes #289
Closes #290

## Test plan
Per instructions, tests are skipped for this batch. Verified with `tsc --noEmit` that the changed files type-check cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)