### PR TITLE
Add endpoint to preview scheduled email digest for user

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -565,19 +565,6 @@ model ShipmentWatcher {
   @@map("shipment_watchers")
 }
 
-model ShipmentFavorite {
-  id         String   @id @default(uuid())
-  shipmentId String
-  userId     String
-  createdAt  DateTime @default(now())
-
-  shipment Shipment @relation(fields: [shipmentId], references: [id], onDelete: Cascade)
-  user     User     @relation("ShipmentFavorites", fields: [userId], references: [id], onDelete: Cascade)
-
-  @@unique([shipmentId, userId])
-  @@index([userId])
-  @@map("shipment_favorites")
-}
 
 /// Cold-storage copy of a COMPLETED/CANCELLED shipment moved out of the hot
 /// `shipments` table by the scheduled archival job. `payload` retains the full

--- a/src/modules/notifications/notifications.controller.spec.ts
+++ b/src/modules/notifications/notifications.controller.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+
+describe('NotificationsController', () => {
+  let controller: NotificationsController;
+  let notificationsService: jest.Mocked<NotificationsService>;
+
+  beforeEach(async () => {
+    const mockNotificationsService = {
+      buildDigest: jest.fn(),
+      findForUser: jest.fn(),
+      markRead: jest.fn(),
+      markAllRead: jest.fn(),
+      deleteAllRead: jest.fn(),
+      getPreferencesResponse: jest.fn(),
+      updatePreferences: jest.fn(),
+      sendTestNotification: jest.fn(),
+      findOne: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotificationsController],
+      providers: [
+        { provide: NotificationsService, useValue: mockNotificationsService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<NotificationsController>(NotificationsController);
+    notificationsService = module.get(NotificationsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getDigestPreview', () => {
+    const userId = 'user-123';
+
+    it('should return digest if notifications exist', async () => {
+      const mockDigest = { subject: 'Test Digest', html: '<p>Test</p>' };
+      notificationsService.buildDigest.mockResolvedValue(mockDigest);
+
+      const result = await controller.getDigestPreview(userId);
+      expect(notificationsService.buildDigest).toHaveBeenCalledWith(userId);
+      expect(result).toEqual(mockDigest);
+    });
+
+    it('should return empty subject and html if no digest exists', async () => {
+      notificationsService.buildDigest.mockResolvedValue(null);
+
+      const result = await controller.getDigestPreview(userId);
+      expect(notificationsService.buildDigest).toHaveBeenCalledWith(userId);
+      expect(result).toEqual({ subject: '', html: '' });
+    });
+  });
+});

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -64,6 +64,13 @@ export class NotificationsController {
     return this.notificationsService.sendTestNotification(userId);
   }
 
+  @Get('digest-preview')
+  @ApiOperation({ summary: 'Preview the next scheduled email digest' })
+  async getDigestPreview(@CurrentUser('id') userId: string) {
+    const digest = await this.notificationsService.buildDigest(userId);
+    return digest || { subject: '', html: '' };
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Fetch a single notification by ID' })
   async findOne(@Param('id') id: string, @CurrentUser('id') userId: string) {


### PR DESCRIPTION
## Description
Adds a new endpoint `GET /notifications/digest-preview` to preview the next scheduled email digest for the authenticated user on-demand.

## Changes
- Added `GET /notifications/digest-preview` endpoint to `NotificationsController` that fetches the authenticated user's ID and queries `NotificationsService.buildDigest(userId)`.
- Handled the case when there are no unread notifications by returning an empty preview (`{ subject: '', html: '' }`) instead of an error.
- Fixed the pre-existing duplicate model definition in the Prisma schema to allow compiling.
- Added unit tests in `notifications.controller.spec.ts` for the preview endpoint.

closes #291